### PR TITLE
libsubprocess: support on_sigstatus callback

### DIFF
--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -575,7 +575,7 @@ static void exec_state_cb (flux_subprocess_t *proc,
             break;
         case FLUX_SUBPROCESS_EXITED:
         case FLUX_SUBPROCESS_INIT:
-        case FLUX_SUBPROCESS_STOPPED:
+        case FLUX_SUBPROCESS_STOPPED: /* deprecated */
             break; // ignore
     }
 }

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -272,7 +272,7 @@ static void state_change_cb (flux_subprocess_t *p,
     switch (state) {
         case FLUX_SUBPROCESS_INIT:
         case FLUX_SUBPROCESS_EXITED:
-        case FLUX_SUBPROCESS_STOPPED:
+        case FLUX_SUBPROCESS_STOPPED: /* deprecated */
             break;
         case FLUX_SUBPROCESS_FAILED:
             completion_cb (p);

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -53,7 +53,6 @@ struct runat_entry {
     bool completed;
     bool interactive;
     bool foreground;
-    bool needs_foreground;
     runat_completion_f cb;
     void *cb_arg;
 };
@@ -273,32 +272,28 @@ static void state_change_cb (flux_subprocess_t *p,
     switch (state) {
         case FLUX_SUBPROCESS_INIT:
         case FLUX_SUBPROCESS_EXITED:
+        case FLUX_SUBPROCESS_STOPPED:
             break;
         case FLUX_SUBPROCESS_FAILED:
             completion_cb (p);
-            break;
-        case FLUX_SUBPROCESS_STOPPED:
-            /* STOPPED may arrive before RUNNING due to a protocol race
-             * (issue #5083) so the pid may not yet be available. If
-             * available, bring process into foreground immediately.
-             * Otherwise, defer via needs_foreground flag until RUNNING state.
-             */
-            if (flux_subprocess_pid (p) > 0)
-                foreground_runat_entry (r, entry, p);
-            else
-                entry->needs_foreground = true;
             break;
         case FLUX_SUBPROCESS_RUNNING:
             if (entry->aborted) {
                 if (kill_async (p, abort_signal) < 0)
                     flux_log_error (r->h, "kill %s", entry->name);
             }
-            else if (entry->needs_foreground) {
-                foreground_runat_entry (r, entry, p);
-                entry->needs_foreground = false;
-            }
             break;
     }
+}
+
+static void sigchld_cb (flux_subprocess_t *p,
+                        flux_subprocess_sigchld_t sigchld)
+{
+    struct runat *r = flux_subprocess_aux_get (p, "runat");
+    struct runat_entry *entry = flux_subprocess_aux_get (p, "runat_entry");
+
+    if (sigchld == FLUX_SUBPROCESS_SIGCHLD_STOPPED)
+        foreground_runat_entry (r, entry, p);
 }
 
 /* Log subprocess output.
@@ -377,6 +372,7 @@ static flux_subprocess_t *start_command (struct runat *r,
         .on_channel_out = NULL,
         .on_stdout = NULL,
         .on_stderr = NULL,
+        .on_sigchld = sigchld_cb,
     };
 
     if (runat_command_setenv (cmd, env_blocklist, r->local_uri, r->jobid) < 0)

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -402,7 +402,7 @@ static void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
             }
             break;
         }
-        case FLUX_SUBPROCESS_STOPPED:
+        case FLUX_SUBPROCESS_STOPPED: /* deprecated */
             /* ignore */
             break;
     }

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -489,6 +489,8 @@ static void sigchld_cb (pid_t pid, int status, void *arg)
     if (WIFSTOPPED (p->status)) {
         if (p->ops.on_state_change)
             (*p->ops.on_state_change) (p, FLUX_SUBPROCESS_STOPPED);
+        sigchld_set (p, FLUX_SUBPROCESS_SIGCHLD_STOPPED);
+        sigchld_notify_start (p);
     }
 
     if (WIFEXITED (p->status) || WIFSIGNALED (p->status)) {

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -487,8 +487,6 @@ static void sigchld_cb (pid_t pid, int status, void *arg)
     p->status = status;
 
     if (WIFSTOPPED (p->status)) {
-        if (p->ops.on_state_change)
-            (*p->ops.on_state_change) (p, FLUX_SUBPROCESS_STOPPED);
         sigchld_set (p, FLUX_SUBPROCESS_SIGCHLD_STOPPED);
         sigchld_notify_start (p);
     }

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -166,6 +166,15 @@ static void process_new_state (flux_subprocess_t *p,
         state_change_start (p);
 }
 
+static void process_new_sigchld (flux_subprocess_t *p,
+                                 flux_subprocess_sigchld_t sigchld)
+{
+    if (sigchld == FLUX_SUBPROCESS_SIGCHLD_STOPPED) {
+        sigchld_set (p, FLUX_SUBPROCESS_SIGCHLD_STOPPED);
+        sigchld_notify_start (p);
+    }
+}
+
 static void process_add_credit (flux_subprocess_t *p, json_t *channels)
 {
     if (p->ops.on_credit) {
@@ -601,6 +610,7 @@ static void rexec_continuation (flux_future_t *f, void *arg)
     }
     else if (subprocess_rexec_is_stopped (f)) {
         process_new_state (p, FLUX_SUBPROCESS_STOPPED);
+        process_new_sigchld (p, FLUX_SUBPROCESS_SIGCHLD_STOPPED);
     }
     else if (subprocess_rexec_is_finished (f, &p->status)) {
         process_new_state (p, FLUX_SUBPROCESS_EXITED);

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -133,17 +133,6 @@ static void process_new_state (flux_subprocess_t *p,
     if (p->state == FLUX_SUBPROCESS_FAILED)
         return;
 
-    if (state == FLUX_SUBPROCESS_STOPPED) {
-        if (p->ops.on_state_change) {
-            /* always a chance caller may destroy subprocess in
-             * callback */
-            subprocess_incref (p);
-            (*p->ops.on_state_change) (p, FLUX_SUBPROCESS_STOPPED);
-            subprocess_decref (p);
-        }
-        return;
-    }
-
     p->state = state;
 
     /* On EXITED, leave the output watchers running so any remaining
@@ -609,7 +598,6 @@ static void rexec_continuation (flux_future_t *f, void *arg)
         process_new_state (p, FLUX_SUBPROCESS_RUNNING);
     }
     else if (subprocess_rexec_is_stopped (f)) {
-        process_new_state (p, FLUX_SUBPROCESS_STOPPED);
         process_new_sigchld (p, FLUX_SUBPROCESS_SIGCHLD_STOPPED);
     }
     else if (subprocess_rexec_is_finished (f, &p->status)) {

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -608,13 +608,6 @@ static void proc_state_change_cb (flux_subprocess_t *p,
                                     "type", "finished",
                                     "status", flux_subprocess_status (p));
     }
-    else if (state == FLUX_SUBPROCESS_STOPPED) {
-        if (client_listening (p))
-            rc = flux_respond_pack (s->h,
-                                    request,
-                                    "{s:s}",
-                                    "type", "stopped");
-    }
     else if (state == FLUX_SUBPROCESS_FAILED) {
         const char *errmsg = NULL;
         if (p->failed_error.text[0] != '\0')

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -809,6 +809,36 @@ error:
     proc_internal_fatal (p);
 }
 
+static void proc_sigchld_cb (flux_subprocess_t *p,
+                             flux_subprocess_sigchld_t sigchld)
+{
+    subprocess_server_t *s = flux_subprocess_aux_get (p, srvkey);
+    const flux_msg_t *request = flux_subprocess_aux_get (p, msgkey);
+    int rc = 0;
+
+    if (sigchld == FLUX_SUBPROCESS_SIGCHLD_STOPPED) {
+        if (client_listening (p))
+            rc = flux_respond_pack (s->h,
+                                    request,
+                                    "{s:s}",
+                                    "type", "stopped");
+    } else {
+        errno = EPROTO;
+        llog_error (s, "subprocess received unexpected sigchld %d", sigchld);
+        goto error;
+    }
+    if (rc < 0) {
+        llog_error (s,
+                    "error responding to %s.exec request: %s",
+                    s->service_name,
+                    strerror (errno));
+    }
+    return;
+
+error:
+    proc_internal_fatal (p);
+}
+
 /* Per RFC 42, a background subprocess's standard input and any writable
  * auxiliary channels are at end-of-file.  Close the write side of each
  * writable channel so the subprocess reads EOF rather than blocking.
@@ -845,6 +875,7 @@ static void server_exec_cb (flux_t *h,
         .on_stdout = proc_output_cb,
         .on_stderr = proc_output_cb,
         .on_credit = proc_credit_cb,
+        .on_sigchld = proc_sigchld_cb,
     };
     char **env = NULL;
     const char *errmsg = NULL;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -326,9 +326,6 @@ static void state_change_prep_cb (flux_reactor_t *r,
 
 static flux_subprocess_state_t state_change_next (flux_subprocess_t *p)
 {
-    /* N.B. possible transition to FLUX_SUBPROCESS_STOPPED not handled
-     * here, see issue #5083
-     */
     assert (p->state_reported != p->state);
     assert (p->state_reported == FLUX_SUBPROCESS_INIT
             || p->state_reported == FLUX_SUBPROCESS_RUNNING);
@@ -1374,7 +1371,7 @@ const char *flux_subprocess_state_string (flux_subprocess_state_t state)
         return "Exited";
     case FLUX_SUBPROCESS_FAILED:
         return "Failed";
-    case FLUX_SUBPROCESS_STOPPED:
+    case FLUX_SUBPROCESS_STOPPED: /* deprecated */
         return "Stopped";
     }
     return NULL;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -437,6 +437,30 @@ void sigchld_notify_start (flux_subprocess_t *p)
     }
 }
 
+static void sigchld_clear_check (flux_subprocess_t *p)
+{
+    /* N.B. no more sigchld reports after EXITED or FAILED */
+    flux_subprocess_state_t state =
+        p->ops.on_state_change ? p->state_reported : p->state;
+
+    if (state == FLUX_SUBPROCESS_EXITED
+        || state == FLUX_SUBPROCESS_FAILED)
+        p->sigchld_pending = 0;
+}
+
+/* True when a queued sigchld must not yet be delivered because the
+ * caller has an on_state_change callback and the RUNNING state has not
+ * been reported to them (see issue #5083).  While deferred we leave the
+ * idle watcher stopped so the reactor is not spun; the state-change
+ * machinery keeps the reactor live until RUNNING is reported, and the
+ * prep watcher re-evaluates each iteration.
+ */
+static bool sigchld_deferred (flux_subprocess_t *p)
+{
+    return p->ops.on_state_change
+        && p->state_reported < FLUX_SUBPROCESS_RUNNING;
+}
+
 static void sigchld_prep_cb (flux_reactor_t *r,
                              flux_watcher_t *w,
                              int revents,
@@ -444,13 +468,15 @@ static void sigchld_prep_cb (flux_reactor_t *r,
 {
     flux_subprocess_t *p = arg;
 
-    if (p->sigchld_pending)
-        flux_watcher_start (p->sigchld_idle_w);
-    else {
+    sigchld_clear_check (p);
+
+    if (!p->sigchld_pending) {
         /* nothing left to report, stop watching */
         flux_watcher_stop (p->sigchld_prep_w);
         flux_watcher_stop (p->sigchld_check_w);
     }
+    else if (!sigchld_deferred (p))
+        flux_watcher_start (p->sigchld_idle_w);
 }
 
 static void sigchld_check_cb (flux_reactor_t *r,
@@ -465,14 +491,19 @@ static void sigchld_check_cb (flux_reactor_t *r,
     /* always a chance caller may destroy subprocess in callback */
     subprocess_incref (p);
 
-    /* Only one sigchld value exists for now, so clear the pending flags
-     * and report it directly.
-     */
+    sigchld_clear_check (p);
+
     if (p->sigchld_pending != 0) {
+        /* N.B. See issue #5083.  We do not want to report any signal
+         * status until after the job is reported as RUNNING.
+         */
+        if (sigchld_deferred (p))
+            goto out;
+        (*p->ops.on_sigchld) (p, p->sigchld_pending);
         p->sigchld_pending = 0;
-        (*p->ops.on_sigchld) (p, FLUX_SUBPROCESS_SIGCHLD_UNKNOWN);
     }
 
+out:
     subprocess_decref (p);
 }
 
@@ -1354,8 +1385,8 @@ flux_subprocess_sigchld_string (flux_subprocess_sigchld_t sigchld)
 {
     switch (sigchld)
     {
-    case FLUX_SUBPROCESS_SIGCHLD_UNKNOWN:
-        return "Unknown";
+    case FLUX_SUBPROCESS_SIGCHLD_STOPPED:
+        return "Stopped";
     }
     return NULL;
 }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -150,6 +150,10 @@ static void subprocess_free (flux_subprocess_t *p)
         flux_watcher_destroy (p->state_idle_w);
         flux_watcher_destroy (p->state_check_w);
 
+        flux_watcher_destroy (p->sigchld_prep_w);
+        flux_watcher_destroy (p->sigchld_idle_w);
+        flux_watcher_destroy (p->sigchld_check_w);
+
         flux_watcher_destroy (p->completed_prep_w);
         flux_watcher_destroy (p->completed_idle_w);
         flux_watcher_destroy (p->completed_check_w);
@@ -413,6 +417,98 @@ static int subprocess_setup_state_change (flux_subprocess_t *p)
     return 0;
 }
 
+/* Pending sigchld is tracked in sigchld_pending.
+ * N.B. only one sigchld is supported right now.
+ */
+void sigchld_set (flux_subprocess_t *p,
+                  flux_subprocess_sigchld_t sigchld)
+{
+    if (!p->ops.on_sigchld)
+        return;
+
+    p->sigchld_pending = sigchld;
+}
+
+void sigchld_notify_start (flux_subprocess_t *p)
+{
+    if (p->ops.on_sigchld) {
+        flux_watcher_start (p->sigchld_prep_w);
+        flux_watcher_start (p->sigchld_check_w);
+    }
+}
+
+static void sigchld_prep_cb (flux_reactor_t *r,
+                             flux_watcher_t *w,
+                             int revents,
+                             void *arg)
+{
+    flux_subprocess_t *p = arg;
+
+    if (p->sigchld_pending)
+        flux_watcher_start (p->sigchld_idle_w);
+    else {
+        /* nothing left to report, stop watching */
+        flux_watcher_stop (p->sigchld_prep_w);
+        flux_watcher_stop (p->sigchld_check_w);
+    }
+}
+
+static void sigchld_check_cb (flux_reactor_t *r,
+                              flux_watcher_t *w,
+                              int revents,
+                              void *arg)
+{
+    flux_subprocess_t *p = arg;
+
+    flux_watcher_stop (p->sigchld_idle_w);
+
+    /* always a chance caller may destroy subprocess in callback */
+    subprocess_incref (p);
+
+    /* Only one sigchld value exists for now, so clear the pending flags
+     * and report it directly.
+     */
+    if (p->sigchld_pending != 0) {
+        p->sigchld_pending = 0;
+        (*p->ops.on_sigchld) (p, FLUX_SUBPROCESS_SIGCHLD_UNKNOWN);
+    }
+
+    subprocess_decref (p);
+}
+
+static int subprocess_setup_sigchld (flux_subprocess_t *p)
+{
+    if (p->ops.on_sigchld) {
+        p->sigchld_prep_w =
+            flux_prepare_watcher_create (p->reactor,
+                                         sigchld_prep_cb,
+                                         p);
+        if (!p->sigchld_prep_w) {
+            log_err ("flux_prepare_watcher_create");
+            return -1;
+        }
+
+        p->sigchld_idle_w =
+            flux_idle_watcher_create (p->reactor,
+                                      NULL,
+                                      p);
+        if (!p->sigchld_idle_w) {
+            log_err ("flux_idle_watcher_create");
+            return -1;
+        }
+
+        p->sigchld_check_w =
+            flux_check_watcher_create (p->reactor,
+                                       sigchld_check_cb,
+                                       p);
+        if (!p->sigchld_check_w) {
+            log_err ("flux_check_watcher_create");
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static void completed_prep_cb (flux_reactor_t *r,
                                flux_watcher_t *w,
                                int revents,
@@ -539,6 +635,9 @@ flux_subprocess_t *flux_local_exec_ex (flux_reactor_t *r,
         goto error;
 
     state_change_start (p);
+
+    if (subprocess_setup_sigchld (p) < 0)
+        goto error;
 
     if (subprocess_setup_completed (p) < 0)
         goto error;
@@ -671,6 +770,9 @@ flux_subprocess_t *flux_rexec_ex (flux_t *h,
         goto error;
 
     if (subprocess_setup_state_change (p) < 0)
+        goto error;
+
+    if (subprocess_setup_sigchld (p) < 0)
         goto error;
 
     if (subprocess_setup_completed (p) < 0)
@@ -1243,6 +1345,17 @@ const char *flux_subprocess_state_string (flux_subprocess_state_t state)
         return "Failed";
     case FLUX_SUBPROCESS_STOPPED:
         return "Stopped";
+    }
+    return NULL;
+}
+
+const char *
+flux_subprocess_sigchld_string (flux_subprocess_sigchld_t sigchld)
+{
+    switch (sigchld)
+    {
+    case FLUX_SUBPROCESS_SIGCHLD_UNKNOWN:
+        return "Unknown";
     }
     return NULL;
 }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -313,9 +313,6 @@ static void state_change_prep_cb (flux_reactor_t *r,
 
 static flux_subprocess_state_t state_change_next (flux_subprocess_t *p)
 {
-    /* N.B. possible transition to FLUX_SUBPROCESS_STOPPED not handled
-     * here, see issue #5083
-     */
     assert (p->state_reported != p->state);
     assert (p->state_reported == FLUX_SUBPROCESS_INIT
             || p->state_reported == FLUX_SUBPROCESS_RUNNING);
@@ -1359,7 +1356,7 @@ const char *flux_subprocess_state_string (flux_subprocess_state_t state)
         return "Exited";
     case FLUX_SUBPROCESS_FAILED:
         return "Failed";
-    case FLUX_SUBPROCESS_STOPPED:
+    case FLUX_SUBPROCESS_STOPPED: /* deprecated */
         return "Stopped";
     }
     return NULL;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -424,6 +424,30 @@ void sigchld_notify_start (flux_subprocess_t *p)
     }
 }
 
+static void sigchld_clear_check (flux_subprocess_t *p)
+{
+    /* N.B. no more sigchld reports after EXITED or FAILED */
+    flux_subprocess_state_t state =
+        p->ops.on_state_change ? p->state_reported : p->state;
+
+    if (state == FLUX_SUBPROCESS_EXITED
+        || state == FLUX_SUBPROCESS_FAILED)
+        p->sigchld_pending = 0;
+}
+
+/* True when a queued sigchld must not yet be delivered because the
+ * caller has an on_state_change callback and the RUNNING state has not
+ * been reported to them (see issue #5083).  While deferred we leave the
+ * idle watcher stopped so the reactor is not spun; the state-change
+ * machinery keeps the reactor live until RUNNING is reported, and the
+ * prep watcher re-evaluates each iteration.
+ */
+static bool sigchld_deferred (flux_subprocess_t *p)
+{
+    return p->ops.on_state_change
+        && p->state_reported < FLUX_SUBPROCESS_RUNNING;
+}
+
 static void sigchld_prep_cb (flux_reactor_t *r,
                              flux_watcher_t *w,
                              int revents,
@@ -431,13 +455,15 @@ static void sigchld_prep_cb (flux_reactor_t *r,
 {
     flux_subprocess_t *p = arg;
 
-    if (p->sigchld_pending)
-        flux_watcher_start (p->sigchld_idle_w);
-    else {
+    sigchld_clear_check (p);
+
+    if (!p->sigchld_pending) {
         /* nothing left to report, stop watching */
         flux_watcher_stop (p->sigchld_prep_w);
         flux_watcher_stop (p->sigchld_check_w);
     }
+    else if (!sigchld_deferred (p))
+        flux_watcher_start (p->sigchld_idle_w);
 }
 
 static void sigchld_check_cb (flux_reactor_t *r,
@@ -452,14 +478,19 @@ static void sigchld_check_cb (flux_reactor_t *r,
     /* always a chance caller may destroy subprocess in callback */
     subprocess_incref (p);
 
-    /* Only one sigchld value exists for now, so clear the pending flags
-     * and report it directly.
-     */
+    sigchld_clear_check (p);
+
     if (p->sigchld_pending != 0) {
+        /* N.B. See issue #5083.  We do not want to report any signal
+         * status until after the job is reported as RUNNING.
+         */
+        if (sigchld_deferred (p))
+            goto out;
+        (*p->ops.on_sigchld) (p, p->sigchld_pending);
         p->sigchld_pending = 0;
-        (*p->ops.on_sigchld) (p, FLUX_SUBPROCESS_SIGCHLD_UNKNOWN);
     }
 
+out:
     subprocess_decref (p);
 }
 
@@ -1339,8 +1370,8 @@ flux_subprocess_sigchld_string (flux_subprocess_sigchld_t sigchld)
 {
     switch (sigchld)
     {
-    case FLUX_SUBPROCESS_SIGCHLD_UNKNOWN:
-        return "Unknown";
+    case FLUX_SUBPROCESS_SIGCHLD_STOPPED:
+        return "Stopped";
     }
     return NULL;
 }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -149,6 +149,10 @@ static void subprocess_free (flux_subprocess_t *p)
         flux_watcher_destroy (p->state_idle_w);
         flux_watcher_destroy (p->state_check_w);
 
+        flux_watcher_destroy (p->sigchld_prep_w);
+        flux_watcher_destroy (p->sigchld_idle_w);
+        flux_watcher_destroy (p->sigchld_check_w);
+
         flux_watcher_destroy (p->completed_prep_w);
         flux_watcher_destroy (p->completed_idle_w);
         flux_watcher_destroy (p->completed_check_w);
@@ -400,6 +404,98 @@ static int subprocess_setup_state_change (flux_subprocess_t *p)
     return 0;
 }
 
+/* Pending sigchld is tracked in sigchld_pending.
+ * N.B. only one sigchld is supported right now.
+ */
+void sigchld_set (flux_subprocess_t *p,
+                  flux_subprocess_sigchld_t sigchld)
+{
+    if (!p->ops.on_sigchld)
+        return;
+
+    p->sigchld_pending = sigchld;
+}
+
+void sigchld_notify_start (flux_subprocess_t *p)
+{
+    if (p->ops.on_sigchld) {
+        flux_watcher_start (p->sigchld_prep_w);
+        flux_watcher_start (p->sigchld_check_w);
+    }
+}
+
+static void sigchld_prep_cb (flux_reactor_t *r,
+                             flux_watcher_t *w,
+                             int revents,
+                             void *arg)
+{
+    flux_subprocess_t *p = arg;
+
+    if (p->sigchld_pending)
+        flux_watcher_start (p->sigchld_idle_w);
+    else {
+        /* nothing left to report, stop watching */
+        flux_watcher_stop (p->sigchld_prep_w);
+        flux_watcher_stop (p->sigchld_check_w);
+    }
+}
+
+static void sigchld_check_cb (flux_reactor_t *r,
+                              flux_watcher_t *w,
+                              int revents,
+                              void *arg)
+{
+    flux_subprocess_t *p = arg;
+
+    flux_watcher_stop (p->sigchld_idle_w);
+
+    /* always a chance caller may destroy subprocess in callback */
+    subprocess_incref (p);
+
+    /* Only one sigchld value exists for now, so clear the pending flags
+     * and report it directly.
+     */
+    if (p->sigchld_pending != 0) {
+        p->sigchld_pending = 0;
+        (*p->ops.on_sigchld) (p, FLUX_SUBPROCESS_SIGCHLD_UNKNOWN);
+    }
+
+    subprocess_decref (p);
+}
+
+static int subprocess_setup_sigchld (flux_subprocess_t *p)
+{
+    if (p->ops.on_sigchld) {
+        p->sigchld_prep_w =
+            flux_prepare_watcher_create (p->reactor,
+                                         sigchld_prep_cb,
+                                         p);
+        if (!p->sigchld_prep_w) {
+            log_err ("flux_prepare_watcher_create");
+            return -1;
+        }
+
+        p->sigchld_idle_w =
+            flux_idle_watcher_create (p->reactor,
+                                      NULL,
+                                      p);
+        if (!p->sigchld_idle_w) {
+            log_err ("flux_idle_watcher_create");
+            return -1;
+        }
+
+        p->sigchld_check_w =
+            flux_check_watcher_create (p->reactor,
+                                       sigchld_check_cb,
+                                       p);
+        if (!p->sigchld_check_w) {
+            log_err ("flux_check_watcher_create");
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static void completed_prep_cb (flux_reactor_t *r,
                                flux_watcher_t *w,
                                int revents,
@@ -526,6 +622,9 @@ flux_subprocess_t *flux_local_exec_ex (flux_reactor_t *r,
         goto error;
 
     state_change_start (p);
+
+    if (subprocess_setup_sigchld (p) < 0)
+        goto error;
 
     if (subprocess_setup_completed (p) < 0)
         goto error;
@@ -658,6 +757,9 @@ flux_subprocess_t *flux_rexec_ex (flux_t *h,
         goto error;
 
     if (subprocess_setup_state_change (p) < 0)
+        goto error;
+
+    if (subprocess_setup_sigchld (p) < 0)
         goto error;
 
     if (subprocess_setup_completed (p) < 0)
@@ -1228,6 +1330,17 @@ const char *flux_subprocess_state_string (flux_subprocess_state_t state)
         return "Failed";
     case FLUX_SUBPROCESS_STOPPED:
         return "Stopped";
+    }
+    return NULL;
+}
+
+const char *
+flux_subprocess_sigchld_string (flux_subprocess_sigchld_t sigchld)
+{
+    switch (sigchld)
+    {
+    case FLUX_SUBPROCESS_SIGCHLD_UNKNOWN:
+        return "Unknown";
     }
     return NULL;
 }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -44,7 +44,11 @@ typedef enum {
     FLUX_SUBPROCESS_RUNNING,      /* exec(2) has been called */
     FLUX_SUBPROCESS_EXITED,       /* process has exited */
     FLUX_SUBPROCESS_FAILED,       /* exec failure or other non-child error */
-    FLUX_SUBPROCESS_STOPPED,      /* process was stopped */
+    FLUX_SUBPROCESS_STOPPED,      /* DEPRECATED, no longer reported.  Use the
+                                   * on_sigchld callback and
+                                   * FLUX_SUBPROCESS_SIGCHLD_STOPPED instead.
+                                   * The enum value is retained for backwards
+                                   * compatibility. */
 } flux_subprocess_state_t;
 
 /*

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -51,9 +51,16 @@ typedef enum {
  * Subprocess sigchld, reported via the on_sigchld callback below.
  * Values are distinct bits so that pending sigchlds can be tracked in a
  * bitmask.
+ *
+ * If an on_state_change callback is also registered, a sigchld will
+ * not be reported until the subprocess has at least reached the RUNNING
+ * state (reported via on_state_change), and will not be reported once
+ * EXITED or FAILED has been reported.  Without an on_state_change
+ * callback, a sigchld is reported as soon as it is received and is
+ * suppressed once the subprocess has actually exited or failed.
  */
 typedef enum {
-    FLUX_SUBPROCESS_SIGCHLD_UNKNOWN = 1, /* placeholder, none reported */
+    FLUX_SUBPROCESS_SIGCHLD_STOPPED = 1, /* SIGSTOP received */
 } flux_subprocess_sigchld_t;
 
 /*
@@ -130,7 +137,9 @@ typedef struct {
     flux_subprocess_output_f on_stdout; /* Read of stdout is ready           */
     flux_subprocess_output_f on_stderr; /* Read of stderr is ready           */
     flux_subprocess_credit_f on_credit; /* Write buffer space available      */
-    flux_subprocess_sigchld_f on_sigchld; /* Process sigchld info      */
+    flux_subprocess_sigchld_f on_sigchld; /* Process sigchld, ordered
+                                           * after RUNNING when
+                                           * on_state_change is set     */
 } flux_subprocess_ops_t;
 
 /*

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -48,6 +48,15 @@ typedef enum {
 } flux_subprocess_state_t;
 
 /*
+ * Subprocess sigchld, reported via the on_sigchld callback below.
+ * Values are distinct bits so that pending sigchlds can be tracked in a
+ * bitmask.
+ */
+typedef enum {
+    FLUX_SUBPROCESS_SIGCHLD_UNKNOWN = 1, /* placeholder, none reported */
+} flux_subprocess_sigchld_t;
+
+/*
  * Subprocess flags
  */
 enum {
@@ -95,6 +104,9 @@ typedef void (*flux_subprocess_state_f) (flux_subprocess_t *p,
 typedef void (*flux_subprocess_credit_f) (flux_subprocess_t *p,
                                           const char *stream,
                                           int bytes);
+typedef void (*flux_subprocess_sigchld_f) (
+    flux_subprocess_t *p,
+    flux_subprocess_sigchld_t sigchld);
 typedef void (*flux_subprocess_hook_f) (flux_subprocess_t *p, void *arg);
 
 /*
@@ -118,6 +130,7 @@ typedef struct {
     flux_subprocess_output_f on_stdout; /* Read of stdout is ready           */
     flux_subprocess_output_f on_stderr; /* Read of stderr is ready           */
     flux_subprocess_credit_f on_credit; /* Write buffer space available      */
+    flux_subprocess_sigchld_f on_sigchld; /* Process sigchld info      */
 } flux_subprocess_ops_t;
 
 /*
@@ -379,6 +392,11 @@ flux_subprocess_state_t flux_subprocess_state (flux_subprocess_t *p);
 /*  Return string value of state of subprocess
  */
 const char *flux_subprocess_state_string (flux_subprocess_state_t state);
+
+/*  Return string value of sigchld of subprocess
+ */
+const char *
+flux_subprocess_sigchld_string (flux_subprocess_sigchld_t sigchld);
 
 /*  Return true if subprocess p is still active, i.e. it is waiting to
  *  start, still running, or waiting for eof on all streams.

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -49,9 +49,16 @@ typedef enum {
 
 /*
  * Subprocess sigchld, reported via the on_sigchld callback below.
+ *
+ * If an on_state_change callback is also registered, a sigchld will
+ * not be reported until the subprocess has at least reached the RUNNING
+ * state (reported via on_state_change), and will not be reported once
+ * EXITED or FAILED has been reported.  Without an on_state_change
+ * callback, a sigchld is reported as soon as it is received and is
+ * suppressed once the subprocess has actually exited or failed.
  */
 typedef enum {
-    FLUX_SUBPROCESS_SIGCHLD_UNKNOWN = 1, /* placeholder, none reported */
+    FLUX_SUBPROCESS_SIGCHLD_STOPPED = 1, /* SIGSTOP received */
 } flux_subprocess_sigchld_t;
 
 /*
@@ -128,7 +135,9 @@ typedef struct {
     flux_subprocess_output_f on_stdout; /* Read of stdout is ready           */
     flux_subprocess_output_f on_stderr; /* Read of stderr is ready           */
     flux_subprocess_credit_f on_credit; /* Write buffer space available      */
-    flux_subprocess_sigchld_f on_sigchld; /* Process sigchld info      */
+    flux_subprocess_sigchld_f on_sigchld; /* Process sigchld, ordered
+                                           * after RUNNING when
+                                           * on_state_change is set     */
 } flux_subprocess_ops_t;
 
 /*

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -48,6 +48,13 @@ typedef enum {
 } flux_subprocess_state_t;
 
 /*
+ * Subprocess sigchld, reported via the on_sigchld callback below.
+ */
+typedef enum {
+    FLUX_SUBPROCESS_SIGCHLD_UNKNOWN = 1, /* placeholder, none reported */
+} flux_subprocess_sigchld_t;
+
+/*
  * Subprocess flags
  */
 enum {
@@ -95,6 +102,9 @@ typedef void (*flux_subprocess_state_f) (flux_subprocess_t *p,
 typedef void (*flux_subprocess_credit_f) (flux_subprocess_t *p,
                                           const char *stream,
                                           int bytes);
+typedef void (*flux_subprocess_sigchld_f) (
+    flux_subprocess_t *p,
+    flux_subprocess_sigchld_t sigchld);
 typedef void (*flux_subprocess_hook_f) (flux_subprocess_t *p, void *arg);
 
 /*
@@ -118,6 +128,7 @@ typedef struct {
     flux_subprocess_output_f on_stdout; /* Read of stdout is ready           */
     flux_subprocess_output_f on_stderr; /* Read of stderr is ready           */
     flux_subprocess_credit_f on_credit; /* Write buffer space available      */
+    flux_subprocess_sigchld_f on_sigchld; /* Process sigchld info      */
 } flux_subprocess_ops_t;
 
 /*
@@ -379,6 +390,11 @@ flux_subprocess_state_t flux_subprocess_state (flux_subprocess_t *p);
 /*  Return string value of state of subprocess
  */
 const char *flux_subprocess_state_string (flux_subprocess_state_t state);
+
+/*  Return string value of sigchld of subprocess
+ */
+const char *
+flux_subprocess_sigchld_string (flux_subprocess_sigchld_t sigchld);
 
 /*  Return true if subprocess p is still active, i.e. it is waiting to
  *  start, still running, or waiting for eof on all streams.

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -95,6 +95,11 @@ struct flux_subprocess {
     flux_watcher_t *state_idle_w;
     flux_watcher_t *state_check_w;
 
+    int sigchld_pending;       /* pending sigchld for on_sigchld */
+    flux_watcher_t *sigchld_prep_w;
+    flux_watcher_t *sigchld_idle_w;
+    flux_watcher_t *sigchld_check_w;
+
     bool completed;             /* process has exited and i/o is complete */
     flux_watcher_t *completed_prep_w;
     flux_watcher_t *completed_idle_w;
@@ -130,6 +135,11 @@ struct flux_subprocess {
 void subprocess_check_completed (flux_subprocess_t *p);
 
 void state_change_start (flux_subprocess_t *p);
+
+void sigchld_set (flux_subprocess_t *p,
+                  flux_subprocess_sigchld_t sigchld);
+
+void sigchld_notify_start (flux_subprocess_t *p);
 
 void channel_destroy (void *arg);
 

--- a/src/common/libsubprocess/test/iochan.c
+++ b/src/common/libsubprocess/test/iochan.c
@@ -101,7 +101,7 @@ static void iochan_state_cb (flux_subprocess_t *p,
             ctx->pid = flux_subprocess_pid (p);
             flux_watcher_start (ctx->source); // start sourcing data
             break;
-        case FLUX_SUBPROCESS_STOPPED:
+        case FLUX_SUBPROCESS_STOPPED: /* deprecated */
             break;
         case FLUX_SUBPROCESS_EXITED: {
             int status = flux_subprocess_status (p);

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -118,7 +118,7 @@ static void iostress_state_cb (flux_subprocess_t *p,
                 || ctx->write_type == WRITE_DIRECT)
                 flux_watcher_start (ctx->source); // start sourcing data
             break;
-        case FLUX_SUBPROCESS_STOPPED:
+        case FLUX_SUBPROCESS_STOPPED: /* deprecated */
             break;
         case FLUX_SUBPROCESS_EXITED: {
             int status = flux_subprocess_status (p);

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -718,6 +718,73 @@ void sigstop_test (flux_t *h)
     flux_cmd_destroy (cmd);
 }
 
+/* Like sigstop_test, but verifies the on_sigchld callback is invoked
+ * with FLUX_SUBPROCESS_SIGCHLD_STOPPED when the subprocess is stopped.
+ */
+
+static int sigchld_stopped_count;
+
+static void sigchld_stop_cb (flux_subprocess_t *p,
+                             flux_subprocess_sigchld_t sigchld)
+{
+    diag ("sigchld callback sigchld=%s",
+          flux_subprocess_sigchld_string (sigchld));
+    ok (sigchld == FLUX_SUBPROCESS_SIGCHLD_STOPPED,
+        "sigchld callback sigchld == STOPPED");
+    ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
+        "sigchld returned when job was running");
+    sigchld_stopped_count++;
+}
+
+flux_subprocess_ops_t sigchld_stoptest_ops = {
+    .on_state_change    = stop_state_cb,
+    .on_stdout          = stop_output_cb,
+    .on_stderr          = stop_output_cb,
+    .on_sigchld         = sigchld_stop_cb,
+};
+
+void sigchld_sigstop_test (flux_t *h)
+{
+    char *av[] = { "/bin/cat", NULL };
+    flux_subprocess_t *p;
+    flux_cmd_t *cmd;
+    int rc;
+
+    cmd = flux_cmd_create (ARRAY_SIZE (av) - 1, av, environ);
+    if (!cmd)
+        BAIL_OUT ("flux_cmd_create failed");
+
+    sigchld_stopped_count = 0;
+
+    p = flux_rexec_ex (h,
+                       SERVER_NAME,
+                       FLUX_NODEID_ANY,
+                       0,
+                       cmd,
+                       &sigchld_stoptest_ops,
+                       tap_logger,
+                       NULL);
+    ok (p != NULL,
+        "sigchld stoptest: created subprocess");
+    if (flux_subprocess_aux_set (p, "reactor", flux_get_reactor (h), NULL) < 0)
+        BAIL_OUT ("could not stash reactor in subprocess aux container");
+
+    rc = flux_reactor_run (flux_get_reactor (h), 0);
+    ok (rc >= 0,
+        "sigchld stoptest: reactor ran successfully");
+    /* N.B. The subprocess is reported as stopped via both the legacy
+     * FLUX_SUBPROCESS_STOPPED state and the new sigchld path (until a
+     * later commit removes the former).  Both append the same
+     * FLUX_SUBPROCESS_SIGCHLD_STOPPED flag, which coalesces into a
+     * single pending sigchld, so on_sigchld is called exactly once.
+     */
+    ok (sigchld_stopped_count == 1,
+        "sigchld stoptest: on_sigchld called once with STOPPED");
+
+    flux_subprocess_destroy (p);
+    flux_cmd_destroy (cmd);
+}
+
 void bg_kill (flux_t *h, const char *label)
 {
     flux_future_t *f;
@@ -1223,6 +1290,8 @@ int main (int argc, char *argv[])
     local_unbuf_multiline_test (h);
     diag ("sigstop_test");
     sigstop_test (h);
+    diag ("sigchld_sigstop_test");
+    sigchld_sigstop_test (h);
     diag ("background_test");
     background_waitable_test (h);
     diag ("background_output_test");

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -40,7 +40,6 @@ struct simple_scorecard {
     unsigned int running:1;
     unsigned int failed:1;
     unsigned int exited:1;
-    unsigned int stopped:1;
 
     // output
     unsigned int stdout_eof:1;
@@ -112,7 +111,7 @@ static void simple_state_cb (flux_subprocess_t *p,
             flux_reactor_stop (flux_get_reactor (ctx->h));
             break;
         case FLUX_SUBPROCESS_STOPPED:
-            ctx->scorecard.stopped = 1;
+            /* deprecated, do not track */
             break;
     }
 }
@@ -187,9 +186,6 @@ void simple_run_check (flux_t *h,
     ok (ctx.scorecard.failed == exp->failed,
         "%s: subprocess state=FAILED was %sreported",
         prefix, exp->failed ? "" : "not ");
-    ok (ctx.scorecard.stopped == exp->stopped,
-        "%s: subprocess state=STOPPED was %sreported",
-        prefix, exp->stopped ? "" : "not ");
     ok (ctx.scorecard.completion == exp->completion,
         "%s: subprocess completion callback was %sinvoked",
         prefix, exp->completion ? "" : "not ");
@@ -636,8 +632,8 @@ void local_unbuf_multiline_test (flux_t *h)
 }
 
 /* In SIGSTOP test, a 'cat' subprocess is sent SIGSTOP upon starting.
- * If remote SIGSTOP handling works, the state callback is called again
- * with state == STOPPED, which triggers closure of stdin and natural
+ * If remote SIGSTOP handling works, the sigchld callback is called again
+ * with sigchld == STOPPED, which triggers closure of stdin and natural
  * termination of the process, which causes the reactor to exit.
  */
 
@@ -651,17 +647,6 @@ static void stop_state_cb (flux_subprocess_t *p,
         pid_t pid = flux_subprocess_pid (p);
         if (pid < 0 || kill (pid, SIGSTOP) < 0) {
             diag ("could not stop test proc: %s", strerror (errno));
-            flux_reactor_stop_error (r);
-        }
-    }
-    else if (state == FLUX_SUBPROCESS_STOPPED) {
-        pid_t pid = flux_subprocess_pid (p);
-        if (pid < 0 || kill (pid, SIGCONT) < 0) {
-            diag ("could not continue test proc: %s", strerror (errno));
-            flux_reactor_stop_error (r);
-        }
-        if (flux_subprocess_close (p, "stdin") < 0) {
-            diag ("could not close remote stdin");
             flux_reactor_stop_error (r);
         }
     }
@@ -680,59 +665,27 @@ static void stop_output_cb (flux_subprocess_t *p, const char *stream)
         diag ("%s: %d bytes", stream, len);
 }
 
-flux_subprocess_ops_t stoptest_ops = {
-    .on_state_change    = stop_state_cb,
-    .on_stdout          = stop_output_cb,
-    .on_stderr          = stop_output_cb,
-};
-
-void sigstop_test (flux_t *h)
-{
-    char *av[] = { "/bin/cat", NULL };
-    flux_subprocess_t *p;
-    flux_cmd_t *cmd;
-    int rc;
-
-    cmd = flux_cmd_create (ARRAY_SIZE (av) - 1, av, environ);
-    if (!cmd)
-        BAIL_OUT ("flux_cmd_create failed");
-
-    p = flux_rexec_ex (h,
-                       SERVER_NAME,
-                       FLUX_NODEID_ANY,
-                       0,
-                       cmd,
-                       &stoptest_ops,
-                       tap_logger,
-                       NULL);
-    ok (p != NULL,
-        "stoptest: created subprocess");
-    if (flux_subprocess_aux_set (p, "reactor", flux_get_reactor (h), NULL) < 0)
-        BAIL_OUT ("could not stash reactor in subprocess aux container");
-
-    rc = flux_reactor_run (flux_get_reactor (h), 0);
-    ok (rc >= 0,
-        "stoptest: reactor ran successfully");
-
-    flux_subprocess_destroy (p);
-    flux_cmd_destroy (cmd);
-}
-
-/* Like sigstop_test, but verifies the on_sigchld callback is invoked
- * with FLUX_SUBPROCESS_SIGCHLD_STOPPED when the subprocess is stopped.
- */
-
 static int sigchld_stopped_count;
 
 static void sigchld_stop_cb (flux_subprocess_t *p,
                              flux_subprocess_sigchld_t sigchld)
 {
+    flux_reactor_t *r = flux_subprocess_aux_get (p, "reactor");
+    pid_t pid = flux_subprocess_pid (p);
     diag ("sigchld callback sigchld=%s",
           flux_subprocess_sigchld_string (sigchld));
     ok (sigchld == FLUX_SUBPROCESS_SIGCHLD_STOPPED,
         "sigchld callback sigchld == STOPPED");
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "sigchld returned when job was running");
+    if (pid < 0 || kill (pid, SIGCONT) < 0) {
+        diag ("could not continue test proc: %s", strerror (errno));
+        flux_reactor_stop_error (r);
+    }
+    if (flux_subprocess_close (p, "stdin") < 0) {
+        diag ("could not close remote stdin");
+        flux_reactor_stop_error (r);
+    }
     sigchld_stopped_count++;
 }
 
@@ -772,12 +725,6 @@ void sigchld_sigstop_test (flux_t *h)
     rc = flux_reactor_run (flux_get_reactor (h), 0);
     ok (rc >= 0,
         "sigchld stoptest: reactor ran successfully");
-    /* N.B. The subprocess is reported as stopped via both the legacy
-     * FLUX_SUBPROCESS_STOPPED state and the new sigchld path (until a
-     * later commit removes the former).  Both append the same
-     * FLUX_SUBPROCESS_SIGCHLD_STOPPED flag, which coalesces into a
-     * single pending sigchld, so on_sigchld is called exactly once.
-     */
     ok (sigchld_stopped_count == 1,
         "sigchld stoptest: on_sigchld called once with STOPPED");
 
@@ -1288,8 +1235,6 @@ int main (int argc, char *argv[])
     local_unbuf_test (h);
     diag ("local_unbuf_multiline_test");
     local_unbuf_multiline_test (h);
-    diag ("sigstop_test");
-    sigstop_test (h);
     diag ("sigchld_sigstop_test");
     sigchld_sigstop_test (h);
     diag ("background_test");

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -857,6 +857,14 @@ void test_state_strings (void)
         "Stopped");
 }
 
+void test_sigchld_strings (void)
+{
+    is (flux_subprocess_sigchld_string (FLUX_SUBPROCESS_SIGCHLD_UNKNOWN),
+        "Unknown");
+    ok (!flux_subprocess_sigchld_string (100),
+        "flux_subprocess_sigchld_string returns NULL on bad sigchld");
+}
+
 void test_exec_fail (flux_reactor_t *r)
 {
     char path [4096];
@@ -1308,6 +1316,8 @@ int main (int argc, char *argv[])
     test_state_change_stopped (r);
     diag ("state_strings");
     test_state_strings ();
+    diag ("sigchld_strings");
+    test_sigchld_strings ();
     diag ("exec_fail");
     test_exec_fail (r);
     diag ("context");

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -806,9 +806,32 @@ void state_change_stopped_cb (flux_subprocess_t *p,
     diag ("state_change_stopped: state = %s",
           flux_subprocess_state_string (state));
     if (state == FLUX_SUBPROCESS_STOPPED) {
-        flux_future_t *f = flux_subprocess_kill (p, SIGKILL);
-        ok (true, "subprocess state == STOPPED in state change handler");
-        flux_future_destroy (f);
+        /* N.B. SIGSTOP reported in two callbacks for now, will be
+         * rectified in later commit */
+        if (stopped_cb_count == 1) {
+            flux_future_t *f = flux_subprocess_kill (p, SIGKILL);
+            ok (true, "subprocess state == STOPPED in state change handler");
+            flux_future_destroy (f);
+        }
+        stopped_cb_count++;
+    }
+}
+
+void sigchld_stopped_cb (flux_subprocess_t *p,
+                         flux_subprocess_sigchld_t sigchld)
+{
+    diag ("sigchld = %s",
+          flux_subprocess_sigchld_string (sigchld));
+    if (sigchld == FLUX_SUBPROCESS_SIGCHLD_STOPPED) {
+        ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
+            "sigchld returned when job was running");
+        /* N.B. SIGSTOP reported in two callbacks for now, will be
+         * rectified in later commit */
+        if (stopped_cb_count == 1) {
+            flux_future_t *f = flux_subprocess_kill (p, SIGKILL);
+            ok (true, "sigchld == STOPPED in sigchld handler");
+            flux_future_destroy (f);
+        }
         stopped_cb_count++;
     }
 }
@@ -822,7 +845,8 @@ void test_state_change_stopped (flux_reactor_t *r)
     ok ((cmd = flux_cmd_create (2, av, NULL)) != NULL, "flux_cmd_create");
 
     flux_subprocess_ops_t ops = {
-        .on_state_change = state_change_stopped_cb
+        .on_state_change = state_change_stopped_cb,
+        .on_sigchld = sigchld_stopped_cb
     };
     stopped_cb_count = 0;
     p = flux_local_exec (r, 0, cmd, &ops);
@@ -838,7 +862,10 @@ void test_state_change_stopped (flux_reactor_t *r)
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");
-    ok (stopped_cb_count == 1, "subprocess was stopped");
+    /* N.B. count is 2 due to legacy FLUX_SUBPROCESS_STOPPED state
+     * still being handled.  This will be rectified in a later commit.
+     */
+    ok (stopped_cb_count == 2, "subprocess was stopped");
     flux_subprocess_destroy (p);
     flux_cmd_destroy (cmd);
 }
@@ -859,8 +886,8 @@ void test_state_strings (void)
 
 void test_sigchld_strings (void)
 {
-    is (flux_subprocess_sigchld_string (FLUX_SUBPROCESS_SIGCHLD_UNKNOWN),
-        "Unknown");
+    is (flux_subprocess_sigchld_string (FLUX_SUBPROCESS_SIGCHLD_STOPPED),
+        "Stopped");
     ok (!flux_subprocess_sigchld_string (100),
         "flux_subprocess_sigchld_string returns NULL on bad sigchld");
 }

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -800,43 +800,22 @@ void test_state_change (flux_reactor_t *r)
     flux_cmd_destroy (cmd);
 }
 
-void state_change_stopped_cb (flux_subprocess_t *p,
-                              flux_subprocess_state_t state)
-{
-    diag ("state_change_stopped: state = %s",
-          flux_subprocess_state_string (state));
-    if (state == FLUX_SUBPROCESS_STOPPED) {
-        /* N.B. SIGSTOP reported in two callbacks for now, will be
-         * rectified in later commit */
-        if (stopped_cb_count == 1) {
-            flux_future_t *f = flux_subprocess_kill (p, SIGKILL);
-            ok (true, "subprocess state == STOPPED in state change handler");
-            flux_future_destroy (f);
-        }
-        stopped_cb_count++;
-    }
-}
-
 void sigchld_stopped_cb (flux_subprocess_t *p,
                          flux_subprocess_sigchld_t sigchld)
 {
     diag ("sigchld = %s",
           flux_subprocess_sigchld_string (sigchld));
     if (sigchld == FLUX_SUBPROCESS_SIGCHLD_STOPPED) {
+        flux_future_t *f = flux_subprocess_kill (p, SIGKILL);
         ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
             "sigchld returned when job was running");
-        /* N.B. SIGSTOP reported in two callbacks for now, will be
-         * rectified in later commit */
-        if (stopped_cb_count == 1) {
-            flux_future_t *f = flux_subprocess_kill (p, SIGKILL);
-            ok (true, "sigchld == STOPPED in sigchld handler");
-            flux_future_destroy (f);
-        }
+        ok (true, "sigchld == STOPPED in sigchld handler");
+        flux_future_destroy (f);
         stopped_cb_count++;
     }
 }
 
-void test_state_change_stopped (flux_reactor_t *r)
+void test_sigchld_stopped (flux_reactor_t *r)
 {
     char *av[] = { "/bin/sleep", "30", NULL };
     flux_cmd_t *cmd;
@@ -845,7 +824,6 @@ void test_state_change_stopped (flux_reactor_t *r)
     ok ((cmd = flux_cmd_create (2, av, NULL)) != NULL, "flux_cmd_create");
 
     flux_subprocess_ops_t ops = {
-        .on_state_change = state_change_stopped_cb,
         .on_sigchld = sigchld_stopped_cb
     };
     stopped_cb_count = 0;
@@ -862,10 +840,7 @@ void test_state_change_stopped (flux_reactor_t *r)
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");
-    /* N.B. count is 2 due to legacy FLUX_SUBPROCESS_STOPPED state
-     * still being handled.  This will be rectified in a later commit.
-     */
-    ok (stopped_cb_count == 2, "subprocess was stopped");
+    ok (stopped_cb_count == 1, "subprocess was stopped");
     flux_subprocess_destroy (p);
     flux_cmd_destroy (cmd);
 }
@@ -1339,8 +1314,8 @@ int main (int argc, char *argv[])
     test_kill_eofs (r);
     diag ("state_change");
     test_state_change (r);
-    diag ("state_change_stopped");
-    test_state_change_stopped (r);
+    diag ("sigchld_stopped");
+    test_sigchld_stopped (r);
     diag ("state_strings");
     test_state_strings ();
     diag ("sigchld_strings");

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -133,7 +133,7 @@ static void worker_state_cb (flux_subprocess_t *p,
             break;
         case FLUX_SUBPROCESS_EXITED:
         case FLUX_SUBPROCESS_INIT:
-        case FLUX_SUBPROCESS_STOPPED:
+        case FLUX_SUBPROCESS_STOPPED: /* deprecated */
             break; // ignore
     }
 }


### PR DESCRIPTION
per discussion in #5083 support a new callback to report SIGSTOP has been signaled to the subprocess.

two notes:

1) I originally called this callback "status", but that naming conflicts with the `subprocess_status()` function.   So I named it "sigstatus".   I didn't want to name it "signal", as we're not supporting all signals.  It's not the greatest name ... welcome to better suggestions :-)

2) the choice of storing "sigstatuses" in a zlist might look strange.  it is intentional for future potential support of other signals (notably SIGCONT).