### PR TITLE
shell: add new `shell.tasks-complete` callback and use it to disable exit-timeout

### DIFF
--- a/doc/man7/flux-shell-plugins.rst
+++ b/doc/man7/flux-shell-plugins.rst
@@ -399,6 +399,21 @@ Shell Lifecycle Callbacks
    cleanup and time-sensitive operations), while ``shell.exit`` runs after
    the reactor stops (suitable only for final synchronous cleanup).
 
+**shell.tasks-complete**
+  Called on the leader shell (rank 0) once all tasks across all shells in
+  the job have completed. Unlike ``shell.finish``, which is called on each
+  shell when its own local tasks complete, this callback is invoked a single
+  time and only after every shell has reported completion of its local tasks.
+  A lost shell is accounted for, so the callback fires even if a shell is
+  lost.
+
+  **Use cases**: Taking action that must wait for all job tasks to complete,
+  independent of non-task processes (such as MPIR tool daemons) that may still
+  be running.
+
+  **Context**: Leader shell only. Reactor is still running. The shell may
+  remain active after this callback if other completion references are held.
+
 Special Purpose Callbacks
 --------------------------
 

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -109,6 +109,7 @@ flux_shell_SOURCES = \
 	doom.c \
 	sysmon.c \
 	exception.c \
+	tasks-complete.c \
 	rlimit.c \
 	taskmap/cyclic.c \
 	taskmap/hostfile.c \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -49,6 +49,7 @@ extern struct shell_builtin builtin_pty;
 extern struct shell_builtin builtin_batch;
 extern struct shell_builtin builtin_doom;
 extern struct shell_builtin builtin_exception;
+extern struct shell_builtin builtin_tasks_complete;
 extern struct shell_builtin builtin_rlimit;
 extern struct shell_builtin builtin_cyclic;
 extern struct shell_builtin builtin_hostfile;
@@ -79,6 +80,7 @@ static struct shell_builtin * builtins [] = {
     &builtin_batch,
     &builtin_doom,
     &builtin_exception,
+    &builtin_tasks_complete,
     &builtin_rlimit,
     &builtin_cyclic,
     &builtin_hostfile,

--- a/src/shell/doom.c
+++ b/src/shell/doom.c
@@ -305,6 +305,23 @@ static int doom_shell_lost (flux_plugin_t *p,
     return 0;
 }
 
+/* All tasks across all shells have completed, so the exit-timeout watchdog
+ * has nothing left to guard: stop the timer. The watchdog exists to catch
+ * tasks that fail to exit, so once every task has completed it must not fire
+ * on non-task processes (e.g. MPIR tool daemons) that legitimately outlive
+ * the tasks. A genuinely hung task prevents its shell from reporting
+ * completion, so the timer is not stopped and still expires in that case.
+ */
+static int doom_tasks_complete (flux_plugin_t *p,
+                                const char *topic,
+                                flux_plugin_arg_t *args,
+                                void *arg)
+{
+    struct shell_doom *doom = arg;
+    flux_watcher_stop (doom->timer);
+    return 0;
+}
+
 static void doom_destroy (struct shell_doom *doom)
 {
     if (doom) {
@@ -399,6 +416,11 @@ static int doom_init (flux_plugin_t *p,
     }
     if (flux_plugin_add_handler (p, "shell.lost", doom_shell_lost, doom) < 0)
         return shell_log_errno ("failed to add shell.lost handler");
+    if (flux_plugin_add_handler (p,
+                                 "shell.tasks-complete",
+                                 doom_tasks_complete,
+                                 doom) < 0)
+        return shell_log_errno ("failed to add shell.tasks-complete handler");
     return 0;
 }
 

--- a/src/shell/output/client.c
+++ b/src/shell/output/client.c
@@ -47,36 +47,16 @@ struct output_client {
     flux_future_t *f_getcredit;
 };
 
-static void client_send_eof (struct output_client *client)
-{
-    /* Note: client should not be instantiated on rank 0, and may be NULL
-     * if already destroyed. Check both conditions before sending EOF.
-     */
-    if (client && client->shell_rank != 0) {
-        flux_future_t *f;
-        /* Nonzero shell rank: send EOF to leader shell to notify
-         *  that no more messages will be sent to shell.write
-         */
-        if (!(f = flux_shell_rpc_pack (client->shell,
-                                       "write",
-                                        0,
-                                        FLUX_RPC_NORESPONSE,
-                                        "{s:s s:i s:{}}",
-                                        "name", "eof",
-                                        "shell_rank", client->shell_rank,
-                                        "context")))
-            shell_log_errno ("shell.write: eof");
-        flux_future_destroy (f);
-    }
-}
-
 void output_client_destroy (struct output_client *client)
 {
     if (client) {
         int saved_errno = errno;
 
-        client_send_eof (client);
-
+        /* Note: no explicit EOF is sent to the leader here. The leader
+         * learns that no more output is forthcoming from any shell via
+         * the shell.tasks-complete callback (see the tasks-complete
+         * builtin and output/service.c).
+         */
         flux_future_destroy (client->f_getcredit);
         free (client);
         errno = saved_errno;

--- a/src/shell/output/service.c
+++ b/src/shell/output/service.c
@@ -14,19 +14,18 @@
  * leader shell implements this "shell-<id>.write" service to which
  * client shell ranks send output (see output/client.c).
  *
- * Clients may send an RFC 24 encoded data event, and "eof" event
- * to indicate no more output is forthcoming, or a "log" event for
+ * Clients may send an RFC 24 encoded data event, or a "log" event for
  * propagation of log messages from other job shells.
  *
  * Local task and logging output is not routed through this service
  * code.
  *
- * The output service includes a reference for each remote shell. If
- * there are no remote shells then the service is not started. When
- * the service is in use, an 'output.write' completion reference is
- * taken on the job shell to ensure the shell and this service remain
- * active. Once all remote shells have sent "eof", then the reference
- * is dropped.
+ * If there are no remote shells the service is not started. When the
+ * service is in use, an 'output.service' completion reference is taken
+ * on the job shell to ensure the shell and this service remain active.
+ * The reference is dropped once all tasks across all shells have
+ * completed, signaled by the shell.tasks-complete callback (see the
+ * tasks-complete builtin), which also accounts for any lost shells.
  *
  */
 #if HAVE_CONFIG_H
@@ -39,59 +38,39 @@
 
 #include <flux/core.h>
 #include <flux/shell.h>
-#include <flux/idset.h>
-
-#include "ccan/str/str.h"
 
 #include "output/output.h"
 
 struct output_service {
     struct shell_output *out;
-    int refcount;
-    struct idset *active_shells;
 };
 
 void output_service_destroy (struct output_service *service)
 {
     if (service) {
         int saved_errno = errno;
-        idset_destroy (service->active_shells);
         free (service);
         errno = saved_errno;
     }
 }
 
-static void output_service_decref (struct output_service *service)
+/* All tasks across all shells have completed (see the tasks-complete
+ * builtin), so no more output will be sent from any remote shell. Drop
+ * the completion reference that keeps this service and the shell active.
+ * This callback is invoked at most once so no re-entry guard is needed.
+ */
+static int output_service_tasks_complete (flux_plugin_t *p,
+                                          const char *topic,
+                                          flux_plugin_arg_t *args,
+                                          void *arg)
 {
-    if (--service->refcount == 0) {
-        if (flux_shell_remove_completion_ref (service->out->shell,
-                                              "output.service") < 0)
-            shell_log_errno ("flux_shell_remove_completion_ref");
+    struct output_service *service = arg;
 
-        /* Remove output service reference from shell output
-         */
-        shell_output_decref (service->out);
-    }
-}
-
-static void output_service_decref_shell_rank (struct output_service *service,
-                                              int shell_rank)
-{
-    if (idset_test (service->active_shells, shell_rank)
-        && idset_clear (service->active_shells, shell_rank) == 0)
-        output_service_decref (service);
-}
-
-static int output_service_write (struct output_service *service,
-                                 const char *type,
-                                 int shell_rank,
-                                 json_t *o)
-{
-    if (streq (type, "eof")) {
-        output_service_decref_shell_rank (service, shell_rank);
-        return 0;
-    }
-    return shell_output_write_entry (service->out, type, o);
+    if (flux_shell_remove_completion_ref (service->out->shell,
+                                          "output.service") < 0)
+        shell_log_errno ("flux_shell_remove_completion_ref");
+    shell_output_decref (service->out);
+    return 0;
 }
 
 static void output_service_write_cb (flux_t *h,
@@ -110,7 +89,7 @@ static void output_service_write_cb (flux_t *h,
                              "name", &type,
                              "shell_rank", &shell_rank,
                              "context", &o) < 0
-        || output_service_write (service, type, shell_rank, o) < 0)
+        || shell_output_write_entry (service->out, type, o) < 0)
         shell_log_errno ("error recording write data for rank %d", shell_rank);
 }
 
@@ -131,28 +110,6 @@ error:
         shell_log_errno ("error responding to write-getcredit");
 }
 
-static int shell_lost (flux_plugin_t *p,
-                       const char *topic,
-                       flux_plugin_arg_t *args,
-                       void *data)
-{
-    struct output_service *service = data;
-    int shell_rank;
-
-    /*  A shell has been lost. We need to decref the output refcount by 1
-     *  since we'll never hear from that shell to avoid rank 0 shell from
-     *  hanging.
-     */
-    if (flux_plugin_arg_unpack (args,
-                                FLUX_PLUGIN_ARG_IN,
-                                "{s:i}",
-                                "shell_rank", &shell_rank) < 0)
-        return shell_log_errno ("shell.lost: unpack of shell_rank failed");
-    output_service_decref_shell_rank (service, shell_rank);
-    shell_debug ("lost shell rank %d", shell_rank);
-    return 0;
-}
-
 struct output_service *output_service_create (struct shell_output *out,
                                               flux_plugin_t *p,
                                               int size)
@@ -162,19 +119,23 @@ struct output_service *output_service_create (struct shell_output *out,
     if (!(service = calloc (1, sizeof (*service))))
         return NULL;
 
-    /* Add a reference for each remote shell */
-    service->refcount = size - 1;
-
-    /* Nothing to do if refcount is zero. Just return empty service object
+    /* Nothing to do if there are no remote shells. Return an empty
+     * service object.
      */
-    if (service->refcount == 0)
+    if (size == 1)
         return service;
 
     service->out = out;
 
-    if (!(service->active_shells = idset_create (0, IDSET_FLAG_AUTOGROW))
-        || idset_range_set (service->active_shells, 0, size - 1) < 0
-        || flux_plugin_add_handler (p, "shell.lost", shell_lost, service) < 0
+    /* Keep the service and shell active until all tasks across all shells
+     * have completed, signaled by the shell.tasks-complete callback. The
+     * tasks-complete builtin accounts for lost shells, so no shell.lost
+     * handler is needed here.
+     */
+    if (flux_plugin_add_handler (p,
+                                 "shell.tasks-complete",
+                                 output_service_tasks_complete,
+                                 service) < 0
         || flux_shell_add_completion_ref (out->shell, "output.service") < 0
         || flux_shell_service_register (out->shell,
                                         "write",

--- a/src/shell/tasks-complete.c
+++ b/src/shell/tasks-complete.c
@@ -1,0 +1,201 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* tasks-complete.c - signal when all tasks in the job have completed
+ *
+ * Each shell reports to shell rank 0 when its local tasks have all
+ * completed, which occurs on the shell.finish callback. The leader
+ * tracks the set of shells that have not yet reported, and when the
+ * set becomes empty, invokes the shell.tasks-complete plugin callback
+ * once. A lost shell is removed from the set since it will never report,
+ * so the callback fires even if a shell is lost.
+ *
+ * Consumers register a shell.tasks-complete handler to act once all tasks
+ * have completed, regardless of non-task processes (e.g. rexec-launched
+ * tool daemons) that may keep the shell alive.
+ */
+#define FLUX_SHELL_PLUGIN_NAME "tasks-complete"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <flux/shell.h>
+#include <flux/idset.h>
+
+#include "internal.h"
+#include "builtins.h"
+
+struct tasks_complete {
+    flux_shell_t *shell;
+    int shell_rank;
+    /* Leader only: shells that have not yet reported completion. Destroyed
+     * and set NULL when the callback fires, which also prevents the callback
+     * from being invoked more than once.
+     */
+    struct idset *active_shells;
+};
+
+static void tasks_complete_destroy (struct tasks_complete *tc)
+{
+    if (tc) {
+        int saved_errno = errno;
+        idset_destroy (tc->active_shells);
+        free (tc);
+        errno = saved_errno;
+    }
+}
+
+/* Leader: note that shell_rank has completed. When the last outstanding
+ * shell reports, invoke the shell.tasks-complete callback exactly once.
+ */
+static void leader_report (struct tasks_complete *tc, int shell_rank)
+{
+    if (!tc->active_shells) // already fired (or not the leader)
+        return;
+    idset_clear (tc->active_shells, shell_rank);
+    if (idset_count (tc->active_shells) == 0) {
+        idset_destroy (tc->active_shells);
+        tc->active_shells = NULL;
+        shell_debug ("all shells report tasks complete");
+        flux_shell_plugstack_call (tc->shell, "shell.tasks-complete", NULL);
+    }
+}
+
+/* Leader service: a follower shell reports completion of its local tasks.
+ */
+static void tasks_complete_cb (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
+{
+    struct tasks_complete *tc = arg;
+    int shell_rank;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:i}",
+                             "shell_rank", &shell_rank) < 0) {
+        shell_log_errno ("failed to unpack tasks-complete request");
+        return;
+    }
+    leader_report (tc, shell_rank);
+}
+
+/* Leader: a lost shell will never report, so remove it from the outstanding
+ * set. The lost shell independently raises a job exception, so this does not
+ * mask the failure.
+ */
+static int tasks_complete_lost (flux_plugin_t *p,
+                                const char *topic,
+                                flux_plugin_arg_t *args,
+                                void *arg)
+{
+    struct tasks_complete *tc = arg;
+    int shell_rank;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:i}",
+                                "shell_rank", &shell_rank) < 0)
+        return shell_log_errno ("shell.lost: unpack of shell_rank failed");
+    leader_report (tc, shell_rank);
+    return 0;
+}
+
+/* All ranks: local tasks have all completed. The leader records its own
+ * completion directly; followers report to the leader.
+ */
+static int tasks_complete_finish (flux_plugin_t *p,
+                                  const char *topic,
+                                  flux_plugin_arg_t *args,
+                                  void *arg)
+{
+    struct tasks_complete *tc;
+    flux_future_t *f;
+
+    if (!(tc = flux_plugin_aux_get (p, "tasks-complete")))
+        return -1;
+
+    if (tc->shell_rank == 0) {
+        leader_report (tc, 0);
+        return 0;
+    }
+    if (!(f = flux_shell_rpc_pack (tc->shell,
+                                   "tasks-complete",
+                                   0,
+                                   FLUX_RPC_NORESPONSE,
+                                   "{s:i}",
+                                   "shell_rank", tc->shell_rank)))
+        return shell_log_errno ("failed to send tasks-complete request");
+    flux_future_destroy (f);
+    return 0;
+}
+
+static int tasks_complete_init (flux_plugin_t *p,
+                                const char *topic,
+                                flux_plugin_arg_t *args,
+                                void *arg)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct tasks_complete *tc;
+    int shell_size;
+
+    if (!shell || !(tc = calloc (1, sizeof (*tc))))
+        return -1;
+    tc->shell = shell;
+    if (flux_shell_info_unpack (shell,
+                                "{s:i s:i}",
+                                "rank", &tc->shell_rank,
+                                "size", &shell_size) < 0
+        || flux_plugin_aux_set (p,
+                                "tasks-complete",
+                                tc,
+                                (flux_free_f) tasks_complete_destroy) < 0) {
+        tasks_complete_destroy (tc);
+        return shell_log_errno ("plugin setup failed");
+    }
+    if (tc->shell_rank != 0)
+        return 0;
+
+    /* Leader: track the set of outstanding shells, including itself.
+     */
+    if (!(tc->active_shells = idset_create (shell_size, 0))
+        || idset_range_set (tc->active_shells, 0, shell_size - 1) < 0) {
+        return shell_log_errno ("failed to create idset");
+    }
+
+    /* With more than one shell, collect the reports from followers
+     * and account for lost shells
+     */
+    if (shell_size > 1) {
+        if (flux_shell_service_register (shell,
+                                         "tasks-complete",
+                                         tasks_complete_cb,
+                                         tc) < 0)
+            return shell_log_errno ("service register failed");
+        if (flux_plugin_add_handler (p,
+                                     "shell.lost",
+                                     tasks_complete_lost,
+                                     tc) < 0)
+            return shell_log_errno ("failed to add lost handler");
+    }
+    return 0;
+}
+
+struct shell_builtin builtin_tasks_complete = {
+    .name = FLUX_SHELL_PLUGIN_NAME,
+    .init = tasks_complete_init,
+    .finish = tasks_complete_finish,
+};
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -570,6 +570,7 @@ check_LTLIBRARIES = \
 	shell/plugins/taskmap-reverse.la \
 	shell/plugins/fork.la \
 	shell/plugins/finish.la \
+	shell/plugins/linger.la \
 	job-manager/plugins/priority-wait.la \
 	job-manager/plugins/priority-invert.la \
 	job-manager/plugins/args.la \
@@ -989,6 +990,13 @@ shell_plugins_finish_la_CPPFLAGS = $(test_cppflags)
 shell_plugins_finish_la_LDFLAGS = \
 	$(fluxplugin_ldflags) -module -rpath /nowhere
 shell_plugins_finish_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+shell_plugins_linger_la_SOURCES = shell/plugins/linger.c
+shell_plugins_linger_la_CPPFLAGS = $(test_cppflags)
+shell_plugins_linger_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+shell_plugins_linger_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
 
 

--- a/t/shell/plugins/linger.c
+++ b/t/shell/plugins/linger.c
@@ -1,0 +1,96 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#define FLUX_SHELL_PLUGIN_NAME "linger"
+
+/* Test plugin that keeps the shell alive past task completion, simulating
+ * a non-task process (such as an MPIR tool daemon) that outlives the job's
+ * tasks. It takes a shell completion reference at shell.init and releases it
+ * after a delay. Used to verify that the exit-timeout watchdog does not fire
+ * once all tasks have completed even if the shell remains active.
+ *
+ * Config: linger = seconds to hold the reference (default 2.0)
+ */
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <flux/shell.h>
+
+struct linger {
+    flux_shell_t *shell;
+    flux_watcher_t *timer;
+};
+
+static void linger_destroy (struct linger *l)
+{
+    if (l) {
+        int saved_errno = errno;
+        flux_watcher_destroy (l->timer);
+        free (l);
+        errno = saved_errno;
+    }
+}
+
+static void linger_timeout (flux_reactor_t *r,
+                            flux_watcher_t *w,
+                            int revents,
+                            void *arg)
+{
+    struct linger *l = arg;
+    shell_log ("releasing linger reference");
+    if (flux_shell_remove_completion_ref (l->shell, "test::linger") < 0)
+        shell_log_errno ("flux_shell_remove_completion_ref");
+    flux_watcher_stop (w);
+}
+
+static int linger_init (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *arg)
+{
+    struct linger *l = arg;
+    flux_reactor_t *r = flux_get_reactor (flux_shell_get_flux (l->shell));
+    double delay = 2.0;
+
+    (void) flux_plugin_conf_unpack (p, "{s?F}", "linger", &delay);
+
+    if (flux_shell_add_completion_ref (l->shell, "test::linger") < 0)
+        return shell_log_errno ("flux_shell_add_completion_ref");
+    if (!(l->timer = flux_timer_watcher_create (r,
+                                                delay,
+                                                0.,
+                                                linger_timeout,
+                                                l)))
+        return shell_log_errno ("flux_timer_watcher_create");
+    flux_watcher_start (l->timer);
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct linger *l;
+
+    if (!shell || !(l = calloc (1, sizeof (*l))))
+        return -1;
+    l->shell = shell;
+    flux_plugin_set_name (p, FLUX_SHELL_PLUGIN_NAME);
+    if (flux_plugin_aux_set (p, NULL, l, (flux_free_f) linger_destroy) < 0
+        || flux_plugin_add_handler (p, "shell.init", linger_init, l) < 0) {
+        linger_destroy (l);
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -77,6 +77,22 @@ test_expect_success 'flux-shell: exit-timeout preserves failing task signal in f
 	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
 	flux job eventlog $jobid | grep exception | grep "Segmentation fault"
 '
+test_expect_success 'flux-shell: create linger userrc' '
+	cat >linger.lua <<-EOF
+	plugin.searchpath = "${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
+	plugin.load { file = "linger.so", conf = { linger = 3.0 } }
+	EOF
+'
+test_expect_success 'flux-shell: exit-timeout ignores lingering non-task process' '
+	run_timeout 30 flux run -n2 -N2 \
+		-o exit-timeout=1s -o userrc=linger.lua true 2>linger.err &&
+	test_must_fail grep exit-timeout linger.err
+'
+test_expect_success 'flux-shell: exit-timeout ignores lingering process (single shell)' '
+	run_timeout 30 flux run -n1 \
+		-o exit-timeout=1s -o userrc=linger.lua true 2>linger1.err &&
+	test_must_fail grep exit-timeout linger1.err
+'
 test_expect_success 'flux-shell: exit-timeout=aaa is rejected' '
 	test_must_fail flux run -o exit-timeout=aaa true
 '


### PR DESCRIPTION
This PR addresses #7708 by refactoring the existing per-shell EOF code in the shell output plugin into its own `tasks-complete` plugin, which invokes `shell.tasks-complete` on shell rank 0 when _all_ job shells have called `shell.finish` and thus all job tasks have exited. The output plugin is then simplified to use this new callback, and the `doom` plugin uses it to fix #7708.
