### PR TITLE
ci: fix systemd unit dir in el8 deploy image

### DIFF
--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -376,7 +376,7 @@ matrix.add_build(
     env=dict(
         TEST_INSTALL="t",
     ),
-    args="--with-flux-security",
+    args=common_args,
     docker_tag=True,
 )
 


### PR DESCRIPTION
Problem: The docker-deploy step on a tag fails to build the fluxorama image because the flux.service unit file is not installed in a location where systemd searches for in the fluxrm/flux-core:el8 base image. This is because the el8 install doesn't pass --with-systemdsystemunitdir on to configure.

Use common_args for the el8 test-install builder, matching the other multiarch distro builds which already pass
--with-systemdsystemunitdir=/etc/systemd/system.