### PR TITLE
sdexec: reap orphan sdproc transient unit on post-start check failure

### DIFF
--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -211,11 +211,17 @@ static void finalize_exec_request_if_done (struct sdproc *proc)
         && (!proc->out || proc->out_eof_sent)
         && (!proc->err || proc->err_eof_sent)) {
 
+        /* A post-start check failed and the unit was SIGKILLed to clean up.
+         * Now that it has been reaped, return the stored error.
+         */
+        if (proc->errnum) {
+            exec_respond_error (proc, proc->errnum, proc->error.text);
+        }
         /* If there was an exec error, fail with ENOENT.
          * N.B. we have no way of discerning which exec(2) error occurred,
          * so guess ENOENT.  It could actually be EPERM, for example.
          */
-        if (sdexec_unit_has_failed (proc->unit)) {
+        else if (sdexec_unit_has_failed (proc->unit)) {
             flux_error_t error;
             errprintf (&error,
                        "unit process could not be started (systemd error %d)",
@@ -418,17 +424,38 @@ static void property_changed_continuation (flux_future_t *f, void *arg)
      * so channel output may begin after this.
      * If there is an exec error, "started" should not be sent.
      */
-    if (!proc->started_response_sent) {
+    if (!proc->started_response_sent && !proc->errnum) {
         if (sdexec_unit_has_started (proc->unit)) {
             flux_error_t check_error;
             if (sdproc_post_start_checks (proc, &check_error) < 0) {
+                flux_future_t *f2;
                 flux_log (h,
                           LOG_ERR,
                           "%s: post-start check failed: %s",
                           sdexec_unit_name (proc->unit),
                           check_error.text);
-                exec_respond_error (proc, EIO, check_error.text);
-                return;
+                /* The unit has already started, so we cannot simply respond
+                 * with an error and destroy the sdproc - that would leak the
+                 * running transient unit. Instead, record the error, SIGKILL
+                 * the unit, and start channel output so streams reach EOF.
+                 * The stored error is returned by
+                 * finalize_exec_request_if_done() once the unit has been
+                 * reaped (failed -> reset-failed -> inactive.dead), the same
+                 * way disconnect_cb() relies on normal cleanup.
+                 */
+                proc->error = check_error;
+                proc->errnum = EIO;
+                if ((f2 = sdexec_kill_unit (h,
+                                            proc->ctx->rank,
+                                            sdexec_unit_name (proc->unit),
+                                            "main",
+                                            SIGKILL)))
+                    flux_future_destroy (f2);
+                else
+                    flux_log_error (h, "error killing unit after failed check");
+                sdexec_channel_start_output (proc->out);
+                sdexec_channel_start_output (proc->err);
+                goto done;
             }
             if (flux_respond_pack (h,
                                    proc->msg,
@@ -444,7 +471,7 @@ static void property_changed_continuation (flux_future_t *f, void *arg)
     /* The finished response is sent when wait status is available.
      * If there was an exec error, "finished" should not be sent.
      */
-    if (!proc->finished_response_sent) {
+    if (!proc->finished_response_sent && !proc->errnum) {
         if (sdexec_unit_has_finished (proc->unit)) {
             if (flux_respond_pack (h,
                                    proc->msg,
@@ -458,10 +485,14 @@ static void property_changed_continuation (flux_future_t *f, void *arg)
     }
     /* If the unit reaches active.exited call StopUnit to cause stdout
      * and stderr to reach eof, and the unit to transition to inactive.dead.
+     * Normally we wait until the finished response has been sent, but on the
+     * post-start check failure path (proc->errnum set) that response is
+     * suppressed, so key off the stored error instead to ensure the unit is
+     * still reaped rather than left in active.exited.
      */
     if (sdexec_unit_state (proc->unit) == STATE_ACTIVE
         && sdexec_unit_substate (proc->unit) == SUBSTATE_EXITED
-        && proc->finished_response_sent) {
+        && (proc->finished_response_sent || proc->errnum)) {
 
         if (!proc->f_stop) {
             flux_future_t *f2;
@@ -512,6 +543,7 @@ static void property_changed_continuation (flux_future_t *f, void *arg)
             proc->f_stop = f2;
         }
     }
+done:
     flux_future_reset (f);
     /* Conditionally send the final RPC response.
      */

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -98,7 +98,6 @@ struct sdproc {
     struct stop_timer stop;
 
     int errnum;
-    const char *errstr;
     flux_error_t error;
 
     char *expected_cpus;  /* expected AllowedCPUs idset string, or NULL */

--- a/t/t2416-sdexec-constrain-resources.t
+++ b/t/t2416-sdexec-constrain-resources.t
@@ -308,6 +308,25 @@ test_expect_success 'AllowedCPUs check failure drains rank with useful message' 
 	flux resource drain -i $drained -no {reason} | grep AllowedCPUs
 '
 
+# A post-start check failure must still be reported as a job failure AND must
+# not leave the transient unit behind (sdexec should SIGKILL and reap it).
+# The unit name is shell-<rank>-<f58plain jobid>.service; match that specific
+# unit (the job may land on either broker) rather than a rank glob.  systemd
+# garbage collects the failed transient unit asynchronously, so wait for it.
+test_expect_success 'AllowedCPUs check failure reports failure and reaps unit' '
+	test_when_finished "flux resource drain -no {ranks} | xargs -r flux resource undrain" &&
+	id=$(flux submit -n1 -c1 \
+	    --setattr=exec.bulkexec.sdexec-test-expected-cpus=9998-9999 \
+	    hostname) &&
+	flux job wait-event -vt 60 $id exception &&
+	flux job wait-event -t 60 $id clean &&
+	rank=$(flux jobs -no {ranks} $id) &&
+	unit=shell-${rank}-$(flux job id --to=f58plain $id).service &&
+	test_debug "echo waiting for $unit to be reaped" &&
+	test_wait_until "test 0 -eq \$(systemctl --user list-units \
+	    --all --no-legend --type=service $unit | wc -l)"
+'
+
 #
 # Mapper error reporting: sdexec-mapper.lookup returns a useful error message
 # when resource IDs cannot be mapped to the local hwloc topology.


### PR DESCRIPTION
When sdexec runs its post-start checks (e.g. the `AllowedCPUs` enforcement check) the transient unit has already entered the running state. If a check fails, sdexec responds to the exec request with an error and immediately destroys the sdproc — but nothing stops the unit. `sdproc_destroy()` only cancels the dbus subscription and frees futures, so the started unit is orphaned and left running. This was observed as a stuck transient unit in testing.

Defer the sdexec error instead of tearing down immediately, mirroring the pattern already used in the disconnect handler.

Amend the testsuite to ensure sdexec cleans up the unit on `AllowedCPUs` failure.