### PR TITLE
sanitize PALS_* in the initial program environment

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -204,7 +204,7 @@ resource manager: :envvar:`FLUX_JOB_ID`, :envvar:`FLUX_JOB_SIZE`,
 :envvar:`FLUX_TASK_RANK`, :envvar:`FLUX_TASK_LOCAL_ID`,
 :envvar:`FLUX_KVS_NAMESPACE`, :envvar:`FLUX_PROXY_REMOTE`,
 :envvar:`FLUX_PMI_LIBRARY_PATH`, :envvar:`I_MPI_PMI_LIBRARY`,
-:envvar:`PMI_*`, :envvar:`SLURM_*`
+:envvar:`PMI_*`, :envvar:`SLURM_*`, :envvar:`PMIX_*`, :envvar:`PALS_*`.
 
 PMI CLIENT
 ==========

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -93,6 +93,7 @@ static const char *env_blocklist[] = {
     "I_MPI_PMI_LIBRARY",
     "SLURM_*",  // flux-framework/flux-core#5206
     "NOTIFY_SOCKET", // see systemd sd_notify(3)
+    "PALS_*", // flux-framework/flux-coral2#493
     NULL,
 };
 


### PR DESCRIPTION
We found that `flux start` can get confused and try to bootstrap from an allocation's `apinfo` file on the crays, because the PALS_* environment vars leak through to the initial program.

Nix those in the initial program's environment, like we do for SLURM_* and PMIX_*.

This should fix
- flux-framework/flux-coral2#493