### PR TITLE
flux-sproc: make ps output more useful

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -381,6 +381,12 @@ static flux_subprocess_t *start_command (struct runat *r,
 
     if (runat_command_setenv (cmd, env_blocklist, r->local_uri, r->jobid) < 0)
         return NULL;
+    /* Label the subprocess with the runat entry name (rc1, rc2, cleanup,
+     * etc.) so it is identifiable in 'flux sproc ps'.  Commands within an
+     * entry run sequentially, so the name is unique among live processes.
+     */
+    if (flux_cmd_set_label (cmd->cmd, entry->name) < 0)
+        return NULL;
     if (!(cmd->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
         ops.on_stdout = stdio_cb;
         ops.on_stderr = stdio_cb;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -981,14 +981,29 @@ static json_t *process_info (flux_subprocess_t *p)
     json_t *info = NULL;
     const char *label;
     const char *state;
+    const char *name;
+    char cmdbuf[64];
 
     if (!(cmd = flux_subprocess_get_cmd (p)))
         return NULL;
     label = flux_cmd_get_label (cmd);
     state = flux_subprocess_active (p) ? "R" : "Z";
+    /* "flux" as argv[0] is uninformative since every flux command begins
+     * with it, so append the subcommand argv[1] in that case, e.g.
+     * "flux module-exec".  Truncated to fit cmdbuf.
+     */
+    name = flux_cmd_arg (cmd, 0);
+    if (streq (name, "flux") && flux_cmd_argc (cmd) > 1) {
+        snprintf (cmdbuf,
+                  sizeof (cmdbuf),
+                  "%s %s",
+                  name,
+                  flux_cmd_arg (cmd, 1));
+        name = cmdbuf;
+    }
     if (!(info = json_pack ("{s:i s:s s:s s:s}",
                             "pid", flux_subprocess_pid (p),
-                            "cmd", flux_cmd_arg (cmd, 0),
+                            "cmd", name,
                             "label", label ? label : "",
                             "state", state))) {
         errno = ENOMEM;


### PR DESCRIPTION
Problem: the `flux sproc ps` output lists flux commands as simply `flux` and rc scripts as `/bin/bash`, for example:
```
$ flux sproc ps
      PID ST LABEL        COMMAND
  2734878 R  -            /bin/bash
  2734886 R  -            flux
```

Label the rc scripts with their internal name (like rc2, cleanup).
When argv[0] is "flux", tack on argv[1].

After these changes, the output for a test instance is e.g.
```
$ flux sproc ps
      PID ST LABEL        COMMAND
  2734310 R  rc2          /bin/bash
  2734294 R  -            flux module-python-exec
```

I tried using broker module name as a label but that unexpectedly broke some tests because `flux module reload` apparently doesn't wait for the subprocess to be completely cleaned up before attempting to reuse the label.  I didn't think it was really worth it to push that further.