### PR TITLE
libkvs: add kvs_treewalk_strerror()

### DIFF
--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -285,23 +285,16 @@ static void dump_error (void *arg,
                         enum kvs_treewalk_error error,
                         int errnum)
 {
-    switch (error) {
-        case KVS_TREEWALK_ERROR_LOAD:
-            read_error ("%s: missing blobref: %s", path, strerror (errnum));
-            break;
-        case KVS_TREEWALK_ERROR_BADCOUNT:
-            log_msg_exit ("%s: blobref count is not 1", path);
-            break;
-        case KVS_TREEWALK_ERROR_DECODE:
-            log_err_exit ("%s: could not decode directory", path);
-            break;
-        case KVS_TREEWALK_ERROR_NOTDIR:
-            log_msg_exit ("%s: dirref references non-directory", path);
-            break;
-        case KVS_TREEWALK_ERROR_INVALID:
-            log_msg_exit ("%s: invalid tree object", path);
-            break;
-    }
+    /* A missing blob is non-fatal under --ignore-failed-read (read_error
+     * returns), so it is handled separately from the fatal categories.
+     */
+    if (error == KVS_TREEWALK_ERROR_LOAD)
+        read_error ("%s: %s: %s",
+                    path,
+                    kvs_treewalk_strerror (error),
+                    strerror (errnum));
+    else
+        log_msg_exit ("%s: %s", path, kvs_treewalk_strerror (error));
 }
 
 static const struct kvs_treewalk_ops dump_ops = {

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -395,34 +395,25 @@ static void fsck_error (void *arg,
 {
     struct fsck_ctx *ctx = arg;
 
-    switch (error) {
-        case KVS_TREEWALK_ERROR_INVALID:
-            errmsg (ctx, "%s: invalid tree object", path);
-            break;
-        case KVS_TREEWALK_ERROR_BADCOUNT:
-            errmsg (ctx, "%s: invalid dirref treeobj count", path);
-            break;
-        case KVS_TREEWALK_ERROR_LOAD:
-            if (errnum == ENOENT)
-                errmsg (ctx, "%s: missing dirref blobref", path);
-            else
-                errmsg (ctx,
-                        "%s: error retrieving dirref blobref: %s",
-                        path,
-                        strerror (errnum));
-            if (ctx->repair && errnum == ENOENT) {
-                record_repair (ctx, path, NULL); // unlink only
-                warn (ctx, "%s unlinked due to missing blobref", path);
-                ctx->unlink_dir_count++;
-            }
-            break;
-        case KVS_TREEWALK_ERROR_DECODE:
-            errmsg (ctx, "%s: could not decode directory", path);
-            break;
-        case KVS_TREEWALK_ERROR_NOTDIR:
-            errmsg (ctx, "%s: dirref references non-directory", path);
-            break;
+    /* A load failure gets errnum-specific wording plus repair handling for a
+     * missing (ENOENT) blobref; the other categories share the common string.
+     */
+    if (error == KVS_TREEWALK_ERROR_LOAD) {
+        if (errnum == ENOENT)
+            errmsg (ctx, "%s: missing dirref blobref", path);
+        else
+            errmsg (ctx,
+                    "%s: error retrieving dirref blobref: %s",
+                    path,
+                    strerror (errnum));
+        if (ctx->repair && errnum == ENOENT) {
+            record_repair (ctx, path, NULL); // unlink only
+            warn (ctx, "%s unlinked due to missing blobref", path);
+            ctx->unlink_dir_count++;
+        }
     }
+    else
+        errmsg (ctx, "%s: %s", path, kvs_treewalk_strerror (error));
     ctx->errorcount++;
 }
 

--- a/src/cmd/builtin/gc.c
+++ b/src/cmd/builtin/gc.c
@@ -268,18 +268,9 @@ static void mark_error (void *arg,
                         enum kvs_treewalk_error error,
                         int errnum)
 {
-    switch (error) {
-        case KVS_TREEWALK_ERROR_INVALID:
-            log_msg_exit ("%s: invalid tree object", path);
-        case KVS_TREEWALK_ERROR_BADCOUNT:
-            log_msg_exit ("%s: dirref blobref count is not 1", path);
-        case KVS_TREEWALK_ERROR_LOAD:
-            log_errn_exit (errnum, "%s: cannot load dirref", path);
-        case KVS_TREEWALK_ERROR_DECODE:
-            log_msg_exit ("%s: cannot decode dirref treeobj", path);
-        case KVS_TREEWALK_ERROR_NOTDIR:
-            log_msg_exit ("%s: dirref references non-directory", path);
-    }
+    if (error == KVS_TREEWALK_ERROR_LOAD)
+        log_errn_exit (errnum, "%s: %s", path, kvs_treewalk_strerror (error));
+    log_msg_exit ("%s: %s", path, kvs_treewalk_strerror (error));
 }
 
 static const struct kvs_treewalk_ops mark_ops = {

--- a/src/common/libkvs/kvs_treewalk.c
+++ b/src/common/libkvs/kvs_treewalk.c
@@ -87,6 +87,23 @@ static void treewalk_fatal (struct kvs_treewalk *tw, int errnum)
         tw->errnum = errnum;
 }
 
+const char *kvs_treewalk_strerror (enum kvs_treewalk_error error)
+{
+    switch (error) {
+        case KVS_TREEWALK_ERROR_INVALID:
+            return "invalid tree object";
+        case KVS_TREEWALK_ERROR_BADCOUNT:
+            return "dirref blobref count is not 1";
+        case KVS_TREEWALK_ERROR_LOAD:
+            return "could not load content";
+        case KVS_TREEWALK_ERROR_DECODE:
+            return "could not decode tree object";
+        case KVS_TREEWALK_ERROR_NOTDIR:
+            return "dirref references non-directory";
+    }
+    return "unknown error";
+}
+
 static void report_error (struct kvs_treewalk *tw,
                           const char *path,
                           enum kvs_treewalk_error error,

--- a/src/common/libkvs/kvs_treewalk.h
+++ b/src/common/libkvs/kvs_treewalk.h
@@ -143,6 +143,11 @@ int kvs_treewalk_run (struct kvs_treewalk *tw);
 
 void kvs_treewalk_destroy (struct kvs_treewalk *tw);
 
+/* Return a static human-readable string describing a kvs_treewalk_error
+ * value.  An unrecognized value returns "unknown error".
+ */
+const char *kvs_treewalk_strerror (enum kvs_treewalk_error error);
+
 #endif /* !_KVS_TREEWALK_H */
 
 /*

--- a/src/common/libkvs/test/treewalk.c
+++ b/src/common/libkvs/test/treewalk.c
@@ -22,6 +22,7 @@
 #include "src/common/libcontent/content.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
 
 #include "treeobj.h"
 #include "kvs_treewalk.h"
@@ -565,6 +566,37 @@ static void test_valref_noload (flux_t *h, struct blobstore *bs)
     free (rootref);
 }
 
+/* kvs_treewalk_strerror() returns a non-empty static string for each defined
+ * error category and a generic "unknown error" for an out-of-range value.
+ */
+static void test_strerror (void)
+{
+    enum kvs_treewalk_error errors[] = {
+        KVS_TREEWALK_ERROR_INVALID,
+        KVS_TREEWALK_ERROR_BADCOUNT,
+        KVS_TREEWALK_ERROR_LOAD,
+        KVS_TREEWALK_ERROR_DECODE,
+        KVS_TREEWALK_ERROR_NOTDIR,
+    };
+    const char *s;
+
+    for (int i = 0; i < ARRAY_SIZE (errors); i++) {
+        s = kvs_treewalk_strerror (errors[i]);
+        ok (s != NULL
+            && strlen (s) > 0
+            && !streq (s, "unknown error"),
+            "kvs_treewalk_strerror (%d) returns a non-empty string",
+            errors[i]);
+    }
+
+    s = kvs_treewalk_strerror (-1);
+    ok (s != NULL && streq (s, "unknown error"),
+        "kvs_treewalk_strerror (-1) returns \"unknown error\"");
+    s = kvs_treewalk_strerror (12345);
+    ok (s != NULL && streq (s, "unknown error"),
+        "kvs_treewalk_strerror (out of range) returns \"unknown error\"");
+}
+
 static void test_invalid_args (flux_t *h)
 {
     struct collector c;
@@ -608,6 +640,7 @@ int main (int argc, char *argv[])
     test_missing_dirref (h, &bs);
     test_missing_valref_blob (h, &bs);
     test_request_failure (h, &bs);
+    test_strerror ();
 
     if (test_server_stop (h) < 0)
         BAIL_OUT ("test_server_stop failed");


### PR DESCRIPTION
Problem: Each use of a kvs_treewalk error callback duplicates a switch statement that maps kvs_treewalk_error values to human-readable strings.

Add kvs_treewalk_strerror() to return a static description string for a given kvs_treewalk_error value.  Return "unknown error" for an unrecognized value.

Add unit tests.

Fixes #7703

---

Side note: this was a simple issue that I picked mostly to try out Opus.