### PR TITLE
testsuite: fix a couple flaky tests

### DIFF
--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -453,7 +453,13 @@ def main():
 
         signal(SIGALRM, sigalrm_handler)
 
+        # Set when an expect entry with "exit": true matches, so that
+        # runpty exits successfully after the reactor stops regardless of
+        # the child's exit status.
+        exit_requested = False
+
         def read_tty():
+            nonlocal exit_requested
             buf.read()
             if expect.match(buf.peek()):
                 send_data, command, should_exit = expect.pop()
@@ -463,12 +469,18 @@ def main():
                     os.system(command)
                 if should_exit:
                     # Pattern matched and exit requested - terminate child
-                    # and exit successfully regardless of child exit status
+                    # and exit successfully regardless of child exit status.
+                    # Stop the reactor deterministically here rather than
+                    # racing a delayed exit against the pty EOF that results
+                    # from killing the child (which would otherwise fall
+                    # through to the child's exit status below).
                     try:
                         os.kill(pid, SIGTERM)
                     except ProcessLookupError:
                         pass
-                    loop.call_later(0.1, sys.exit, 0)
+                    exit_requested = True
+                    loop.remove_reader(fd)
+                    loop.stop()
                     return
             buf.send_data(ofile.write_entry)
             if buf.eof:
@@ -480,6 +492,11 @@ def main():
 
         loop.add_reader(fd, read_tty)
         loop.run_forever()
+
+        # Exit successfully if an expect entry requested it, without
+        # waiting on (or reporting) the child's exit status.
+        if exit_requested:
+            sys.exit(0)
 
         (pid, status) = os.waitpid(pid, 0)
         sys.exit(status_to_exitcode(status))

--- a/t/t2610-job-shell-mpir.t
+++ b/t/t2610-job-shell-mpir.t
@@ -125,7 +125,7 @@ test_expect_success 'mpir: tool tasks are killed after rexec-shutdown-timeout' '
 	chmod +x mpir-catch-sigterm.sh &&
 	chmod +x wait-for-ready.sh &&
 	id=$(flux submit -N2 -n2 -o stop-tasks-in-exec \
-	     -o rexec-shutdown-timeout=0.5s \
+	     -o rexec-shutdown-timeout=2.5s \
 	     ./wait-for-ready.sh) &&
 	flux job wait-event -vt 5 -p exec -m sync=true $id shell.start &&
 	shell_rank=$(shell_leader_rank $id) &&

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -208,32 +208,38 @@ test_expect_success NO_CHAIN_LINT 'flux-top can call itself recursively' '
 	$runpty -o recurse.log --input=recurse.in flux top &&
 	grep -q $(echo $(cat expected.id) | sed "s/ƒ//") recurse.log
 '
-# note that FLUX_URI_RESOLVE_LOCAL=t is intentionally not set on
-# the runpty line below, as we're using a fake ssh
+# note that FLUX_URI_RESOLVE_LOCAL is intentionally unset on the runpty
+# line below, as we are using a fake ssh.
+#
+# Input is driven by expect patterns rather than fixed timestamps to
+# avoid raciness: send "k" to select the batch.sh job (the last entry,
+# reached by wrapping backwards from no selection), press enter once it
+# is highlighted to recurse into it, dismiss the resulting error popup
+# with any key ("x"), then quit with "q" once the popup dismissal has
+# forced a redraw.  flux-top is expected to exit normally, demonstrating
+# that it did not exit abnormally when the recursive connection failed.
+#
+# N.B. the unset of FLUX_URI_RESOLVE_LOCAL is scoped to a subshell so it
+# cannot leak into subsequent tests if runpty exits nonzero.
 test_expect_success NO_CHAIN_LINT 'flux-top does not exit on recursive failure' '
 	cat <<-EOF1 >ssh-fail &&
 	#!/bin/sh
 	printf "ssh failure\n" >&2
 	EOF1
 	chmod +x ssh-fail &&
-	SHELL=/bin/sh &&
-	flux jobs &&
-	flux proxy $(cat jobid2) flux jobs -c1 -no {id} >expected.id &&
-	cat <<-EOF >recurse-fail.in &&
-	{ "version": 2 }
-	[0.5, "i", "j"]
-	[1.0, "i", "j"]
-	[1.5, "i", "j"]
-	[2.0, "i", "k"]
-	[2.5, "i", "\n"]
-	[3.25, "i", "x"]
-	[3.75, "i", "q"]
+	cat <<-EOF >recurse-fail-expect.json &&
+	[
+	  { "expect": "batch.sh",                 "send": "k" },
+	  { "expect": "batch.sh",                 "send": "\n" },
+	  { "expect": "error connecting to Flux", "send": "x" },
+	  { "expect": ".",                        "send": "q" }
+	]
 	EOF
-	unset FLUX_URI_RESOLVE_LOCAL &&
-	FLUX_SSH=$(pwd)/ssh-fail \
-	    $runpty -f asciicast -o recurse-fail.log \
-	        --input=recurse-fail.in flux top &&
-	export FLUX_URI_RESOLVE_LOCAL=t
+	( unset FLUX_URI_RESOLVE_LOCAL &&
+	  FLUX_SSH=$(pwd)/ssh-fail \
+	      $runpty -f asciicast -o recurse-fail.log \
+	          --expect recurse-fail-expect.json \
+	          --timeout=60 flux top ) &&
 	grep -qi "error connecting to Flux" recurse-fail.log
 '
 test_expect_success 'cleanup running jobs' '


### PR DESCRIPTION
This PR addresses racy tests reported in `t2610-job-shell-mpir.t` and `t2801-top-cmd.t`.

An issue with the `runpty.py` helper script was also found and fixed.