### PR TITLE
shell: add coprocess helper plugin

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -189,6 +189,7 @@ MAN3_FILES_SECONDARY = \
 	man3/flux_shell_task_cmd.3 \
 	man3/flux_shell_rank_mustache_render.3 \
 	man3/flux_shell_task_mustache_render.3 \
+	man3/flux_shell_mustache_is_per_rank.3 \
 	man3/flux_service_unregister.3 \
 	man3/flux_send_new.3 \
 	man3/flux_clone.3 \

--- a/doc/man3/flux_shell_mustache_render.rst
+++ b/doc/man3/flux_shell_mustache_render.rst
@@ -22,6 +22,9 @@ SYNOPSIS
                                           flux_shell_task_t *task,
                                           const char *fmt);
 
+   bool flux_shell_mustache_is_per_rank (flux_shell_t *shell,
+                                         const char *fmt);
+
 DESCRIPTION
 ===========
 
@@ -38,11 +41,20 @@ task specified by :var:`task`.
 These functions are useful for expanding job-specific templates in environment
 variables, command arguments, or plugin configurations.
 
+:func:`flux_shell_mustache_is_per_rank` returns ``true`` if :var:`fmt` renders
+to a different result across shell ranks or tasks, i.e. it contains a per-rank
+or per-task tag such as ``{{node.id}}``, ``{{node.name}}``, ``{{task.id}}``, or
+``{{tmpdir}}``. This is useful for deciding whether a templated output path
+yields a distinct file per shell.
+
 RETURN VALUE
 ============
 
-These functions return an allocated string on success which the caller must
-free, or NULL on failure with :var:`errno` set.
+The render functions return an allocated string on success which the caller
+must free, or NULL on failure with :var:`errno` set.
+
+:func:`flux_shell_mustache_is_per_rank` returns ``true`` or ``false``, setting
+:var:`errno` to :var:`EINVAL` and returning ``false`` on invalid arguments.
 
 
 ERRORS

--- a/doc/man5/flux-shell-initrc.rst
+++ b/doc/man5/flux-shell-initrc.rst
@@ -346,6 +346,44 @@ This allows version specific mpi plugins to be placed in
 ``$rcpath/mpi/name@version.lua`` and selected via ``-o mpi=name@version``.
 
 
+coprocess.define(spec)
+----------------------
+
+Define a co-process that a user may enable by name. ``spec`` is a table
+describing the co-process for the ``coprocess`` shell plugin (see the
+COPROCESS section of :man7:`flux-shell-options`). It must contain a ``name``
+plus the usual coprocess keys such as ``command``, ``output``, and ``ranks``.
+
+The co-process is enabled only if the shell option matching ``name`` is set,
+following the usual scalar-or-object option convention: ``-o <name>`` enables
+it with the defaults in ``spec``, while ``-o <name>.<key>=<val>`` enables it
+with ``spec.<key>`` overridden (the bare and dotted forms are alternatives,
+not combined). The resulting definition is merged into the ``coprocess`` shell
+option consumed by the coprocess plugin.
+
+This is typically called from a drop-in rc file under
+``$rcpath/lua.d/*.lua``. For example, ``/etc/flux/shell/lua.d/vmstat.lua``:
+
+.. code-block:: lua
+
+  coprocess.define {
+      name = "vmstat",
+      command = {"vmstat", "5"},
+      output = "vmstat-{{id}}.log",
+  }
+
+lets a user run ``flux run -o vmstat ...`` to sample memory and CPU stats
+alongside the job, or ``-o vmstat.output=stat.log`` to override the output
+file.
+
+.. note::
+  When the ``output`` template resolves to the same path on every shell, all
+  co-process output is forwarded to and written by the leader shell. In the
+  case of high output volume, a per-shell output template should be preferred
+  (i.e. on that includes ``{{node.id}}`` or `{{node.name}}``) to avoid
+  overwhelming the leader.
+
+
 SHELL INFORMATION
 =================
 

--- a/doc/man7/flux-shell-options.rst
+++ b/doc/man7/flux-shell-options.rst
@@ -735,20 +735,17 @@ COPROCESS
   ``SIGKILL`` if they do not exit within ``coprocess-kill-timeout``.
 
   This option is typically set from a drop-in Lua rc file rather than on the
-  command line. For example, a site could provide
-  ``/etc/flux/shell/lua.d/vmstat.lua`` that sets the option when
-  ``-o vmstat`` is given:
+  command line, using the ``coprocess.define`` helper (see
+  :man5:`flux-shell-initrc`). For example, a site could provide
+  ``/etc/flux/shell/lua.d/vmstat.lua`` so that ``-o vmstat`` launches it:
 
   .. code-block:: lua
 
-    if shell.options["vmstat"] then
-        shell.options["coprocess"] = {
-            vmstat = {
-                command = {"vmstat", "5"},
-                output  = "vmstat-{{id}}.log",
-            }
-        }
-    end
+    coprocess.define {
+        name = "vmstat",
+        command = {"vmstat", "5"},
+        output = "vmstat-{{id}}.log",
+    }
 
 .. option:: coprocess-kill-timeout=FSD
 

--- a/doc/man7/flux-shell-options.rst
+++ b/doc/man7/flux-shell-options.rst
@@ -690,6 +690,72 @@ MONITORING
 
     $ flux run -o sysmon -o sysmon.period=5s myapp
 
+COPROCESS
+=========
+
+.. option:: coprocess=OBJECT
+
+  Launch one or more helper processes ("co-processes") that run alongside the
+  job for its duration. This is intended for tools such as node monitoring
+  or profiling utilities.
+
+  The option value is a JSON object keyed by co-process name. Each named
+  entry is itself an object with the following keys:
+
+  **command**
+    (array of strings, required) The argv of the helper command. Each argument
+    may contain shell mustache tags, which are expanded before the helper
+    is launched (see the MUSTACHE TEMPLATES section in :man1:`flux-submit`).
+    For example, ``"--jobid={{id}}"`` expands to the F58 job ID.
+
+  **output**
+    (string, optional) A template for the output file that captures
+    the helper's combined stdout and stderr. If unset, it defaults to
+    ``coproc-<name>-{{id}}.log`` (a single aggregated file per co-process).
+    The template is rendered with shell mustache tags (see the MUSTACHE
+    TEMPLATES section in :man1:`flux-submit`); useful tags include ``{{id}}``
+    (the F58 job ID, matching :man1:`flux-jobs`), ``{{node.id}}`` (shell
+    rank), and ``{{node.name}}`` (node hostname). Each shell renders the
+    template for its own rank, so a template with a per-node tag names a
+    distinct file on each node.
+
+  **ranks**
+    (string, optional) An RFC 22 idset of shell ranks on which to launch
+    the co-process, or ``"all"``. Default: ``"all"`` (one helper per shell,
+    i.e.  per node).
+
+  Each participating shell launches its own copy of the helper. When the
+  ``output`` template expands to the same path on every shell (a per-job
+  file), follower shells forward their output to the leader shell, which
+  writes the single aggregated file. When the template expands to a distinct
+  path per shell (it contains ``{{node.id}}`` or ``{{node.name}}``), each
+  shell writes its own file directly, avoiding any forwarding to the leader.
+
+  Co-processes are sent ``SIGTERM`` when all tasks complete, escalating to
+  ``SIGKILL`` if they do not exit within ``coprocess-kill-timeout``.
+
+  This option is typically set from a drop-in Lua rc file rather than on the
+  command line. For example, a site could provide
+  ``/etc/flux/shell/lua.d/vmstat.lua`` that sets the option when
+  ``-o vmstat`` is given:
+
+  .. code-block:: lua
+
+    if shell.options["vmstat"] then
+        shell.options["coprocess"] = {
+            vmstat = {
+                command = {"vmstat", "5"},
+                output  = "vmstat-{{id}}.log",
+            }
+        }
+    end
+
+.. option:: coprocess-kill-timeout=FSD
+
+  Time to wait after co-processes are sent ``SIGTERM`` (when all tasks
+  complete) before escalating to ``SIGKILL``. Accepts Flux Standard Duration.
+  Default: ``10s``.
+
 REXEC OPTIONS
 =============
 

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -299,6 +299,7 @@ man_pages = [
     ('man3/flux_shell_mustache_render', 'flux_shell_mustache_render', 'expand mustache templates in shell plugins', [author], 3),
     ('man3/flux_shell_mustache_render', 'flux_shell_rank_mustache_render', 'expand mustache templates in shell plugins', [author], 3),
     ('man3/flux_shell_mustache_render', 'flux_shell_task_mustache_render', 'expand mustache templates in shell plugins', [author], 3),
+    ('man3/flux_shell_mustache_render', 'flux_shell_mustache_is_per_rank', 'expand mustache templates in shell plugins', [author], 3),
     ('man3/flux_signal_watcher_create', 'flux_signal_watcher_get_signum', 'create signal watcher', [author], 3),
     ('man3/flux_signal_watcher_create', 'flux_signal_watcher_create', 'create signal watcher', [author], 3),
     ('man3/flux_stat_watcher_create', 'flux_stat_watcher_get_rstat', 'create stat watcher', [author], 3),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -846,8 +846,11 @@ kbd
 adminarch
 AiVi
 auth
+coproc
+coprocess
 coredump
 coredumpctl
+vmstat
 fatnode
 fubar
 javascript

--- a/src/bindings/lua/flux/shell.lua
+++ b/src/bindings/lua/flux/shell.lua
@@ -101,5 +101,53 @@ function shell.source_rcpath_option (opt)
         end
     end
 end
+
+coprocess = {}
+
+--- Define a co-process that a user may enable by name.
+--
+--  `spec` is a table describing the co-process for the "coprocess" shell
+--  plugin (see flux-shell-options(7)). It must contain a `name` and the
+--  usual coprocess keys such as `command`, `output`, and `ranks`.
+--
+--  The co-process is enabled only if the shell option matching `name` is set,
+--  following the usual scalar-or-object option convention:
+--
+--    -o <name>              enable with the defaults in `spec`
+--    -o <name>.<key>=<val>  enable, overriding `spec.<key>` (repeatable)
+--
+--  (as with other shell options, the bare and dotted forms are alternatives,
+--  not combined). When enabled, the resulting definition is merged into the
+--  "coprocess" shell option for the coprocess plugin to launch.
+--
+--  Typically called from a drop-in rc file under shell.rcpath/lua.d, e.g.
+--  /etc/flux/shell/lua.d/gpumon.lua:
+--
+--    coprocess.define {
+--        name = "gpumon",
+--        command = {"nvidia-smi", "dmon", "-s", "pucvmet", "-d", "5"},
+--        output = "gpumon-{{id}}.log",
+--    }
+--
+function coprocess.define (spec)
+    local name = spec.name
+    if not name then
+        error ("coprocess.define: spec is missing required 'name'")
+    end
+    local opt = shell.options[name]
+    if opt == nil then          -- not enabled by the user
+        return
+    end
+    spec.name = nil             -- strip helper-only key from the definition
+    if type (opt) == "table" then
+        -- -o <name>.<key>=<val> overrides of the spec defaults
+        for k, v in pairs (opt) do
+            spec[k] = v
+        end
+    end
+    local coproc = shell.options["coprocess"] or {}
+    coproc[name] = spec
+    shell.options["coprocess"] = coproc
+end
 -- vi: ts=4 sw=4 expandtab
--- 
+--

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -117,7 +117,8 @@ flux_shell_SOURCES = \
 	files.c \
 	hwloc.c \
 	rexec.c \
-	env-expand.c
+	env-expand.c \
+	coprocess.c
 
 if HAVE_INOTIFY
 flux_shell_SOURCES += oom.c

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -59,6 +59,7 @@ extern struct shell_builtin builtin_hwloc;
 extern struct shell_builtin builtin_rexec;
 extern struct shell_builtin builtin_env_expand;
 extern struct shell_builtin builtin_sysmon;
+extern struct shell_builtin builtin_coprocess;
 
 static struct shell_builtin * builtins [] = {
     &builtin_tmpdir,
@@ -92,6 +93,7 @@ static struct shell_builtin * builtins [] = {
     &builtin_rexec,
     &builtin_env_expand,
     &builtin_sysmon,
+    &builtin_coprocess,
     &builtin_list_end,
 };
 

--- a/src/shell/coprocess.c
+++ b/src/shell/coprocess.c
@@ -1,0 +1,700 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* coprocess.c - launch helper process(es) alongside a job
+ *
+ * A coprocess is a helper command (e.g. a node monitoring tool) that runs
+ * for the duration of the job. Co-processes are described by the "coprocess"
+ * job shell option, a JSON object keyed by co-process name, e.g.
+ *
+ *   -o coprocess='{"gpumon":{"command":["nvidia-smi","dmon"],
+ *                            "output":"gpumon-{{id}}.log"}}'
+ *
+ * Each named entry may set:
+ *   command  (array of strings, required) - argv of the helper
+ *   output   (string, optional)           - output file template
+ *   ranks    (idset string or "all")      - shell ranks that launch it;
+ *                                           default "all"
+ *
+ * Where command and output support shell mustache templates as expanded
+ * by flux_shell_mustache_render(3).
+ *
+ * If `output` renders per-shell, then each shell opens the output file
+ * and directs output locally. Otherwise, output is sent back to the rank 0
+ * shell which then directs output to the single output file.
+ *
+ * At shell.finish each co-process is sent SIGTERM, escalating to SIGKILL
+ * after coprocess-kill-timeout. A completion reference per co-process keeps
+ * the shell reactor alive until the helper is reaped, so all of its output
+ * (including any final output emitted on SIGTERM) is read before exit.
+ *
+ * For aggregated output, a follower forwards a final EOF to the leader from
+ * its completion callback (after all output has been read and forwarded, and
+ * since RPCs are delivered in order, after the last data chunk). The leader
+ * holds a "coprocess.service" completion reference until every forwarding
+ * follower has sent its EOF, so late output is not dropped by the leader
+ * exiting early. A lost shell is dropped from the waited-on set via
+ * shell.lost so the reference is still released.
+ */
+#define FLUX_SHELL_PLUGIN_NAME "coprocess"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <signal.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <flux/core.h>
+#include <flux/shell.h>
+#include <flux/idset.h>
+#include <jansson.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/fsd.h"
+#include "ccan/str/str.h"
+
+#include "internal.h"
+#include "builtins.h"
+
+extern char **environ;
+
+static const double default_kill_timeout = 10.;
+
+struct coprocess_ctx {
+    flux_shell_t *shell;
+    int shell_rank;
+    int shell_size;
+    zlistx_t *procs;            /* list of struct coproc */
+    int running;                /* count of live local subprocesses */
+    double kill_timeout;
+    flux_watcher_t *kill_timer;
+    bool killed;                /* SIGKILL escalation sent */
+    bool service_ref;           /* leader holds "coprocess.service" ref */
+};
+
+struct coproc {
+    char *name;
+    flux_cmd_t *cmd;
+    char *output;               /* output file template */
+    bool output_per_shell;      /* template renders to a distinct file/shell */
+    struct idset *ranks;        /* shell ranks to launch on, NULL = all */
+    flux_subprocess_t *proc;    /* live subprocess on this shell, or NULL */
+    int fd;                     /* open output file, or -1 */
+    struct idset *eof_pending;  /* leader: follower ranks owing an EOF */
+    struct coprocess_ctx *ctx;
+};
+
+static void coproc_destroy (struct coproc *c)
+{
+    if (c) {
+        int saved_errno = errno;
+        free (c->name);
+        flux_cmd_destroy (c->cmd);
+        free (c->output);
+        idset_destroy (c->ranks);
+        idset_destroy (c->eof_pending);
+        flux_subprocess_destroy (c->proc);
+        if (c->fd >= 0)
+            close (c->fd);
+        free (c);
+        errno = saved_errno;
+    }
+}
+
+/* zlistx destructor */
+static void coproc_destructor (void **item)
+{
+    if (item) {
+        coproc_destroy (*item);
+        *item = NULL;
+    }
+}
+
+static void coprocess_ctx_destroy (struct coprocess_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        zlistx_destroy (&ctx->procs);
+        flux_watcher_destroy (ctx->kill_timer);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct coproc *coproc_find (struct coprocess_ctx *ctx,
+                                   const char *name)
+{
+    struct coproc *c = zlistx_first (ctx->procs);
+    while (c) {
+        if (streq (c->name, name))
+            return c;
+        c = zlistx_next (ctx->procs);
+    }
+    return NULL;
+}
+
+/* True if this co-process should be launched on the local shell rank.
+ */
+static bool coproc_on_rank (struct coproc *c, int rank)
+{
+    if (!c->ranks)                          /* "all" */
+        return true;
+    return idset_test (c->ranks, rank);
+}
+
+/* Parse a single co-process config entry into a struct coproc.
+ */
+static struct coproc *coproc_create (struct coprocess_ctx *ctx,
+                                     const char *name,
+                                     json_t *entry)
+{
+    struct coproc *c;
+    json_t *command = NULL;
+    json_t *value;
+    const char *output = NULL;
+    const char *ranks = NULL;
+    size_t index;
+    json_error_t error;
+
+    if (!(c = calloc (1, sizeof (*c))))
+        return NULL;
+    c->ctx = ctx;
+    c->fd = -1;
+    if (!(c->name = strdup (name)))
+        goto error;
+    if (json_unpack_ex (entry,
+                        &error,
+                        0,
+                        "{s:o s?s s?s !}",
+                        "command", &command,
+                        "output", &output,
+                        "ranks", &ranks) < 0) {
+        shell_log_error ("%s: %s", name, error.text);
+        goto inval;
+    }
+    if (!json_is_array (command) || json_array_size (command) == 0) {
+        shell_log_error ("%s: command must be a non-empty array",
+                         name);
+        goto inval;
+    }
+    if (!(c->cmd = flux_cmd_create (0, NULL, environ)))
+        goto error;
+    json_array_foreach (command, index, value) {
+        int rc;
+        const char *arg;
+        char *xarg = NULL;
+        if (!json_is_string (value)) {
+            shell_log_error ("%s: command elements must be strings",
+                             name);
+            goto inval;
+        }
+        arg = json_string_value (value);
+        if (strstr (arg, "{{")) {
+            if (!(xarg = flux_shell_mustache_render (ctx->shell, arg))) {
+                shell_log_error ("%s: failed to expand '%s'", name, arg);
+                goto error;
+            }
+            arg = xarg;
+        }
+        rc = flux_cmd_argv_append (c->cmd, arg);
+        free (xarg);
+        if (rc < 0)
+            goto error;
+    }
+    /* Default output template if not configured. */
+    if (output) {
+        if (!(c->output = strdup (output)))
+            goto error;
+    }
+    else if (asprintf (&c->output, "coproc-%s-{{id}}.log", name) < 0)
+        goto error;
+    c->output_per_shell = flux_shell_mustache_is_per_rank (ctx->shell,
+                                                           c->output);
+    if (ranks && !streq (ranks, "all")) {
+        if (!(c->ranks = idset_decode (ranks))) {
+            shell_log_error ("%s: invalid ranks '%s'", name, ranks);
+            goto inval;
+        }
+    }
+    /* Leader with aggregated output: track the follower ranks that will
+     * forward output and owe an EOF (rank 0 writes its own output directly).
+     * eof_pending stays NULL if no follower participates.
+     */
+    if (ctx->shell_rank == 0
+        && !c->output_per_shell
+        && ctx->shell_size > 1) {
+        int rank;
+        if (!(c->eof_pending = idset_create (ctx->shell_size, 0)))
+            goto error;
+        if (!c->ranks)  /* "all" */
+            idset_range_set (c->eof_pending, 1, ctx->shell_size - 1);
+        else {
+            for (rank = 1; rank < ctx->shell_size; rank++) {
+                if (coproc_on_rank (c, rank)
+                    && idset_set (c->eof_pending, rank) < 0)
+                    goto error;
+            }
+        }
+        if (idset_count (c->eof_pending) == 0) {
+            idset_destroy (c->eof_pending);
+            c->eof_pending = NULL;
+        }
+    }
+    return c;
+inval:
+    errno = EINVAL;
+error:
+    coproc_destroy (c);
+    return NULL;
+}
+
+/* Lazily open the co-process output file, returning its fd or -1 on error.
+ */
+static int coproc_getfd (struct coproc *c)
+{
+    char *path;
+
+    if (c->fd >= 0)
+        return c->fd;
+    if (!(path = flux_shell_rank_mustache_render (c->ctx->shell,
+                                                  c->ctx->shell_rank,
+                                                  c->output)))
+        return -1;
+    if ((c->fd = open (path, O_CREAT | O_WRONLY | O_TRUNC, 0600)) < 0)
+        shell_log_errno ("%s: open %s", c->name, path);
+    free (path);
+    return c->fd;
+}
+
+/* Write a chunk to the co-process output file, opening it if necessary.
+ */
+static void coproc_write (struct coproc *c, const char *buf, int len)
+{
+    int fd = coproc_getfd (c);
+    if (fd >= 0 && write_all (fd, buf, len) < 0)
+        shell_log_errno ("%s: write output", c->name);
+}
+
+/* Follower: forward an output chunk to the leader's coprocess-write service. */
+static void coproc_forward (struct coproc *c, const char *buf, int len)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_shell_rpc_pack (c->ctx->shell,
+                                   "coprocess-write",
+                                   0,
+                                   FLUX_RPC_NORESPONSE,
+                                   "{s:s s:s#}",
+                                   "name", c->name,
+                                   "data", buf, len)))
+        shell_log_errno ("%s: forward output", c->name);
+    flux_future_destroy (f);
+}
+
+/* Notify the leader that this follower has forwarded all output for 'c'. */
+static void coproc_forward_eof (struct coproc *c)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_shell_rpc_pack (c->ctx->shell,
+                                   "coprocess-write",
+                                   0,
+                                   FLUX_RPC_NORESPONSE,
+                                   "{s:s s:i}",
+                                   "name", c->name,
+                                   "eof_rank", c->ctx->shell_rank)))
+        shell_log_errno ("%s: forward eof", c->name);
+    flux_future_destroy (f);
+}
+
+/* Leader: release the output aggregation service reference once every
+ * follower that forwards output has sent its EOF (or been lost).
+ */
+static bool coproc_eof_outstanding (struct coprocess_ctx *ctx)
+{
+    struct coproc *c = zlistx_first (ctx->procs);
+    while (c) {
+        if (c->eof_pending && idset_count (c->eof_pending) > 0)
+            return true;
+        c = zlistx_next (ctx->procs);
+    }
+    return false;
+}
+
+static void coproc_service_check (struct coprocess_ctx *ctx)
+{
+    if (ctx->service_ref && !coproc_eof_outstanding (ctx)) {
+        if (flux_shell_remove_completion_ref (ctx->shell,
+                                              "coprocess.service") < 0)
+            shell_log_errno ("coprocess: remove service completion ref");
+        ctx->service_ref = false;
+    }
+}
+
+/* Leader: follower rank 'shell_rank' has finished forwarding output for 'c'.
+ */
+static void coproc_eof (struct coproc *c, int shell_rank)
+{
+    if (c->eof_pending) {
+        idset_clear (c->eof_pending, shell_rank);
+        coproc_service_check (c->ctx);
+    }
+}
+
+/* stdout/stderr callback for a local co-process. Drain and write the data:
+ * the leader writes directly; a follower writes its own file directly when
+ * the output template is per-shell, otherwise forwards to the leader for
+ * aggregation into a single per-job file. Don't assume the data is NUL or
+ * newline terminated.
+ */
+static void coproc_output_cb (flux_subprocess_t *p, const char *stream)
+{
+    struct coproc *c = flux_subprocess_aux_get (p, "coproc");
+    const char *buf;
+    int len;
+
+    len = flux_subprocess_read (p, stream, &buf);
+    if (len <= 0)
+        return;
+    if (c->ctx->shell_rank == 0 || c->output_per_shell)
+        coproc_write (c, buf, len);
+    else
+        coproc_forward (c, buf, len);
+}
+
+static void kill_continuation (flux_future_t *f, void *arg)
+{
+    /* ESRCH means the co-process already exited before or during the kill,
+     * which is an expected race (e.g. a short-lived helper) and not an error.
+     */
+    if (flux_future_get (f, NULL) < 0 && errno != ESRCH)
+        shell_log_errno ("coprocess: kill");
+    flux_future_destroy (f);
+}
+
+static int coproc_kill (struct coproc *c, int signum)
+{
+    flux_future_t *f;
+
+    if (!c->proc)
+        return 0;
+    if (!(f = flux_subprocess_kill (c->proc, signum))) {
+        if (errno == ESRCH)
+            return 0;
+        return -1;
+    }
+    if (flux_future_then (f, -1, kill_continuation, NULL) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    return 0;
+}
+
+/* Co-process completed (exited or was signaled): drop its completion
+ * reference so the shell can exit once all co-processes are reaped.
+ */
+static void coproc_completion_cb (flux_subprocess_t *p)
+{
+    struct coproc *c = flux_subprocess_aux_get (p, "coproc");
+    struct coprocess_ctx *ctx = c->ctx;
+
+    c->proc = NULL;
+    flux_subprocess_destroy (p);
+
+    /* A follower forwarding to the leader has now read and forwarded all
+     * output, so tell the leader no more is coming for this co-process.
+     */
+    if (ctx->shell_rank != 0 && !c->output_per_shell)
+        coproc_forward_eof (c);
+
+    if (--ctx->running == 0 && ctx->kill_timer)
+        flux_watcher_stop (ctx->kill_timer);
+    if (flux_shell_remove_completion_ref (ctx->shell,
+                                          "coprocess::%s",
+                                          c->name) < 0)
+        shell_log_errno ("%s: remove completion ref", c->name);
+}
+
+/* SIGKILL escalation timer: any co-process still running after kill_timeout
+ * gets SIGKILL.
+ */
+static void kill_timer_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
+{
+    struct coprocess_ctx *ctx = arg;
+    struct coproc *c;
+
+    if (ctx->killed)
+        return;
+    ctx->killed = true;
+    shell_warn ("coprocess: helper(s) still running, sending SIGKILL");
+    c = zlistx_first (ctx->procs);
+    while (c) {
+        if (c->proc && coproc_kill (c, SIGKILL) < 0)
+            shell_log_errno ("%s: SIGKILL", c->name);
+        c = zlistx_next (ctx->procs);
+    }
+}
+
+/* Leader service: receive output forwarded by a follower shell. Each message
+ * carries either "data" (an output chunk) or "eof_rank" (the follower is done
+ * forwarding), never both. Since RPCs from a given follower are delivered in
+ * order, the eof_rank message arrives after that follower's last data chunk.
+ */
+static void write_service_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    struct coprocess_ctx *ctx = arg;
+    const char *name;
+    const char *data = NULL;
+    size_t len = 0;
+    int eof_rank = -1;
+    struct coproc *c;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s?s% s?i}",
+                             "name", &name,
+                             "data", &data, &len,
+                             "eof_rank", &eof_rank) < 0) {
+        shell_log_errno ("coprocess: write service unpack");
+        return;
+    }
+    if (!(c = coproc_find (ctx, name))) {
+        shell_log_error ("coprocess: write for unknown co-process '%s'", name);
+        return;
+    }
+    if (data)
+        coproc_write (c, data, len);
+    if (eof_rank >= 0)
+        coproc_eof (c, eof_rank);
+}
+
+/* Leader: a lost shell will never send its EOF, so drop it from every
+ * co-process's pending set. The lost shell independently raises a job
+ * exception, so this does not mask the failure.
+ */
+static int coprocess_lost (flux_plugin_t *p,
+                           const char *topic,
+                           flux_plugin_arg_t *args,
+                           void *arg)
+{
+    struct coprocess_ctx *ctx = arg;
+    struct coproc *c;
+    int shell_rank;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:i}",
+                                "shell_rank", &shell_rank) < 0)
+        return shell_log_errno ("coprocess: shell.lost unpack");
+    c = zlistx_first (ctx->procs);
+    while (c) {
+        if (c->eof_pending)
+            idset_clear (c->eof_pending, shell_rank);
+        c = zlistx_next (ctx->procs);
+    }
+    coproc_service_check (ctx);
+    return 0;
+}
+
+static int coprocess_start (flux_plugin_t *p,
+                            const char *topic,
+                            flux_plugin_arg_t *args,
+                            void *data)
+{
+    struct coprocess_ctx *ctx = data;
+    struct coproc *c;
+    flux_subprocess_ops_t ops = {
+        .on_stdout = coproc_output_cb,
+        .on_stderr = coproc_output_cb,
+        .on_completion = coproc_completion_cb,
+    };
+
+    c = zlistx_first (ctx->procs);
+    while (c) {
+        if (coproc_on_rank (c, ctx->shell_rank)) {
+            flux_subprocess_t *proc;
+            if (!(proc = flux_local_exec (ctx->shell->r, 0, c->cmd, &ops))
+                || flux_subprocess_aux_set (proc, "coproc", c, NULL) < 0) {
+                shell_log_errno ("%s: launch failed", c->name);
+                flux_subprocess_destroy (proc);
+                /* This follower will produce no output to forward, so release
+                 * the leader from waiting on its EOF.
+                 */
+                if (ctx->shell_rank != 0 && !c->output_per_shell)
+                    coproc_forward_eof (c);
+                c = zlistx_next (ctx->procs);
+                continue;
+            }
+            c->proc = proc;
+            ctx->running++;
+            if (flux_shell_add_completion_ref (ctx->shell,
+                                               "coprocess::%s",
+                                               c->name) < 0)
+                shell_log_errno ("%s: add completion ref",
+                                 c->name);
+            shell_debug ("%s: launched", c->name);
+        }
+        c = zlistx_next (ctx->procs);
+    }
+    return 0;
+}
+
+static int coprocess_finish (flux_plugin_t *p,
+                             const char *topic,
+                             flux_plugin_arg_t *args,
+                             void *data)
+{
+    struct coprocess_ctx *ctx = data;
+    struct coproc *c;
+
+    if (ctx->running == 0)
+        return 0;
+
+    c = zlistx_first (ctx->procs);
+    while (c) {
+        if (c->proc && coproc_kill (c, SIGTERM) < 0)
+            shell_log_errno ("%s: SIGTERM", c->name);
+        c = zlistx_next (ctx->procs);
+    }
+
+    /* Escalate to SIGKILL after kill_timeout */
+    if (!(ctx->kill_timer = flux_timer_watcher_create (ctx->shell->r,
+                                                       ctx->kill_timeout,
+                                                       0.,
+                                                       kill_timer_cb,
+                                                       ctx)))
+        return shell_log_errno ("coprocess: create kill timer");
+    flux_watcher_start (ctx->kill_timer);
+    return 0;
+}
+
+static int coprocess_init (flux_plugin_t *p,
+                           const char *topic,
+                           flux_plugin_arg_t *args,
+                           void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct coprocess_ctx *ctx;
+    json_t *config = NULL;
+    const char *name;
+    json_t *entry;
+    const char *timeout = NULL;
+
+    if (flux_shell_getopt_unpack (shell, "coprocess", "o", &config) < 0)
+        return -1;
+
+    if (!config)
+        return 0;
+
+    if (!json_is_object (config) || json_object_size (config) == 0) {
+        shell_log_error ("coprocess option must be a non-empty object");
+        return -1;
+    }
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return -1;
+    ctx->shell = shell;
+    ctx->kill_timeout = default_kill_timeout;
+    /* Grace period after SIGTERM before escalating to SIGKILL (FSD). */
+    if (flux_shell_getopt_unpack (shell,
+                                  "coprocess-kill-timeout",
+                                  "s",
+                                  &timeout) < 0) {
+        shell_log_error ("invalid coprocess-kill-timeout");
+        goto error;
+    }
+    if (timeout && fsd_parse_duration (timeout, &ctx->kill_timeout) < 0) {
+        shell_log_error ("failed to parse coprocess-kill-timeout");
+        goto error;
+    }
+    if (flux_shell_info_unpack (shell,
+                                "{s:i s:i}",
+                                "rank", &ctx->shell_rank,
+                                "size", &ctx->shell_size) < 0)
+        goto error;
+    if (!(ctx->procs = zlistx_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zlistx_set_destructor (ctx->procs, coproc_destructor);
+
+    json_object_foreach (config, name, entry) {
+        struct coproc *c;
+        if (!(c = coproc_create (ctx, name, entry)))
+            goto error;
+        if (!zlistx_add_end (ctx->procs, c)) {
+            coproc_destroy (c);
+            errno = ENOMEM;
+            goto error;
+        }
+    }
+
+    /* Transfer ownership of ctx to the plugin aux before taking any resource
+     * (service, completion ref) that would otherwise be leaked on a later
+     * error. After this succeeds, ctx is freed on plugin destruction, so error
+     * paths return -1 without destroying it.
+     */
+    if (flux_plugin_aux_set (p,
+                             "coprocess",
+                             ctx,
+                             (flux_free_f)coprocess_ctx_destroy) < 0)
+        goto error;
+
+    if (flux_plugin_add_handler (p, "shell.start", coprocess_start, ctx) < 0
+        || flux_plugin_add_handler (p,
+                                    "shell.finish",
+                                    coprocess_finish,
+                                    ctx) < 0)
+        return -1;
+
+    /* If any follower will forward output (a non-empty eof_pending set on the
+     * leader), register the aggregation service to receive it and hold a
+     * completion reference until all such followers have reported EOF.
+     */
+    if (coproc_eof_outstanding (ctx)) {
+        if (flux_plugin_add_handler (p,
+                                     "shell.lost",
+                                     coprocess_lost,
+                                     ctx) < 0
+            || flux_shell_service_register (shell,
+                                            "coprocess-write",
+                                            write_service_cb,
+                                            ctx) < 0
+            || flux_shell_add_completion_ref (shell,
+                                              "coprocess.service") < 0)
+            return -1;
+        ctx->service_ref = true;
+    }
+
+    shell_debug ("coprocess enabled (%d configured)",
+                 (int)zlistx_size (ctx->procs));
+    return 0;
+error:
+    coprocess_ctx_destroy (ctx);
+    return -1;
+}
+
+struct shell_builtin builtin_coprocess = {
+    .name = FLUX_SHELL_PLUGIN_NAME,
+    .init = coprocess_init,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/output/conf.c
+++ b/src/shell/output/conf.c
@@ -56,44 +56,6 @@
 static const int default_client_lwm = 100;
 static const int default_client_hwm = 1000;
 
-/* Detect if a mustache template is per-shell or per-task by rendering
- * per-rank template on rank 0 and rank 1, then a per-task template using
- * the first task on this rank. If any of these differ, return true,
- * otherwise, false.
- */
-static bool template_is_per_shell (flux_shell_t *shell,
-                                   const char *template)
-{
-    bool result = false;
-    char *s1 = NULL;
-    char *s2 = NULL;
-    char *s3 = NULL;
-    flux_shell_task_t *task = flux_shell_task_first (shell);
-
-    /* Handle {{tmpdir}} as a special case, since otherwise it will
-     * go undetected as a per-shell mustache template:
-     */
-    if (strstr (template, "{{tmpdir}}"))
-        return true;
-
-    /* Note: if shell_size == 1, then flux_shell_rank_mustache_render()
-     * for rank 1 will return NULL, so ensure this conditional fails early
-     * in that case:
-     */
-    if (!(s1 = flux_shell_rank_mustache_render (shell, 1, template))
-        || !(s2 = flux_shell_rank_mustache_render (shell, 0, template))
-        || !(s3 = flux_shell_task_mustache_render (shell, task, template)))
-        goto out;
-
-    if (!streq (s1, s2) || !streq (s2, s3) || !streq (s1, s3))
-        result = true;
-out:
-    free (s1);
-    free (s2);
-    free (s3);
-    return result;
-}
-
 static int output_stream_getopts (flux_shell_t *shell,
                                   const char *name,
                                   struct output_stream *stream)
@@ -129,7 +91,8 @@ static int output_stream_getopts (flux_shell_t *shell,
     }
     if (stream->template) {
         stream->type = FLUX_OUTPUT_TYPE_FILE;
-        stream->per_shell = template_is_per_shell (shell, stream->template);
+        stream->per_shell = flux_shell_mustache_is_per_rank (shell,
+                                                             stream->template);
     }
 
     if (strcasecmp (stream->buffer_type, "none") == 0)

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1119,6 +1119,43 @@ char *flux_shell_mustache_render (flux_shell_t *shell, const char *fmt)
     return do_mustache_render (shell, -1, NULL, fmt);
 }
 
+bool flux_shell_mustache_is_per_rank (flux_shell_t *shell, const char *fmt)
+{
+    bool result = false;
+    char *s0 = NULL;
+    char *s1 = NULL;
+    char *st = NULL;
+    flux_shell_task_t *task;
+
+    if (!shell || !fmt) {
+        errno = EINVAL;
+        return false;
+    }
+    /* If shell size is 1, then return false immediately since per-rank
+     * template can't be true:
+     */
+    if (shell->info->shell_size == 1)
+        return false;
+    /* {{tmpdir}} is per-rank but renders identically across ranks here, so
+     * special-case it.
+     */
+    if (strstr (fmt, "{{tmpdir}}"))
+        return true;
+    /* Render for shell rank 0, rank 1, and the first task on this rank and
+     * compare.  If any differ, the template is per-rank (or per-task).
+     */
+    task = flux_shell_task_first (shell);
+    if ((s0 = flux_shell_rank_mustache_render (shell, 0, fmt))
+        && (s1 = flux_shell_rank_mustache_render (shell, 1, fmt))
+        && (st = flux_shell_task_mustache_render (shell, task, fmt))
+        && (!streq (s0, s1) || !streq (s0, st)))
+        result = true;
+    free (s0);
+    free (s1);
+    free (st);
+    return result;
+}
+
 /* Render "node.*" specific tags using the rank_info object for the
  * requested shell rank. The part after `node.` will be fetched directly
  * from the rank_info object.

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -11,6 +11,7 @@
 #ifndef FLUX_SHELL_H
 #define FLUX_SHELL_H
 
+#include <stdbool.h>
 #include <flux/core.h>
 #include <flux/taskmap.h>
 #include <flux/hostlist.h>
@@ -438,6 +439,14 @@ char *flux_shell_rank_mustache_render (flux_shell_t *shell,
 char *flux_shell_task_mustache_render (flux_shell_t *shell,
                                        flux_shell_task_t *task,
                                        const char *fmt);
+
+/*  Return true if mustache template 'fmt' renders to a different result
+ *  across shell ranks or tasks (i.e. it contains a per-rank or per-task tag
+ *  such as {{node.id}}, {{node.name}}, {{task.id}}, or {{tmpdir}}). This is
+ *  useful for deciding whether a templated output path yields a distinct file
+ *  per shell. Returns false (with errno set to EINVAL) on invalid arguments.
+ */
+bool flux_shell_mustache_is_per_rank (flux_shell_t *shell, const char *fmt);
 
 #ifdef __cplusplus
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -258,6 +258,7 @@ TESTSCRIPTS = \
 	t2621-job-shell-plugin-fork.t \
 	t2622-job-shell-sysmon.t \
 	t2623-job-shell-oom.t \
+	t2624-job-shell-coprocess.t \
 	t2710-python-cli-submit.t \
 	t2711-python-cli-run.t \
 	t2713-python-cli-bulksubmit.t \

--- a/t/t2624-job-shell-coprocess.t
+++ b/t/t2624-job-shell-coprocess.t
@@ -1,0 +1,283 @@
+#!/bin/sh
+#
+test_description='Test flux-shell coprocess plugin'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4
+
+# Write a userrc that sets the "coprocess" shell option to the JSON object
+# provided as the first argument.  Usage: write_rc FILE 'JSON'
+write_rc() {
+	cat >"$1" <<-EOF
+	shell.options["coprocess"] = $2
+	EOF
+}
+
+# Submit job and wait for output. Set `f58` variable to jobid.
+submit_and_wait() {
+	f58=$(flux submit "$@") &&
+	flux job attach $f58
+}
+
+test_expect_success 'coprocess plugin is inert when option is unset' '
+	flux run -o verbose=2 true 2>unset.err &&
+	test_must_fail grep -i coprocess unset.err
+'
+
+test_expect_success 'coprocess launches helper and captures output' '
+	write_rc mon.lua "{
+	  mon = { command = {\"sh\", \"-c\", \"echo HELLO; sleep 30\"},
+	          output = \"mon-{{id}}.log\" }
+	}" &&
+	submit_and_wait -o userrc=$(pwd)/mon.lua sleep 1 &&
+	test -f mon-${f58}.log &&
+	grep HELLO mon-${f58}.log
+'
+
+test_expect_success 'job with sleeping coprocess still exits promptly' '
+	write_rc term.lua "{
+	  mon = { command = {\"sleep\", \"300\"},
+	          output = \"term-{{id}}.log\" }
+	}" &&
+	run_timeout 60 flux run -o userrc=$(pwd)/term.lua sleep 1
+'
+
+test_expect_success 'short-lived coprocess exits without a kill error' '
+	write_rc short.lua "{
+	  mon = { command = {\"hostname\"},
+	          output = \"short-{{id}}.out\" }
+	}" &&
+	flux run -o userrc=$(pwd)/short.lua true 2>short.err &&
+	test_must_fail grep -i "No such process" short.err &&
+	test_must_fail grep -i "coprocess.*kill" short.err
+'
+
+test_expect_success 'coprocess that traps SIGTERM is killed by SIGKILL' '
+	write_rc trap.lua "{
+	  mon = { command = {\"sh\", \"-c\",
+	             \"trap \\\"\\\" TERM; while true; do sleep 1; done\"},
+	          output = \"trap-{{id}}.log\" }
+	}" &&
+	run_timeout 60 flux run -o userrc=$(pwd)/trap.lua \
+		-o coprocess-kill-timeout=1s sleep 1 2>trap.err &&
+	grep -i "sending SIGKILL" trap.err
+'
+
+test_expect_success 'invalid coprocess-kill-timeout is rejected' '
+	write_rc kt.lua "{
+	  mon = { command = {\"true\"}, output = \"kt-{{id}}.log\" }
+	}" &&
+	test_must_fail flux run -o userrc=$(pwd)/kt.lua \
+		-o coprocess-kill-timeout=notfsd true 2>kt.err &&
+	grep -i "coprocess-kill-timeout" kt.err
+'
+
+test_expect_success 'multi-node coprocess output is aggregated to one file' '
+	write_rc agg.lua "{
+	  mon = { command = {\"sh\", \"-c\",
+	                     \"flux getattr rank; sleep 30\"},
+	          output = \"agg-{{id}}.log\" }
+	}" &&
+	submit_and_wait -N2 -o userrc=$(pwd)/agg.lua sleep 1 &&
+	test -f agg-${f58}.log &&
+	test $(wc -l <agg-${f58}.log) -eq 2
+'
+
+# Output emitted only after SIGTERM must still reach the aggregated file from
+# every shell, including followers whose final chunk races shutdown. The
+# helper writes a marker line from its SIGTERM handler, then exits.
+test_expect_success 'final coprocess output on SIGTERM is not lost' '
+	write_rc term_out.lua "{
+	  mon = { command = {\"sh\", \"-c\",
+		    \"trap \\\"echo BYE{{node.id}}; exit 0\\\" TERM; while true; do sleep 0.1; done\"},
+	          output = \"termout-{{id}}.log\" }
+	}" &&
+	submit_and_wait -N2 -o userrc=$(pwd)/term_out.lua sleep 1 &&
+	test -f termout-${f58}.log &&
+	grep BYE0 termout-${f58}.log &&
+	grep BYE1 termout-${f58}.log
+'
+
+test_expect_success 'per-node output template yields one file per node' '
+	write_rc pernode.lua "{
+	  mon = { command = {\"sh\", \"-c\",
+	                     \"echo rank{{node.id}}; sleep 30\"},
+	          output = \"pernode-{{id}}-{{node.id}}.log\" }
+	}" &&
+	submit_and_wait -N2 -o userrc=$(pwd)/pernode.lua sleep 1 &&
+	grep rank0 pernode-${f58}-0.log &&
+	grep rank1 pernode-${f58}-1.log
+'
+
+# With a per-shell template each shell writes its own file directly, so the
+# leader does not register the coprocess-write aggregation service. Verify a
+# follower still produces its file (it wrote it itself, not via the leader).
+test_expect_success 'per-shell template avoids leader output forwarding' '
+	write_rc direct.lua "{
+	  mon = { command = {\"sh\", \"-c\",
+	                     \"echo host-{{node.name}}; sleep 30\"},
+	          output = \"direct-{{node.name}}.log\" }
+	}" &&
+	submit_and_wait -N2 -o userrc=$(pwd)/direct.lua sleep 1 &&
+	test -f direct-$(hostname).log &&
+	grep host-$(hostname) direct-$(hostname).log
+'
+
+test_expect_success 'ranks option restricts launch to a subset of shells' '
+	write_rc ranks.lua "{
+	  mon = { command = {\"sh\", \"-c\", \"echo hi; sleep 30\"},
+	          output = \"ranks-{{id}}-{{node.id}}.log\",
+	          ranks = \"0\" }
+	}" &&
+	submit_and_wait -N2 -o userrc=$(pwd)/ranks.lua sleep 1 &&
+	test -f ranks-${f58}-0.log &&
+	test_must_fail test -f ranks-${f58}-1.log
+'
+
+test_expect_success 'ranks option may exclude the leader shell' '
+	write_rc foll.lua "{
+	  mon = { command = {\"sh\", \"-c\", \"echo FOLLONLY; sleep 30\"},
+	          output = \"foll-{{id}}.log\",
+	          ranks = \"1\" }
+	}" &&
+	submit_and_wait -N2 -o userrc=$(pwd)/foll.lua sleep 1 &&
+	test -f foll-${f58}.log &&
+	grep FOLLONLY foll-${f58}.log
+'
+
+test_expect_success 'output template supports {{node.name}}' '
+	write_rc host.lua "{
+	  mon = { command = {\"sh\", \"-c\", \"echo hi; sleep 30\"},
+	          output = \"host-{{node.name}}.log\" }
+	}" &&
+	flux run -o userrc=$(pwd)/host.lua sleep 1 &&
+	test -f host-$(hostname).log
+'
+
+test_expect_success 'command supports mustache templates' '
+	write_rc cmdtmpl.lua "{
+	  mon = { command = {\"sh\", \"-c\", \"echo id={{id}}; sleep 30\"},
+		  output = \"cmdtmpl-{{id}}.log\" }
+	}" &&
+	submit_and_wait -o userrc=$(pwd)/cmdtmpl.lua sleep 1 &&
+	grep "id=${f58}" cmdtmpl-${f58}.log
+'
+
+test_expect_success 'multiple co-processes run concurrently' '
+	write_rc multi.lua "{
+	  a = { command = {\"sh\", \"-c\", \"echo AAA; sleep 30\"},
+	        output = \"multi-a-{{id}}.log\" },
+	  b = { command = {\"sh\", \"-c\", \"echo BBB; sleep 30\"},
+                output = \"multi-b-{{id}}.log\" }
+	}" &&
+	submit_and_wait -o userrc=$(pwd)/multi.lua sleep 1 &&
+	grep AAA multi-a-${f58}.log &&
+	grep BBB multi-b-${f58}.log
+'
+
+# Two co-processes, both aggregated to their own leader file across two nodes.
+# Exercises independent per-co-process EOF accounting on the leader.
+test_expect_success 'multiple aggregated co-processes on multiple nodes' '
+	write_rc multiagg.lua "{
+	  a = { command = {\"sh\", \"-c\", \"echo A{{node.id}}; sleep 30\"},
+	        output = \"multiagg-a-{{id}}.log\" },
+	  b = { command = {\"sh\", \"-c\", \"echo B{{node.id}}; sleep 30\"},
+                output = \"multiagg-b-{{id}}.log\" }
+	}" &&
+	submit_and_wait -N2 -o userrc=$(pwd)/multiagg.lua sleep 1 &&
+	grep A0 multiagg-a-${f58}.log &&
+	grep A1 multiagg-a-${f58}.log &&
+	grep B0 multiagg-b-${f58}.log &&
+	grep B1 multiagg-b-${f58}.log
+'
+
+# A follower shell that dies by signal generates a lost-shell exception,
+# handled by the coprocess shell.lost handler which drops the lost rank from
+# the leader's EOF wait set. A task barrier ensures all shells are up before
+# rank 3 kills its own shell, and exit-timeout=none ensures the leader waits
+# on the aggregation reference rather than a timeout. Verify the leader
+# observes the lost shell and the job then completes.
+test_expect_success 'lost follower shell is handled with aggregated output' '
+	write_rc lost.lua "{
+	  mon = { command = {\"sh\", \"-c\", \"echo COPROC; sleep 300\"},
+	          output = \"lost-{{id}}.log\" }
+	}" &&
+	cat >killshell.sh <<-EOF &&
+	#!/bin/sh
+	flux pmi barrier
+	test \$(flux getattr rank) -eq 3 && kill -9 \$PPID
+	sleep 300
+	EOF
+	chmod +x killshell.sh &&
+	id=$(flux submit -N4 --tasks-per-node=1 -o exit-timeout=none \
+		-o userrc=$(pwd)/lost.lua ./killshell.sh) &&
+	flux job wait-event -Wt 60 -Hp output \
+		-m message="shell rank 3 (on $(hostname)): Killed" $id log &&
+	flux cancel $id &&
+	flux job wait-event -t 60 $id clean
+'
+
+test_expect_success 'co-process with no output key uses a default file' '
+	write_rc noout.lua "{
+	  mon = { command = {\"sh\", \"-c\", \"echo DEFAULTOUT; sleep 30\"} }
+	}" &&
+	submit_and_wait -o userrc=$(pwd)/noout.lua sleep 1 &&
+	test -f coproc-mon-${f58}.log &&
+	grep DEFAULTOUT coproc-mon-${f58}.log
+'
+
+test_expect_success 'failure to launch a co-process is non-fatal' '
+	write_rc badcmd.lua "{
+	  mon = { command = {\"/nonexistent/command\"},
+	          output = \"badcmd-{{id}}.log\" }
+	}" &&
+	flux run -o userrc=$(pwd)/badcmd.lua sleep 1 2>badcmd.err &&
+	grep -i "launch failed" badcmd.err
+'
+
+# A follower that fails to launch its co-process must still release the leader
+# from waiting on its output EOF, or the job would hang until kill-timeout.
+test_expect_success 'follower launch failure does not hang aggregated job' '
+	write_rc badmulti.lua "{
+	  mon = { command = {\"/nonexistent/command\"},
+	          output = \"badmulti-{{id}}.log\" }
+	}" &&
+	run_timeout 30 flux run -N2 -o userrc=$(pwd)/badmulti.lua sleep 1
+'
+
+test_expect_success 'co-process that exits early is non-fatal' '
+	write_rc early.lua "{
+	  mon = { command = {\"sh\", \"-c\", \"exit 3\"},
+	          output = \"early-{{id}}.log\" }
+	}" &&
+	flux run -o userrc=$(pwd)/early.lua sleep 1
+'
+
+test_expect_success 'invalid coprocess command is rejected' '
+	write_rc bad.lua "{ mon = { command = \"notanarray\" } }" &&
+	test_must_fail flux run -o userrc=$(pwd)/bad.lua true 2>bad.err &&
+	grep -i "command must be" bad.err
+'
+
+test_expect_success 'empty coprocess command array is rejected' '
+	write_rc empty.lua "{ mon = { command = {} } }" &&
+	test_must_fail flux run -o userrc=$(pwd)/empty.lua true 2>empty.err &&
+	grep -i "non-empty array" empty.err
+'
+
+test_expect_success 'invalid ranks idset is rejected' '
+	write_rc badranks.lua "{
+	  mon = { command = {\"true\"}, ranks = \"notanidset\" }
+	}" &&
+	test_must_fail flux run -o userrc=$(pwd)/badranks.lua true 2>badranks.err &&
+	grep -i "invalid ranks" badranks.err
+'
+
+test_expect_success 'non-object coprocess option is rejected' '
+	write_rc notobj.lua "\"nope\"" &&
+	test_must_fail flux run -o userrc=$(pwd)/notobj.lua true 2>notobj.err &&
+	grep -i "non-empty object" notobj.err
+'
+
+test_done

--- a/t/t2624-job-shell-coprocess.t
+++ b/t/t2624-job-shell-coprocess.t
@@ -280,4 +280,45 @@ test_expect_success 'non-object coprocess option is rejected' '
 	grep -i "non-empty object" notobj.err
 '
 
+#  coprocess.define() Lua helper: a drop-in registers a co-process by name
+#  that the user enables with -o <name> (defaults) or -o <name>.<key>=<val>
+#  (overrides).
+test_expect_success 'write coprocess.define rc file' '
+	cat >def.lua <<-EOF
+	coprocess.define {
+	    name = "mon",
+	    command = {"sh", "-c", "echo DEFINED; sleep 30"},
+	    output = "def-{{id}}.log",
+	}
+	EOF
+'
+
+test_expect_success "coprocess.define is inert unless enabled" '
+	flux run -o verbose=2 -o userrc=$(pwd)/def.lua true 2>def-off.err &&
+	test_must_fail grep -i "mon: launched" def-off.err
+'
+
+test_expect_success "coprocess.define enabled with -o mon uses defaults" '
+	submit_and_wait -o userrc=$(pwd)/def.lua -o mon sleep 1 &&
+	test -f def-${f58}.log &&
+	grep DEFINED def-${f58}.log
+'
+
+test_expect_success "coprocess.define -o mon.output overrides the default" '
+	submit_and_wait -o userrc=$(pwd)/def.lua \
+		-o mon.output=override.log sleep 1 &&
+	grep DEFINED override.log
+'
+
+#  A missing name raises a Lua error while loading the rc file, which
+#  terminates the shell by signal rather than exiting nonzero.
+test_expect_success "coprocess.define without a name is an error" '
+	cat >noname.lua <<-EOF &&
+	coprocess.define { command = {"true"} }
+	EOF
+	test_must_fail_or_be_terminated \
+		flux run -o userrc=$(pwd)/noname.lua -o mon true 2>noname.err &&
+	grep -i "missing required .name" noname.err
+'
+
 test_done


### PR DESCRIPTION
This PR implements the design discussed in #7680 (motivated by #7679): a generic `coprocess` builtin shell plugin that launches and manages one or more helper "coprocesses" — e.g. node monitoring or profiling tools — alongside a job for its duration.

Co-processes are configured via the `coprocess` shell option, a JSON object keyed by name, where each entry sets a `command` (with mustache template support), an optional `output` file template, and an optional `ranks` idset selecting which shells launch it. Each participating shell launches its helper locally with `flux_local_exec(3)`; helpers are sent SIGTERM when the job's tasks complete, escalating to SIGKILL after a configurable `coprocess-kill-timeout`.

Output handling depends on the `output` template. When it renders to a distinct path per shell (e.g. it contains `{{node.id}}` or `{{node.name}}`), each shell writes its own file directly. Otherwise, output is aggregated to a single file on the leader shell, with followers forwarding their output over a shell service — the same leader-aggregation pattern used by the builtin `output` plugin (which this shares the new `flux_shell_mustache_is_per_rank(3)` helper with). The leader holds a completion reference until every follower has signaled EOF, accounting for lost shells, so no output is dropped at shutdown.

A `coprocess.define()` Lua helper lets a site register a co-process in a drop-in rc file so users can enable it by name — `flux run -o gpumon` for defaults, or `-o gpumon.output=foo.log` to override a field.

e.g.: 

```lua
  coprocess.define {
      name = "vmstat",
      command = {"vmstat", "5"},
      output = "vmstat-{{id}}.log",
 }
```

would be run as

```sh
$ flux run -o vmstat. ...
```

The `coprocess.define()` commits are added as a follow-on because this part of the feature is not strictly necessary, so could be dropped if it seems gratuitous.

Fixes #7680
Fixes #7679