### PR TITLE
libsubprocess: add attach for background processes

### DIFF
--- a/doc/man1/flux-exec.rst
+++ b/doc/man1/flux-exec.rst
@@ -5,7 +5,7 @@ flux-exec(1)
 SYNOPSIS
 ========
 
-**flux** **exec** [*--noinput*] [*--label-io*] [*—dir=DIR*] [*--rank=IDSET*] [*--verbose*] *COMMAND...*
+**flux** **exec** [*OPTIONS*] [*--rank=IDSET*] [*--bg*] *COMMAND...*
 
 DESCRIPTION
 ===========

--- a/doc/man1/flux-exec.rst
+++ b/doc/man1/flux-exec.rst
@@ -5,7 +5,8 @@ flux-exec(1)
 SYNOPSIS
 ========
 
-**flux** **exec** [*OPTIONS*] [*--rank=IDSET*] [*--bg*] *COMMAND...*
+| **flux** **exec** [*OPTIONS*] [*--rank=IDSET*] [*--bg*] *COMMAND...*
+| **flux** **exec** [*OPTIONS*] [*--rank=IDSET*] *--attach* *PID|LABEL*
 
 DESCRIPTION
 ===========
@@ -126,6 +127,23 @@ OPTIONS
    in subsequent operations. The label appears in process list responses
    and must be unique across all processes managed by the subprocess server.
 
+.. option:: --attach
+
+   Attach to a running background process identified by the free argument
+   (PID or label).  While attached, program output is copied to
+   :program:`flux exec` without interrupting background logging.
+
+   If the remote process terminates while attached, :program:`flux exec`
+   terminates and reports its exit status the same way it would for a
+   foreground process.
+
+   In attach mode :kbd:`Control-C` (SIGINT) detaches from the process
+   without forwarding the signal.  SIGTERM, on the other hand, is forwarded.
+
+   Attaching to a waitable background process that has already exited
+   reports its exit status and reaps it, after which it can no longer be
+   waited on or attached to.
+
 CAVEATS
 =======
 
@@ -157,3 +175,8 @@ FLUX RFC
 :doc:`rfc:spec_22`
 
 :doc:`rfc:spec_42`
+
+SEE ALSO
+========
+
+:man1:`flux-sproc`

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <flux/core.h>
 #include <flux/optparse.h>
 #include <signal.h>
@@ -59,6 +60,10 @@ static struct optparse_option cmdopts[] = {
     { .name = "waitable",
       .has_arg = 0,
       .usage = "Process remains a zombie until exit status is collected",
+    },
+    { .name = "attach",
+      .has_arg = 0,
+      .usage = "Attach to a running background process (arg is pid or label)",
     },
     { .name = "label",
       .has_arg = 1,
@@ -164,6 +169,33 @@ int sigint_count = 0;
 
 bool use_imp = false;
 const char *imp_path = NULL;
+
+/* attach mode: SIGINT detaches (leaves the background process running) rather
+ * than forwarding the signal.  These describe the attach target for the
+ * detach hint.
+ */
+bool attach = false;
+const char *attach_label = NULL;
+pid_t attach_pid = -1;
+
+/* Return a human-readable name for the target of this invocation, used in
+ * diagnostics.  For a normal exec this is the command name (argv[0]); in
+ * attach mode there is no command, so describe the attach target by pid or
+ * label instead.  Uses a static buffer; the result is only valid until the
+ * next call.
+ */
+static const char *target_name (flux_cmd_t *cmd)
+{
+    static char buf[128];
+    if (attach) {
+        if (attach_label)
+            snprintf (buf, sizeof (buf), "label %s", attach_label);
+        else
+            snprintf (buf, sizeof (buf), "pid %ld", (long)attach_pid);
+        return buf;
+    }
+    return flux_cmd_arg (cmd, 0);
+}
 
 void output_exitsets (const char *key, void *item)
 {
@@ -305,7 +337,7 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
          */
         log_msg ("Error: rank %d: %s: %s",
                  flux_subprocess_rank (p),
-                 flux_cmd_arg (cmd, 0),
+                 target_name (cmd),
                  errmsg);
 
         /* bash standard, 126 for permission/access denied, 127 for
@@ -451,6 +483,23 @@ static void killall (zlistx_t *l, int signum)
 
 static void signal_cb (int signum)
 {
+    /* In attach mode, Ctrl-C detaches from the background process rather than
+     * signaling it: exiting the client drops the connection, and the server
+     * reverts the process to background (it keeps running).  To signal the
+     * process instead, the user runs 'flux sproc kill'.  SIGTERM still passes
+     * through (forwarded below).
+     */
+    if (signum == SIGINT && attach) {
+        if (attach_label)
+            fprintf (stderr,
+                     "detached; use 'flux sproc kill %s' to signal it\n",
+                     attach_label);
+        else
+            fprintf (stderr,
+                     "detached; use 'flux sproc kill %ld' to signal it\n",
+                     (long)attach_pid);
+        exit (0);
+    }
     if (signum == SIGINT) {
         if (sigint_count >= 2) {
             double since_last = monotime_since (last);
@@ -783,15 +832,45 @@ int main (int argc, char *argv[])
     if ((optindex = optparse_parse_args (opts, argc, argv)) < 0)
         exit (1);
 
-    if (optindex == argc) {
+    attach = optparse_hasopt (opts, "attach");
+
+    if (attach) {
+        /* --attach takes a single argument identifying an already-running
+         * background process, and no command-oriented options.  The target
+         * is a pid if it parses as a positive integer, otherwise a label
+         * (mirroring flux-sproc(1)).
+         */
+        if (optindex == argc)
+            log_msg_exit ("--attach requires a pid or label argument");
+        if (optindex + 1 != argc)
+            log_msg_exit ("--attach takes a single pid or label argument");
+        if (optparse_hasopt (opts, "bg")
+            || optparse_hasopt (opts, "waitable"))
+            log_msg_exit ("--attach cannot be used with --bg or --waitable");
+        const char *target = argv[optindex];
+        char *endptr;
+        long val;
+        errno = 0;
+        val = strtol (target, &endptr, 10);
+        if (errno != 0 || *endptr != '\0' || val <= 0 || val > INT_MAX) {
+            attach_pid = -1;
+            attach_label = target;
+        }
+        else
+            attach_pid = val;
+    }
+    else if (optindex == argc) {
         optparse_print_usage (opts);
         exit (1);
     }
 
-    if (!(cmd = flux_cmd_create (argc - optindex, &argv[optindex], environ)))
+    if (!(cmd = flux_cmd_create (attach ? 0 : argc - optindex,
+                                 attach ? NULL : &argv[optindex],
+                                 environ)))
         log_err_exit ("flux_cmd_create");
 
-    if (optparse_getopt (opts, "label", &optargp) > 0
+    if (!attach
+        && optparse_getopt (opts, "label", &optargp) > 0
         && flux_cmd_set_label (cmd, optargp) < 0)
         log_err_exit ("failed to set label");
 
@@ -803,28 +882,30 @@ int main (int argc, char *argv[])
 
     flux_cmd_unsetenv (cmd, "FLUX_PROXY_REMOTE");
 
-    if (optparse_getopt (opts, "dir", &optargp) > 0) {
-        if (!(cwd = strdup (optargp)))
-            log_err_exit ("strdup");
-    }
-    else {
-        if (!(cwd = get_current_dir_name ()))
-            log_err_exit ("get_current_dir_name");
-    }
+    if (!attach) {
+        if (optparse_getopt (opts, "dir", &optargp) > 0) {
+            if (!(cwd = strdup (optargp)))
+                log_err_exit ("strdup");
+        }
+        else {
+            if (!(cwd = get_current_dir_name ()))
+                log_err_exit ("get_current_dir_name");
+        }
 
-    if (!streq (cwd, "none")) {
-        if (flux_cmd_setcwd (cmd, cwd) < 0)
-            log_err_exit ("flux_cmd_setcwd");
-    }
-    if (optparse_hasopt (opts, "setopt")) {
-        const char *arg;
-        optparse_getopt_iterator_reset (opts, "setopt");
-        while ((arg = optparse_getopt_next (opts, "setopt"))) {
-            const char *value;
-            char *name = split_opt (arg, '=', &value);
-            if (!name || flux_cmd_setopt (cmd, name, value) < 0)
-                log_err_exit ("error handling '%s' option", arg);
-            free (name);
+        if (!streq (cwd, "none")) {
+            if (flux_cmd_setcwd (cmd, cwd) < 0)
+                log_err_exit ("flux_cmd_setcwd");
+        }
+        if (optparse_hasopt (opts, "setopt")) {
+            const char *arg;
+            optparse_getopt_iterator_reset (opts, "setopt");
+            while ((arg = optparse_getopt_next (opts, "setopt"))) {
+                const char *value;
+                char *name = split_opt (arg, '=', &value);
+                if (!name || flux_cmd_setopt (cmd, name, value) < 0)
+                    log_err_exit ("error handling '%s' option", arg);
+                free (name);
+            }
         }
     }
 
@@ -846,18 +927,20 @@ int main (int argc, char *argv[])
     if (flux_get_size (h, &rank_range) < 0)
         log_err_exit ("flux_get_size");
 
-    if (optparse_hasopt (opts, "with-imp")) {
-        if (!(imp_path = get_flux_imp_path (h)))
-            log_err_exit ("--with-imp: exec.imp path not found in config");
-        use_imp = true;
-        if (flux_cmd_argv_insert (cmd, 0, "run") < 0
-            || flux_cmd_argv_insert (cmd, 0, imp_path) < 0)
-            log_err_exit ("failed to prepend 'flux-imp run' to command");
-    }
-    else {
-        use_imp = check_for_imp_run (argc - optindex,
-                                     &argv[optindex],
-                                     &imp_path);
+    if (!attach) {
+        if (optparse_hasopt (opts, "with-imp")) {
+            if (!(imp_path = get_flux_imp_path (h)))
+                log_err_exit ("--with-imp: exec.imp path not found in config");
+            use_imp = true;
+            if (flux_cmd_argv_insert (cmd, 0, "run") < 0
+                || flux_cmd_argv_insert (cmd, 0, imp_path) < 0)
+                log_err_exit ("failed to prepend 'flux-imp run' to command");
+        }
+        else {
+            use_imp = check_for_imp_run (argc - optindex,
+                                         &argv[optindex],
+                                         &imp_path);
+        }
     }
 
     /* Allow systemd commands to work on flux systemd instance by
@@ -909,6 +992,14 @@ int main (int argc, char *argv[])
     rank_count = idset_count (targets);
     if (rank_count == 0)
         log_msg_exit ("No targets specified");
+    /* A process ID is only meaningful on a single rank, so attaching by pid
+     * to more than one rank cannot work.  (A label may legitimately match a
+     * background process on every rank, so label attach is not restricted.)
+     * The default target set is all ranks, so require --rank to narrow it.
+     */
+    if (attach && attach_pid > 0 && rank_count > 1)
+        log_msg_exit ("--attach by pid requires a single target rank "
+                      "(use --rank)");
     if (!(hanging = idset_copy (targets)))
         log_err_exit ("idset_copy");
 
@@ -924,7 +1015,7 @@ int main (int argc, char *argv[])
 
     monotime (&t0);
     if (optparse_getopt (opts, "verbose", NULL) > 0) {
-        const char *argv0 = flux_cmd_arg (cmd, 0);
+        const char *argv0 = target_name (cmd);
         char *nodeset = idset_encode (targets,
                                       IDSET_FLAG_RANGE | IDSET_FLAG_BRACKETS);
         if (!nodeset)
@@ -970,15 +1061,27 @@ int main (int argc, char *argv[])
     while (rank != IDSET_INVALID_ID) {
         flux_subprocess_t *p;
         struct subproc_credit *spcred;
-        if (!(p = flux_rexec_ex (h,
-                                 service_name,
-                                 rank,
-                                 flags,
-                                 cmd,
-                                 &ops,
-                                 NULL,
-                                 NULL)))
-            log_err_exit ("flux_rexec");
+        if (attach) {
+            if (!(p = flux_rexec_attach (h,
+                                         service_name,
+                                         rank,
+                                         flags,
+                                         attach_pid,
+                                         attach_label,
+                                         &ops)))
+                log_err_exit ("flux_rexec_attach");
+        }
+        else {
+            if (!(p = flux_rexec_ex (h,
+                                     service_name,
+                                     rank,
+                                     flags,
+                                     cmd,
+                                     &ops,
+                                     NULL,
+                                     NULL)))
+                log_err_exit ("flux_rexec");
+        }
         if (!(spcred = calloc (1, sizeof (*spcred))))
             log_err_exit ("calloc");
         if (!zlistx_add_end (subprocesses, p))

--- a/src/common/libsubprocess/client.c
+++ b/src/common/libsubprocess/client.c
@@ -40,6 +40,7 @@ struct rexec_response {
     const char *type;
     pid_t pid;
     int status;
+    json_t *cmd;            /* command object, "attached" response only */
     struct rexec_io io;
     json_t *channels;
 };
@@ -60,6 +61,8 @@ static void rexec_response_clear (struct rexec_response *resp)
     free (resp->io.data);
     json_decref (resp->channels);
     resp->channels = NULL;
+    json_decref (resp->cmd);
+    resp->cmd = NULL;
 
     memset (resp, 0, sizeof (*resp));
 
@@ -95,7 +98,10 @@ static struct rexec_ctx *rexec_ctx_create (flux_cmd_t *cmd,
     }
     if (!(ctx = calloc (1, sizeof (*ctx))))
         return NULL;
-    if (!(ctx->cmd = cmd_tojson (cmd))
+    /* cmd is NULL for attach requests, which identify the target by
+     * pid/label rather than carrying a command object.
+     */
+    if ((cmd && !(ctx->cmd = cmd_tojson (cmd)))
         || !(ctx->service_name = strdup (service_name)))
         goto error;
     ctx->flags = flags;
@@ -287,6 +293,76 @@ error:
     return NULL;
 }
 
+flux_future_t *subprocess_rexec_attach (flux_t *h,
+                                        const char *service_name,
+                                        uint32_t rank,
+                                        pid_t pid,
+                                        const char *label,
+                                        int flags,
+                                        int local_flags)
+{
+    flux_future_t *f = NULL;
+    struct rexec_ctx *ctx;
+    char *topic;
+    bool sign = false;
+
+    if (!h || !service_name || (pid <= 0 && !label)) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (asprintf (&topic, "%s.attach", service_name) < 0)
+        return NULL;
+    /* No command object for attach; the target is identified by pid/label.
+     */
+    if (!(ctx = rexec_ctx_create (NULL, service_name, rank, 0)))
+        goto error;
+#if HAVE_FLUX_SECURITY
+    if (local_flags & FLUX_SUBPROCESS_FLAGS_SIGN) {
+        local_flags &= ~FLUX_SUBPROCESS_FLAGS_SIGN;
+        ctx->sign = sign = true;
+    }
+#endif
+    /* The attach flags select which output streams the server forwards
+     * (stdout, stderr, and/or auxiliary channels).
+     */
+    if (label)
+        f = rpc_pack_signed (h,
+                             sign,
+                             topic,
+                             rank,
+                             FLUX_RPC_STREAMING,
+                             false,
+                             "{s:i s:s s:i}",
+                             "pid", (int)pid,
+                             "label", label,
+                             "flags", flags);
+    else
+        f = rpc_pack_signed (h,
+                             sign,
+                             topic,
+                             rank,
+                             FLUX_RPC_STREAMING,
+                             false,
+                             "{s:i s:i}",
+                             "pid", (int)pid,
+                             "flags", flags);
+    if (!f
+        || flux_future_aux_set (f,
+                                "flux::rexec",
+                                ctx,
+                                (flux_free_f)rexec_ctx_destroy) < 0) {
+        rexec_ctx_destroy (ctx);
+        goto error;
+    }
+    ctx->matchtag = flux_rpc_get_matchtag (f);
+    free (topic);
+    return f;
+error:
+    ERRNO_SAFE_WRAP (free, topic);
+    flux_future_destroy (f);
+    return NULL;
+}
+
 flux_future_t *subprocess_rexec_bg (flux_t *h,
                                     const char *service_name,
                                     uint32_t rank,
@@ -353,12 +429,13 @@ int subprocess_rexec_get (flux_future_t *f)
     }
     rexec_response_clear (&ctx->response);
     if (flux_rpc_get_unpack (f,
-                             "{s:s s?i s?i s?O s?O}",
+                             "{s:s s?i s?i s?O s?O s?O}",
                              "type", &ctx->response.type,
                              "pid", &ctx->response.pid,
                              "status", &ctx->response.status,
                              "io", &ctx->response.io.obj,
-                             "channels", &ctx->response.channels) < 0)
+                             "channels", &ctx->response.channels,
+                             "cmd", &ctx->response.cmd) < 0)
         return -1;
     if (streq (ctx->response.type, "output")) {
         if (iodecode (ctx->response.io.obj,
@@ -387,11 +464,29 @@ int subprocess_rexec_get (flux_future_t *f)
     }
     else if (!streq (ctx->response.type, "started")
         && !streq (ctx->response.type, "stopped")
-        && !streq (ctx->response.type, "finished")) {
+        && !streq (ctx->response.type, "finished")
+        && !streq (ctx->response.type, "attached")) {
         errno = EPROTO;
         return -1;
     }
     return 0;
+}
+
+bool subprocess_rexec_is_attached (flux_future_t *f,
+                                   pid_t *pid,
+                                   json_t **cmd)
+{
+    struct rexec_ctx *ctx;
+    if ((ctx = flux_future_aux_get (f, "flux::rexec"))
+        && ctx->response.type != NULL
+        && streq (ctx->response.type, "attached")) {
+        if (pid)
+            *pid = ctx->response.pid;
+        if (cmd)
+            *cmd = ctx->response.cmd;
+        return true;
+    }
+    return false;
 }
 
 bool subprocess_rexec_is_started (flux_future_t *f, pid_t *pid)

--- a/src/common/libsubprocess/client.h
+++ b/src/common/libsubprocess/client.h
@@ -55,7 +55,22 @@ flux_future_t *subprocess_rexec_bg (flux_t *h,
                                     const flux_cmd_t *cmd,
                                     int local_flags);
 
+/* Attach to an existing background subprocess identified by pid or label
+ * (label takes precedence if non-NULL).  Returns a streaming future whose
+ * first response is "attached".
+ */
+flux_future_t *subprocess_rexec_attach (flux_t *h,
+                                        const char *service_name,
+                                        uint32_t rank,
+                                        pid_t pid,
+                                        const char *label,
+                                        int flags,
+                                        int local_flags);
+
 int subprocess_rexec_get (flux_future_t *f);
+bool subprocess_rexec_is_attached (flux_future_t *f,
+                                   pid_t *pid,
+                                   json_t **cmd);
 bool subprocess_rexec_is_started (flux_future_t *f, pid_t *pid);
 bool subprocess_rexec_is_stopped (flux_future_t *f);
 bool subprocess_rexec_is_finished (flux_future_t *f, int *status);

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -397,13 +397,33 @@ static int remote_setup_channels (flux_subprocess_t *p)
     return 0;
 }
 
-int subprocess_remote_setup (flux_subprocess_t *p, const char *service_name)
+/* Set up the client-side I/O channels (stdio + auxiliary channels) from
+ * p->cmd.  Channel buffering options are read from the command, so p->cmd
+ * must be the actual command before this is called.  For attach this is
+ * deferred until the command is received in the attach response.
+ */
+int remote_setup_io (flux_subprocess_t *p)
 {
     if (remote_setup_stdio (p) < 0)
         return -1;
     if (remote_setup_channels (p) < 0)
         return -1;
+    return 0;
+}
+
+int subprocess_setup_service_name (flux_subprocess_t *p,
+                                   const char *service_name)
+{
     if (!(p->service_name = strdup (service_name)))
+        return -1;
+    return 0;
+}
+
+int subprocess_remote_setup (flux_subprocess_t *p, const char *service_name)
+{
+    if (remote_setup_io (p) < 0)
+        return -1;
+    if (subprocess_setup_service_name (p, service_name) < 0)
         return -1;
     return 0;
 }
@@ -519,6 +539,7 @@ static void rexec_continuation (flux_future_t *f, void *arg)
     json_t *channels = NULL;
     int len;
     bool eof;
+    json_t *attach_cmd = NULL;
 
     if (subprocess_rexec_get (f) < 0) {
         if (errno == ENODATA) {
@@ -542,7 +563,36 @@ static void rexec_continuation (flux_future_t *f, void *arg)
         set_failed (p, "%s", future_strerror (f, errno));
         goto error;
     }
-    if (subprocess_rexec_is_started (f, &p->pid)) {
+    if (subprocess_rexec_is_attached (f, &p->pid, &attach_cmd)) {
+        /* Successful attach to an already-running background subprocess.
+         * The attach request carried no command, so the I/O channels are set
+         * up now from the command object returned in the attach response.
+         * This reconstructs the original channel names and buffering options,
+         * so the reattached subprocess behaves like the original.  Output
+         * only begins after this response, so deferring channel setup to here
+         * is safe.
+         *
+         * The client requested forwarding for exactly the streams it has
+         * output callbacks for (see remote_attach()), and the server honors
+         * that, so the read channels set up here match the forwarded streams
+         * and their EOFs; no reconciliation is needed.
+         */
+        flux_cmd_t *cmd;
+        if (!attach_cmd || !(cmd = cmd_fromjson (attach_cmd, NULL))) {
+            errno = EPROTO;
+            set_failed (p, "attach response missing valid command");
+            goto error;
+        }
+        flux_cmd_destroy (p->cmd);
+        p->cmd = cmd;
+        if (remote_setup_io (p) < 0) {
+            set_failed (p, "error setting up attach I/O: %s", strerror (errno));
+            goto error;
+        }
+        p->pid_set = true;
+        process_new_state (p, FLUX_SUBPROCESS_RUNNING);
+    }
+    else if (subprocess_rexec_is_started (f, &p->pid)) {
         p->pid_set = true;
         process_new_state (p, FLUX_SUBPROCESS_RUNNING);
     }
@@ -604,6 +654,47 @@ int remote_exec (flux_subprocess_t *p)
         || flux_future_then (f, -1., rexec_continuation, p) < 0) {
         llog_debug (p,
                     "error sending rexec.exec request: %s",
+                    strerror (errno));
+        flux_future_destroy (f);
+        return -1;
+    }
+    p->f = f;
+    return 0;
+}
+
+int remote_attach (flux_subprocess_t *p, pid_t pid, const char *label)
+{
+    flux_future_t *f;
+    int flags = 0;
+    int local_flags = p->flags;
+
+    /* Select which streams the server should forward based on which output
+     * callbacks the caller registered, as remote_exec() does.  Auxiliary
+     * channels are requested with the channel flag; the specific channels
+     * come from the command returned in the attach response.
+     */
+    if (p->ops.on_stdout)
+        flags |= SUBPROCESS_REXEC_STDOUT;
+    if (p->ops.on_stderr)
+        flags |= SUBPROCESS_REXEC_STDERR;
+    if (p->ops.on_channel_out)
+        flags |= SUBPROCESS_REXEC_CHANNEL;
+
+    /* Clear LOCAL_UNBUF for the remote subprocess object.
+     */
+    local_flags &= ~FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF;
+
+    if (!(f = subprocess_rexec_attach (p->h,
+                                       p->service_name,
+                                       p->rank,
+                                       pid,
+                                       label,
+                                       flags,
+                                       local_flags))
+        || flux_future_then (f, -1., rexec_continuation, p) < 0) {
+        llog_debug (p,
+                    "error sending %s.attach request: %s",
+                    p->service_name,
                     strerror (errno));
         flux_future_destroy (f);
         return -1;

--- a/src/common/libsubprocess/remote.h
+++ b/src/common/libsubprocess/remote.h
@@ -15,7 +15,15 @@
 
 int subprocess_remote_setup (flux_subprocess_t *p, const char *service_name);
 
+/* Set only the service name, deferring I/O channel setup.  Used by attach,
+ * which sets up channels from the command received in the attach response.
+ */
+int subprocess_setup_service_name (flux_subprocess_t *p,
+                                   const char *service_name);
+
 int remote_exec (flux_subprocess_t *p);
+
+int remote_attach (flux_subprocess_t *p, pid_t pid, const char *label);
 
 flux_future_t *remote_kill (flux_subprocess_t *p, int signum);
 

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -24,6 +24,7 @@
  * kill       - Send signal to subprocess
  * list       - List active and zombie subprocesses
  * wait       - Wait for and collect exit status of waitable subprocess
+ * attach     - Attach a client to a running background subprocess
  * disconnect - Notify server of client disconnect
  *
  * EXEC REQUEST TYPES
@@ -33,9 +34,10 @@
  *    in the "finished" response. Process is removed from server list
  *    after final response is sent.
  *
- * 2. Non-streaming (background): Process runs detached. Server does not
- *    stream output or send status responses. Process is removed from server
- *    list immediately upon exit unless marked waitable.
+ * 2. Non-streaming (background): Process runs detached. Server logs output
+ *    to its own log but does not stream output or send status responses to
+ *    a client unless one attaches (see ATTACH below). Process is removed
+ *    from server list immediately upon exit unless marked waitable.
  *
  * 3. Waitable: Background process enters zombie state upon exit, remaining
  *    in server list until status is collected via wait RPC or server is
@@ -48,6 +50,10 @@
  *
  * Waitable subprocess:
  *   exec -> running -> exited -> zombie -> wait RPC -> [removed from list]
+ *
+ * Attached background subprocess:
+ *   exec (background) -> running -> attach -> exited -> [removed from list]
+ *   (on client disconnect before exit, reverts to unattached background)
  *
  * WAITABLE SUBPROCESS BEHAVIOR
  * ----------------------------
@@ -74,19 +80,46 @@
  * - Once status is collected process is removed from server list and cannot
  *   be waited on again.
  *
+ * - wait and attach both consume the exit status and are mutually exclusive:
+ *   a wait is rejected if a client is attached, and an attach is rejected if
+ *   a wait is pending (both EBUSY).
+ *
+ * ATTACH BEHAVIOR
+ * ---------------
+ * - A client may attach to a running background subprocess (by pid or label)
+ *   to receive its output and exit status, as if it had been started
+ *   streaming.  Output produced before the attach is not replayed, but an
+ *   EOF is synthesized for any forwarded stream already at end-of-file.
+ *
+ * - Attach fails with ENOENT if no such subprocess exists, or EBUSY if it
+ *   is not in background mode, already has a client attached, or is being
+ *   waited on.
+ *
+ * - Auxiliary channels are not supported in background mode, so the exec
+ *   request that starts the process (not the attach) is rejected with
+ *   EINVAL if it has them.
+ *
+ * - The attach does not change how the process was started: it remains a
+ *   background process (and still logs to the server log) for its lifetime.
+ *   A client may detach and reattach any number of times while it runs.
+ *
  * DISCONNECT HANDLING
  * -------------------
  * When a client disconnects:
- * - Streaming (non-background) processes from that client are killed with
+ * - Foreground (streaming) processes from that client are killed with
  *   SIGKILL
+ * - An attached background process reverts to unattached background mode
+ *   and continues running
  * - Any pending wait RPC from that client is cancelled
- * - Background processes continue running regardless of client disconnect
+ * - Unattached background processes are unaffected
  *
  * IMPLEMENTATION NOTES
  * --------------------
  * - Process list maintained in s->subprocesses (zlistx)
  * - Process lookup by PID via iteration, by label via s->labels hash
  * - p->waiter stores pending wait RPC message if wait is in progress
+ * - p->bg records how the process was started and never changes; p->attached
+ *   tracks whether a client is currently attached to a background process
  * - proc_delete() handles wait notification and process deletion
  */
 
@@ -151,6 +184,7 @@ struct subprocess_server {
 };
 
 static void server_kill (flux_subprocess_t *p, int signum);
+static bool stream_is_forwarded (flux_subprocess_t *p, const char *name);
 
 #if HAVE_FLUX_SECURITY
 static int server_unpack_signed (subprocess_server_t *s,
@@ -298,9 +332,20 @@ static int server_auth_unpack (subprocess_server_t *s,
 static inline bool is_waitable (flux_subprocess_t *p)
 {
     /* Currently, processes are only waitable if they have the waitable
-     * flag and they are in background mode.
+     * flag and they were started in background mode.
      */
     return (p->bg && p->waitable);
+}
+
+/* True if a client's exec/attach request is currently outstanding and
+ * should receive the process's output and status: a foreground process
+ * always has one; a background process only while a client is attached.
+ * Note this is distinct from p->bg, which records how the process was
+ * started and never changes.
+ */
+static inline bool client_listening (flux_subprocess_t *p)
+{
+    return (!p->bg || p->attached);
 }
 
 static inline void clear_waitable (flux_subprocess_t *p)
@@ -442,6 +487,9 @@ static void proc_completion_cb (flux_subprocess_t *p)
     subprocess_server_t *s = flux_subprocess_aux_get (p, srvkey);
     const flux_msg_t *request = flux_subprocess_aux_get (p, msgkey);
 
+    /* A process started in background logs its exit to the server log for
+     * the duration of its life, independent of whether a client is attached.
+     */
     if (p->bg) {
         int exitcode;
         flux_cmd_t *cmd = flux_subprocess_get_cmd (p);
@@ -467,7 +515,12 @@ static void proc_completion_cb (flux_subprocess_t *p)
                        exitcode);
         }
     }
-    else if (p->state != FLUX_SUBPROCESS_FAILED) {
+    /* A listening client (foreground, or an attached background process)
+     * gets an ENODATA response to terminate its streaming RPC.  These are
+     * not mutually exclusive: a background process that exits while attached
+     * is both logged (above) and responded to (here).
+     */
+    if (client_listening (p) && p->state != FLUX_SUBPROCESS_FAILED) {
         /* no fallback if this fails */
         if (flux_respond_error (s->h, request, ENODATA, NULL) < 0) {
             llog_error (s,
@@ -527,7 +580,7 @@ static void proc_state_change_cb (flux_subprocess_t *p,
             flux_subprocess_aux_set (p, msgkey, NULL, NULL);
     }
     else if (state == FLUX_SUBPROCESS_EXITED) {
-        if (!p->bg)
+        if (client_listening (p))
             rc = flux_respond_pack (s->h,
                                     request,
                                     "{s:s s:i}",
@@ -535,7 +588,7 @@ static void proc_state_change_cb (flux_subprocess_t *p,
                                     "status", flux_subprocess_status (p));
     }
     else if (state == FLUX_SUBPROCESS_STOPPED) {
-        if (!p->bg)
+        if (client_listening (p))
             rc = flux_respond_pack (s->h,
                                     request,
                                     "{s:s}",
@@ -633,7 +686,13 @@ static void proc_output_cb (flux_subprocess_t *p, const char *stream)
         goto error;
     }
 
-    if (!p->bg) {
+    /* Forward output to the client if one is listening (foreground, or a
+     * background process with a client attached) and this stream is selected
+     * for forwarding by the flags.  For a background process the stdout/stderr
+     * callbacks are registered so output can be logged (below) even when it is
+     * not forwarded, so the flags must be consulted here.
+     */
+    if (client_listening (p) && stream_is_forwarded (p, stream)) {
         if (len) {
             if (proc_output (p, stream, s, request, buf, len, false) < 0)
                 goto error;
@@ -643,9 +702,11 @@ static void proc_output_cb (flux_subprocess_t *p, const char *stream)
                 goto error;
         }
     }
-    else if (len) {
-        /* background process: log output (ignore EOF) */
-
+    /* A background-launched process logs its output to the server log for the
+     * duration of its life, so the log is a complete record whether or not a
+     * client is attached (ignore EOF).
+     */
+    if (p->bg && len) {
         const char *label = flux_cmd_get_label (p->cmd);
         if (!label)
             label = basename_simple (flux_cmd_arg (p->cmd, 0));
@@ -785,6 +846,15 @@ static void server_exec_cb (flux_t *h,
         errmsg = "command string is empty";
         goto error;
     }
+    /* N.B. although RFC 42 implies that auxiliary channels may be created
+     * for background subprocs, they are not yet supported by this
+     * server implementation.  Support could be added later if needed.
+     */
+    if (background && zlist_size (cmd_channel_list (cmd)) > 0) {
+        errno = EINVAL;
+        errmsg = "auxiliary channels are not allowed in background mode";
+        goto error;
+    }
 
     if (!(env = cmd_env_expand (cmd))) {
         errmsg = "could not expand command environment";
@@ -825,6 +895,7 @@ static void server_exec_cb (flux_t *h,
     }
 
     p->bg = background;
+    p->rexec_flags = flags;
 
     /* Per RFC 42, a background subprocess's input is at end-of-file.
      */
@@ -1117,8 +1188,20 @@ static void server_disconnect_cb (flux_t *h,
         p = zlistx_first (s->subprocesses);
         while (p) {
             const char *uuid = subprocess_sender (p);
-            if (!p->bg && sender && streq (uuid, sender))
-                server_kill (p, SIGKILL);
+            if (sender && uuid && streq (uuid, sender)) {
+                /* RFC 42: if an attached client disconnects, the subprocess
+                 * reverts to unattached background mode and continues
+                 * running.  A foreground (never-backgrounded) process is
+                 * killed.  p->bg records how the process was started and is
+                 * not changed here.
+                 */
+                if (p->attached) {
+                    p->attached = false;
+                    flux_subprocess_aux_set (p, msgkey, NULL, NULL);
+                }
+                else
+                    server_kill (p, SIGKILL);
+            }
             if (p->waiter
                 && streq (flux_msg_route_first (p->waiter), sender)) {
                 flux_msg_decref (p->waiter);
@@ -1164,6 +1247,14 @@ static void server_wait_cb (flux_t *h,
         errno = EINVAL;
         goto error;
     }
+    /* wait and attach both consume the exit status, so they are mutually
+     * exclusive (attach rejects a waited-on process the same way).
+     */
+    if (p->attached) {
+        errmsg = "subprocess has a client attached";
+        errno = EBUSY;
+        goto error;
+    }
     p->waiter = flux_msg_incref (msg);
 
     /* If process is complete, proc_delete() notifies p->waiter of final
@@ -1178,6 +1269,211 @@ error:
                     "error responding to %s.wait request: %s",
                     s->service_name,
                     strerror (errno));
+}
+
+/* Send an "attached" response to indicate a successful attach, including the
+ * command object so the client can reconstruct its I/O channels (names and
+ * buffering options), since the attach request carried no command.  The
+ * client already knows the forwarding flags it requested, so they are not
+ * echoed (RFC 42).
+ */
+static int attach_respond (subprocess_server_t *s,
+                           const flux_msg_t *msg,
+                           flux_subprocess_t *p)
+{
+    flux_cmd_t *cmd = flux_subprocess_get_cmd (p);
+    json_t *cmd_obj;
+    int rc;
+
+    if (!cmd || !(cmd_obj = cmd_tojson (cmd))) {
+        errno = ENOMEM;
+        return -1;
+    }
+    rc = flux_respond_pack (s->h,
+                            msg,
+                            "{s:s s:i s:o}",
+                            "type", "attached",
+                            "pid", flux_subprocess_pid (p),
+                            "cmd", cmd_obj);
+    return rc;
+}
+
+/* Return true if output on read channel 'name' is forwarded to the client,
+ * per p->rexec_flags.  For a foreground exec these are the exec flags; for an
+ * attached subprocess they are the flags from the attach request.
+ */
+static bool stream_is_forwarded (flux_subprocess_t *p, const char *name)
+{
+    if (streq (name, "stdout"))
+        return (p->rexec_flags & SUBPROCESS_REXEC_STDOUT) ? true : false;
+    if (streq (name, "stderr"))
+        return (p->rexec_flags & SUBPROCESS_REXEC_STDERR) ? true : false;
+    return (p->rexec_flags & SUBPROCESS_REXEC_CHANNEL) ? true : false;
+}
+
+/* Emit an EOF output response for each forwarded output stream that has
+ * already reached end-of-file.  Per RFC 42, the client expects exactly one
+ * EOF for each forwarded stream on every attach.  A stream that reached EOF
+ * while the process was in background mode produced no EOF at that time
+ * (background output, including EOF, is not forwarded), so it is synthesized
+ * here.  Streams still open deliver their EOF later through the normal
+ * streaming path once the process is no longer in background mode.
+ *
+ * This covers stdout, stderr, and any forwarded auxiliary read channels.
+ */
+static int attach_emit_closed_eofs (subprocess_server_t *s,
+                                    const flux_msg_t *msg,
+                                    flux_subprocess_t *p)
+{
+    struct subprocess_channel *c;
+
+    c = zhash_first (p->channels);
+    while (c) {
+        const char *name = zhash_cursor (p->channels);
+        if ((c->flags & CHANNEL_READ)
+            && stream_is_forwarded (p, name)
+            && flux_subprocess_read_stream_closed (p, name)
+            && proc_output (p, name, s, msg, NULL, 0, true) < 0)
+            return -1;
+        c = zhash_next (p->channels);
+    }
+    return 0;
+}
+
+/* Attach to an already-terminated waitable (zombie) subprocess.  Synthesize
+ * the full streaming response sequence: attached -> output EOFs for each
+ * forwarded stream -> finished -> ENODATA, then reap the process (RFC 42).
+ *
+ * A terminated process has reached end-of-file on all forwarded streams, so
+ * attach_emit_closed_eofs() emits an EOF for each (its read_stream_closed
+ * check is always true here).
+ */
+static int attach_zombie (subprocess_server_t *s,
+                          const flux_msg_t *msg,
+                          flux_subprocess_t *p)
+{
+    if (attach_respond (s, msg, p) < 0
+        || attach_emit_closed_eofs (s, msg, p) < 0)
+        return -1;
+    if (flux_respond_pack (s->h,
+                           msg,
+                           "{s:s s:i}",
+                           "type", "finished",
+                           "status", flux_subprocess_status (p)) < 0)
+        return -1;
+    if (flux_respond_error (s->h, msg, ENODATA, NULL) < 0)
+        return -1;
+    /* A waitable process that has been successfully attached to and reaped
+     * SHALL NOT be waited on or attached to again.
+     */
+    clear_waitable (p);
+    proc_delete (s, p);
+    return 0;
+}
+
+static void server_attach_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    subprocess_server_t *s = arg;
+    pid_t pid;
+    const char *label = NULL;
+    int flags;
+    flux_error_t error;
+    const char *errmsg = NULL;
+    flux_subprocess_t *p;
+
+    if (server_auth_unpack (s,
+                            msg,
+                            &error,
+                            "{s:i s?s s:i}",
+                            "pid", &pid,
+                            "label", &label,
+                            "flags", &flags) < 0) {
+        errmsg = error.text;
+        goto error;
+    }
+    if (!flux_msg_is_streaming (msg)) {
+        errmsg = "attach request is missing STREAMING flag";
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(p = proc_find (s, pid, label, &error))) {
+        /* RFC 42: subprocess does not exist -> ENOENT.  A process that
+         * exited without the waitable flag has already been removed from
+         * the list, so it also lands here.
+         */
+        errno = ENOENT;
+        errmsg = error.text;
+        goto error;
+    }
+    /* RFC 42: EBUSY if the subprocess is a foreground streaming process or
+     * already has a client attached.  Note that an exited waitable zombie
+     * was still started in background (p->bg true).
+     */
+    if (!p->bg) {
+        errno = EBUSY;
+        errmsg = "subprocess is not in background mode";
+        goto error;
+    }
+    if (p->attached) {
+        errno = EBUSY;
+        errmsg = "subprocess already has a client attached";
+        goto error;
+    }
+    /* Waiter and attach would both consume wait result.
+     */
+    if (p->waiter) {
+        errno = EBUSY;
+        errmsg = "subprocess is being waited on";
+        goto error;
+    }
+    /* The attach request flags select which streams to forward for the
+     * duration of this attach.
+     */
+    p->rexec_flags = flags;
+    /* Already-terminated waitable zombie: synthesize the response sequence
+     * and reap.
+     */
+    if (!flux_subprocess_active (p)) {
+        if (attach_zombie (s, msg, p) < 0)
+            llog_error (s,
+                        "error responding to %s.attach request: %s",
+                        s->service_name,
+                        strerror (errno));
+        return;
+    }
+    /* Active process: attach a client.  Install the attach request as the
+     * subprocess request message so the existing state/output/completion
+     * callbacks stream to this client, and mark attached so client_listening()
+     * reports true and a client disconnect reverts to unattached background
+     * rather than killing the process.  p->bg is left set: it records that
+     * the process was started in background and is unaffected by attach.
+     */
+    if (flux_subprocess_aux_set (p,
+                                 msgkey,
+                                 (void *)flux_msg_incref (msg),
+                                 (flux_free_f)flux_msg_decref) < 0) {
+        flux_msg_decref (msg);
+        goto error;
+    }
+    p->attached = true;
+    if (attach_respond (s, msg, p) < 0
+        || attach_emit_closed_eofs (s, msg, p) < 0) {
+        llog_error (s,
+                    "error responding to %s.attach request: %s",
+                    s->service_name,
+                    strerror (errno));
+    }
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0) {
+        llog_error (s,
+                    "error responding to %s.attach request: %s",
+                    s->service_name,
+                    strerror (errno));
+    }
 }
 
 static struct flux_msg_handler_spec htab[] = {
@@ -1204,6 +1500,11 @@ static struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,
       "wait",
       server_wait_cb,
+      0
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "attach",
+      server_attach_cb,
       0
     },
     { FLUX_MSGTYPE_REQUEST,

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -699,6 +699,80 @@ flux_subprocess_t *flux_rexec (flux_t *h,
     return flux_rexec_ex (h, "rexec", rank, flags, cmd, ops, NULL, NULL);
 }
 
+flux_subprocess_t *flux_rexec_attach (flux_t *h,
+                                      const char *service_name,
+                                      int rank,
+                                      int flags,
+                                      pid_t pid,
+                                      const char *label,
+                                      const flux_subprocess_ops_t *ops)
+{
+    flux_subprocess_t *p = NULL;
+    flux_cmd_t *cmd = NULL;
+    flux_reactor_t *r;
+    int valid_flags = FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF
+                    | FLUX_SUBPROCESS_FLAGS_SIGN;
+
+    if (!h
+        || (rank < 0
+            && rank != FLUX_NODEID_ANY
+            && rank != FLUX_NODEID_UPSTREAM)
+        || (pid <= 0 && !label)
+        || !service_name) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (flags & ~valid_flags) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(r = flux_get_reactor (h)))
+        return NULL;
+
+    /* An attach carries no command; the target is identified by pid/label.
+     * subprocess_create() still requires a cmd object for its channel setup,
+     * so use an empty one.
+     */
+    if (!(cmd = flux_cmd_create (0, NULL, NULL)))
+        return NULL;
+
+    if (!(p = subprocess_create (h,
+                                 r,
+                                 flags,
+                                 cmd,
+                                 ops,
+                                 NULL,
+                                 rank,
+                                 false,
+                                 NULL,
+                                 NULL)))
+        goto error;
+
+    /* Defer I/O channel setup: it is done from the command received in the
+     * attach response (see rexec_continuation()).  Only the service name is
+     * needed now to send the attach request.
+     */
+    if (subprocess_setup_service_name (p, service_name) < 0)
+        goto error;
+
+    if (subprocess_setup_state_change (p) < 0)
+        goto error;
+
+    if (subprocess_setup_completed (p) < 0)
+        goto error;
+
+    if (remote_attach (p, pid, label) < 0)
+        goto error;
+
+    flux_cmd_destroy (cmd);
+    return p;
+
+error:
+    subprocess_decref (p);
+    flux_cmd_destroy (cmd);
+    return NULL;
+}
+
 void flux_subprocess_stream_start (flux_subprocess_t *p, const char *stream)
 {
     struct subprocess_channel *c;

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -192,6 +192,22 @@ flux_subprocess_t *flux_rexec_ex (flux_t *h,
                                   subprocess_log_f log_fn,
                                   void *log_data);
 
+/* Attach to an existing background subprocess on rank, identified by
+ * process id or command label (when specifying a label, set pid = -1;
+ * label takes precedence if both are given).  The returned subprocess
+ * enters the RUNNING state.  Output forwarding follows the flags the
+ * subprocess was originally started with.
+ *
+ * Valid flags: FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF, FLUX_SUBPROCESS_FLAGS_SIGN.
+ */
+flux_subprocess_t *flux_rexec_attach (flux_t *h,
+                                      const char *service_name,
+                                      int rank,
+                                      int flags,
+                                      pid_t pid,
+                                      const char *label,
+                                      const flux_subprocess_ops_t *ops);
+
 /* Like flux_rexec(3), but run process in background.
  *
  * If service_name is NULL, then default to `rexec`.

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -117,9 +117,11 @@ struct flux_subprocess {
     int signal_pending;         /* signal sent while starting */
 
     /* server */
-    bool bg;                    /* if flags & SUBPROCESS_REXEC_BACKGROUND */
+    bool bg;                    /* started in background (immutable) */
     bool waitable;              /* if flags & SUBPROCESS_REXEC_WAITABLE */
     const flux_msg_t *waiter;   /* subprocess wait request */
+    int rexec_flags;            /* RFC 42 exec 'flags' proc was started with */
+    bool attached;              /* a client is attached to this bg process */
 };
 
 void subprocess_check_completed (flux_subprocess_t *p);

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -812,6 +812,154 @@ void bg_test (flux_t *h,
     flux_future_destroy (f);
 }
 
+/* Start a waitable background subprocess with the given label.  The stdout
+ * and stderr forwarding flags are ignored in background mode (RFC 42);
+ * forwarding is selected later by the attaching client's callbacks.
+ */
+static void attach_bg_start (flux_t *h,
+                             const char *label,
+                             int ac,
+                             char **av)
+{
+    flux_future_t *f;
+    flux_cmd_t *cmd;
+
+    if (!(cmd = flux_cmd_create (ac, av, environ))
+        || flux_cmd_set_label (cmd, label) < 0)
+        BAIL_OUT ("attach_bg_start: flux_cmd_create");
+    f = flux_rexec_bg (h,
+                       SERVER_NAME,
+                       FLUX_NODEID_ANY,
+                       FLUX_SUBPROCESS_FLAGS_WAITABLE,
+                       cmd);
+    if (!f)
+        BAIL_OUT ("attach_bg_start: flux_rexec_bg");
+    ok (flux_rpc_get (f, NULL) == 0,
+        "%s: background exec started", label);
+    flux_future_destroy (f);
+    flux_cmd_destroy (cmd);
+}
+
+/* Attach to a background subprocess and run to completion, checking the
+ * scorecard.  Uses the simple_ops callbacks.
+ */
+static void attach_run_check (flux_t *h,
+                              const char *prefix,
+                              const char *label,
+                              struct simple_scorecard *exp)
+{
+    flux_subprocess_t *p;
+    struct simple_ctx ctx;
+    int rc;
+
+    memset (&ctx, 0, sizeof (ctx));
+    ctx.h = h;
+    p = flux_rexec_attach (h,
+                           SERVER_NAME,
+                           FLUX_NODEID_ANY,
+                           0,
+                           -1,
+                           label,
+                           &simple_ops);
+    ok (p != NULL,
+        "%s: flux_rexec_attach returned a subprocess object", prefix);
+    if (!p)
+        BAIL_OUT ("flux_rexec_attach failed");
+    if (flux_subprocess_aux_set (p, "ctx", &ctx, NULL) < 0)
+        BAIL_OUT ("flux_subprocess_aux_set failed");
+    rc = flux_reactor_run (flux_get_reactor (h), 0);
+    ok (rc >= 0,
+        "%s: client reactor ran successfully", prefix);
+    ok (ctx.scorecard.running == exp->running,
+        "%s: subprocess state=RUNNING was %sreported",
+        prefix, exp->running ? "" : "not ");
+    ok (ctx.scorecard.exited == exp->exited,
+        "%s: subprocess state=EXITED was %sreported",
+        prefix, exp->exited ? "" : "not ");
+    ok (ctx.scorecard.completion == exp->completion,
+        "%s: subprocess completion callback was %sinvoked",
+        prefix, exp->completion ? "" : "not ");
+    ok (ctx.scorecard.exit_nonzero == exp->exit_nonzero,
+        "%s: subprocess did%s exit with nonzero exit code",
+        prefix, exp->exit_nonzero ? "" : " not");
+    ok (ctx.scorecard.stdout_eof == exp->stdout_eof,
+        "%s: subprocess stdout %s EOF",
+        prefix, exp->stdout_eof ? "got" : "did not get");
+    ok (ctx.scorecard.stderr_eof == exp->stderr_eof,
+        "%s: subprocess stderr %s EOF",
+        prefix, exp->stderr_eof ? "got" : "did not get");
+    flux_subprocess_destroy (p);
+}
+
+void attach_test (flux_t *h)
+{
+    struct simple_scorecard exp;
+
+    /* Attach to a running background process: it should report RUNNING,
+     * stream its stdout/stderr EOFs when it exits, and complete with the
+     * exit status.
+     */
+    char *run_av[] = { "/bin/sh", "-c", "sleep 0.2; exit 4", NULL };
+    attach_bg_start (h, "att-run", ARRAY_SIZE (run_av) - 1, run_av);
+    memset (&exp, 0, sizeof (exp));
+    exp.running = 1;
+    exp.exited = 1;
+    exp.completion = 1;
+    exp.exit_nonzero = 1;
+    exp.stdout_eof = 1;
+    exp.stderr_eof = 1;
+    attach_run_check (h, "attach running", "att-run", &exp);
+
+    /* Attach to a background process that closed stdout *before* the attach.
+     * The EOF consumed in background mode is not forwarded, so the server
+     * synthesizes it on attach; without that EOF the client's per-stream
+     * accounting would never balance and completion would not fire.
+     */
+    char *closed_av[] = {
+        "/bin/sh", "-c", "echo hi; exec 1>&-; sleep 0.2; exit 9", NULL
+    };
+    attach_bg_start (h, "att-closed", ARRAY_SIZE (closed_av) - 1, closed_av);
+    /* Pump the reactor so the server observes the stdout close while the
+     * process is still in background mode.
+     */
+    flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_NOWAIT);
+    memset (&exp, 0, sizeof (exp));
+    exp.running = 1;
+    exp.exited = 1;
+    exp.completion = 1;
+    exp.exit_nonzero = 1;
+    exp.stdout_eof = 1;
+    exp.stderr_eof = 1;
+    attach_run_check (h, "attach stdout-closed-in-bg", "att-closed", &exp);
+
+    /* Attach to a nonexistent label -> the attach RPC fails with ENOENT,
+     * surfaced to the client as the FAILED state.
+     */
+    struct simple_ctx ctx;
+    flux_subprocess_t *p;
+    memset (&ctx, 0, sizeof (ctx));
+    ctx.h = h;
+    p = flux_rexec_attach (h,
+                           SERVER_NAME,
+                           FLUX_NODEID_ANY,
+                           0,
+                           -1,
+                           "att-nope",
+                           &simple_ops);
+    ok (p != NULL,
+        "attach nonexistent: flux_rexec_attach returned a subprocess object");
+    if (p) {
+        if (flux_subprocess_aux_set (p, "ctx", &ctx, NULL) < 0)
+            BAIL_OUT ("flux_subprocess_aux_set failed");
+        flux_reactor_run (flux_get_reactor (h), 0);
+        ok (ctx.scorecard.failed == 1,
+            "attach nonexistent: subprocess reached FAILED state");
+        ok (flux_subprocess_fail_errno (p) == ENOENT,
+            "attach nonexistent: fail errno is ENOENT");
+        flux_subprocess_destroy (p);
+    }
+}
+
 void background_waitable_test (flux_t *h)
 {
     char *cmd_noexist[] = { "/noexist", NULL };
@@ -881,6 +1029,32 @@ void background_input_reject_test (flux_t *h)
         "background exec with stdio-fallthrough flag fails with EINVAL");
     flux_future_destroy (f);
 
+    /* Non-streaming (background) + a command with an auxiliary channel ->
+     * EINVAL (implementation restriction; see server_exec_cb()).
+     */
+    flux_cmd_t *chan_cmd;
+    json_t *chan_obj = NULL;
+    if (!(chan_cmd = flux_cmd_create (1, av, environ))
+        || flux_cmd_add_channel (chan_cmd, "TEST_CHANNEL") < 0
+        || !(chan_obj = cmd_tojson (chan_cmd)))
+        BAIL_OUT ("background_input_reject_test: channel cmd setup");
+    f = flux_rpc_pack (h,
+                       topic,
+                       FLUX_NODEID_ANY,
+                       0,
+                       "{s:O s:i s:i}",
+                       "cmd", chan_obj,
+                       "flags", 0,
+                       "local_flags", 0);
+    ok (f != NULL,
+        "sent background exec request with auxiliary channel");
+    errno = 0;
+    ok (flux_rpc_get (f, NULL) < 0 && errno == EINVAL,
+        "background exec with auxiliary channel fails with EINVAL");
+    flux_future_destroy (f);
+    json_decref (chan_obj);
+    flux_cmd_destroy (chan_cmd);
+
     free (topic);
     json_decref (cmd_obj);
     flux_cmd_destroy (cmd);
@@ -910,6 +1084,8 @@ int main (int argc, char *argv[])
     background_waitable_test (h);
     diag ("background_input_reject_test");
     background_input_reject_test (h);
+    diag ("attach_test");
+    attach_test (h);
 
     test_server_stop (h);
     flux_close (h);

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -850,7 +850,10 @@ void background_input_reject_test (flux_t *h)
         BAIL_OUT ("background_input_reject_test: asprintf");
 
     /* Non-streaming (background) + write-credit flag -> EINVAL */
-    f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0,
+    f = flux_rpc_pack (h,
+                       topic,
+                       FLUX_NODEID_ANY,
+                       0,
                        "{s:O s:i s:i}",
                        "cmd", cmd_obj,
                        "flags", SUBPROCESS_REXEC_WRITE_CREDIT,
@@ -863,7 +866,10 @@ void background_input_reject_test (flux_t *h)
     flux_future_destroy (f);
 
     /* Non-streaming (background) + stdio-fallthrough local flag -> EINVAL */
-    f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0,
+    f = flux_rpc_pack (h,
+                       topic,
+                       FLUX_NODEID_ANY,
+                       0,
                        "{s:O s:i s:i}",
                        "cmd", cmd_obj,
                        "flags", 0,

--- a/src/common/libsubprocess/test/sign.c
+++ b/src/common/libsubprocess/test/sign.c
@@ -526,6 +526,134 @@ static void test_signed_kill_succeeds (flux_t *h)
     flux_subprocess_destroy (p);
 }
 
+/* Start a signed, labeled, waitable background 'sleep 300' so it can be
+ * attached to.  Returns the pid.
+ */
+static pid_t start_bg_sleep (flux_t *h, const char *label)
+{
+    char *av[] = { "sleep", "300", NULL };
+    flux_cmd_t *cmd;
+    flux_future_t *f;
+    int pid;
+
+    if (!(cmd = flux_cmd_create (2, av, environ))
+        || flux_cmd_set_label (cmd, label) < 0)
+        BAIL_OUT ("flux_cmd_create failed");
+    f = flux_rexec_bg (h,
+                       SERVER_NAME,
+                       FLUX_NODEID_ANY,
+                       FLUX_SUBPROCESS_FLAGS_WAITABLE
+                       | FLUX_SUBPROCESS_FLAGS_SIGN,
+                       cmd);
+    if (!f)
+        BAIL_OUT ("flux_rexec_bg failed");
+    if (flux_rpc_get_unpack (f, "{s:i}", "pid", &pid) < 0)
+        BAIL_OUT ("signed background exec failed: %s",
+                  future_strerror (f, errno));
+    flux_future_destroy (f);
+    flux_cmd_destroy (cmd);
+    return pid;
+}
+
+struct attach_ctx {
+    flux_t *h;
+    bool running;
+    bool failed;
+    int fail_errno;
+};
+
+static void attach_state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
+{
+    struct attach_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
+
+    diag ("attach state: %s", flux_subprocess_state_string (state));
+    if (state == FLUX_SUBPROCESS_RUNNING) {
+        ctx->running = true;
+        flux_reactor_stop (flux_get_reactor (ctx->h));
+    }
+    else if (state == FLUX_SUBPROCESS_FAILED) {
+        ctx->failed = true;
+        ctx->fail_errno = flux_subprocess_fail_errno (p);
+        flux_reactor_stop (flux_get_reactor (ctx->h));
+    }
+}
+
+static flux_subprocess_ops_t attach_ops = {
+    .on_state_change = attach_state_cb,
+    .on_stdout       = discard_output_cb,
+    .on_stderr       = discard_output_cb,
+};
+
+/* An unsigned attach to a sign-required server must be rejected with EPERM. */
+static void test_unsigned_attach_rejected (flux_t *h)
+{
+    struct attach_ctx ctx = { .h = h };
+    flux_subprocess_t *p;
+    flux_future_t *f;
+    pid_t pid;
+
+    pid = start_bg_sleep (h, "att-unsigned");
+
+    p = flux_rexec_attach (h,
+                           SERVER_NAME,
+                           FLUX_NODEID_ANY,
+                           0,
+                           -1,
+                           "att-unsigned",
+                           &attach_ops);
+    if (!p)
+        BAIL_OUT ("flux_rexec_attach failed");
+    if (flux_subprocess_aux_set (p, "ctx", &ctx, NULL) < 0)
+        BAIL_OUT ("flux_subprocess_aux_set failed");
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        BAIL_OUT ("flux_reactor_run failed");
+    ok (ctx.failed && ctx.fail_errno == EPERM,
+        "unsigned attach to sign-required server gets EPERM");
+    flux_subprocess_destroy (p);
+
+    /* Clean up the background process with a signed kill. */
+    f = subprocess_kill (h, SERVER_NAME, FLUX_NODEID_ANY, pid, SIGKILL, true);
+    if (f)
+        (void)flux_future_get (f, NULL);
+    flux_future_destroy (f);
+}
+
+/* A signed attach to a sign-required server must succeed. */
+static void test_signed_attach_succeeds (flux_t *h)
+{
+    struct attach_ctx ctx = { .h = h };
+    flux_subprocess_t *p;
+    flux_future_t *f;
+    pid_t pid;
+
+    pid = start_bg_sleep (h, "att-signed");
+
+    p = flux_rexec_attach (h,
+                           SERVER_NAME,
+                           FLUX_NODEID_ANY,
+                           FLUX_SUBPROCESS_FLAGS_SIGN,
+                           -1,
+                           "att-signed",
+                           &attach_ops);
+    if (!p)
+        BAIL_OUT ("flux_rexec_attach failed");
+    if (flux_subprocess_aux_set (p, "ctx", &ctx, NULL) < 0)
+        BAIL_OUT ("flux_subprocess_aux_set failed");
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        BAIL_OUT ("flux_reactor_run failed");
+    ok (ctx.running && !ctx.failed,
+        "signed attach to sign-required server succeeds");
+
+    /* Kill (signed) so the attached streaming process completes. */
+    f = subprocess_kill (h, SERVER_NAME, FLUX_NODEID_ANY, pid, SIGKILL, true);
+    if (f)
+        (void)flux_future_get (f, NULL);
+    flux_future_destroy (f);
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        BAIL_OUT ("flux_reactor_run failed");
+    flux_subprocess_destroy (p);
+}
+
 static bool sign_wrap_works (void)
 {
     flux_security_t *sec = flux_security_create (0);
@@ -588,6 +716,12 @@ int main (int argc, char *argv[])
 
     diag ("test_signed_kill_succeeds");
     test_signed_kill_succeeds (h);
+
+    diag ("test_unsigned_attach_rejected");
+    test_unsigned_attach_rejected (h);
+
+    diag ("test_signed_attach_succeeds");
+    test_signed_attach_succeeds (h);
 
     test_server_stop (h);
     flux_close (h);

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -120,6 +120,23 @@ void test_corner_cases (flux_reactor_t *r)
     ok (flux_rexec_wait (h, NULL, -42, 1234, NULL) == NULL && errno == EINVAL,
         "flux_rexec_wait fails with EINVAL with invalid rank");
 
+    ok (flux_rexec_attach (NULL, "rexec", 0, 0, 1234, NULL, NULL) == NULL
+        && errno == EINVAL,
+        "flux_rexec_attach fails with EINVAL with NULL handle");
+    ok (flux_rexec_attach (h, NULL, 0, 0, 1234, NULL, NULL) == NULL
+        && errno == EINVAL,
+        "flux_rexec_attach fails with EINVAL with NULL service_name");
+    ok (flux_rexec_attach (h, "rexec", 0, 0, -1, NULL, NULL) == NULL
+        && errno == EINVAL,
+        "flux_rexec_attach fails with EINVAL with neither pid nor label");
+    ok (flux_rexec_attach (h, "rexec", -42, 0, 1234, NULL, NULL) == NULL
+        && errno == EINVAL,
+        "flux_rexec_attach fails with EINVAL with invalid rank");
+    ok (flux_rexec_attach (h, "rexec", 0, FLUX_SUBPROCESS_FLAGS_FORK_EXEC,
+                           1234, NULL, NULL) == NULL
+        && errno == EINVAL,
+        "flux_rexec_attach fails with EINVAL with invalid flag");
+
     ok (flux_local_exec (r, 0, cmd, NULL) == NULL
         && errno == EINVAL,
         "flux_local_exec fails with cmd with zero args");

--- a/t/t0005-exec-jobid.t
+++ b/t/t0005-exec-jobid.t
@@ -217,6 +217,25 @@ test_expect_success SIGN_WRAP 'create kill-signed.py' '
 	EOF
 	chmod +x kill-signed.py
 '
+# flux exec --attach plumbs FLUX_SUBPROCESS_FLAGS_SIGN through to
+# flux_rexec_attach(3).  Exercise that seam through the CLI: a signed attach
+# to a sign-required server succeeds, while an unsigned attach is rejected.
+test_expect_success SIGN_WRAP 'signed attach to sign-required server works' '
+	flux exec --bg --waitable --label=att-sign --sign \
+		--jobid=$sign_jobid sh -c "sleep 3; exit 4" &&
+	test_expect_code 4 \
+		flux exec --attach --sign --jobid=$sign_jobid att-sign
+'
+test_expect_success SIGN_WRAP 'unsigned attach to sign-required server is rejected' '
+	flux exec --bg --waitable --label=att-unsign --sign \
+		--jobid=$sign_jobid sleep inf &&
+	test_must_fail flux exec --attach --jobid=$sign_jobid att-unsign \
+		2>attach-unsigned.err &&
+	test_debug "cat attach-unsigned.err" &&
+	grep "request signature required" attach-unsigned.err &&
+	SIGN_SERVICE=$sign_service SIGN_RANK=$sign_rank \
+		flux python kill-signed.py att-unsign
+'
 test_expect_success SIGN_WRAP 'kill background process' '
 	SIGN_SERVICE=$sign_service SIGN_RANK=$sign_rank \
 	    flux python kill-signed.py test

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -576,4 +576,137 @@ test_expect_success 'rexec: failed processes are not kept as zombies' '
 	test_debug "cat failed-zombie.out" &&
 	test_must_fail grep nonexistent failed-zombie.out
 '
+#
+# attach (RFC 42)
+#
+test_expect_success 'rexec: --attach requires a target argument' '
+	test_must_fail flux exec -r 0 --attach
+'
+test_expect_success 'rexec: --attach takes a single argument' '
+	test_must_fail flux exec -r 0 --attach x y
+'
+test_expect_success 'rexec: --attach cannot be combined with --bg' '
+	test_must_fail flux exec -r 0 --attach --bg x
+'
+# A pid is only meaningful on one rank, so attaching by pid to the default
+# (all-ranks) target set must be rejected.  Label attach is not restricted.
+test_expect_success 'rexec: --attach by pid to multiple ranks fails' '
+	test_must_fail flux exec -r 0-1 --attach 123456 2>attach_multi.err &&
+	grep "single target rank" attach_multi.err
+'
+# A value that overflows pid_t must be treated as a label, not truncated
+# into a valid pid.  The error wording distinguishes the two.
+test_expect_success 'rexec: --attach pid overflow is treated as a label' '
+	test_expect_code 127 flux exec -r 0 --attach 4294967297 2>attach_ovf.err &&
+	grep "label 4294967297" attach_ovf.err
+'
+# N.B. flux-exec maps the ENOENT attach failure to exit code 127
+test_expect_success 'rexec: --attach to nonexistent label fails' '
+	test_expect_code 127 flux exec -r 0 --attach nosuchlabel
+'
+test_expect_success 'rexec: --attach to nonexistent pid fails' '
+	test_expect_code 127 flux exec -r 0 --attach 123456
+'
+test_expect_success 'rexec: attach to running background process by label' '
+	flux exec -r 0 --bg --label=att-run sh -c "sleep 3; exit 4" &&
+	test_expect_code 4 flux exec -r 0 --attach att-run
+'
+test_expect_success 'rexec: attach to running background process by pid' '
+	IFS=": " read -r rank pid <<-EOF &&
+	$(flux exec -r0 --bg sh -c "sleep 3; exit 5")
+	EOF
+	test_debug "echo attaching to pid $pid on rank $rank" &&
+	test_expect_code 5 flux exec -r 0 --attach $pid
+'
+test_expect_success 'rexec: attach to already-exited waitable zombie returns status' '
+	flux exec -r 0 --bg --waitable --label=att-zombie sh -c "exit 7" &&
+	$rps | grep att-zombie &&
+	test_expect_code 7 flux exec -r 0 --attach att-zombie
+'
+test_expect_success 'rexec: attach reaps zombie (second attach fails)' '
+	flux exec -r 0 --bg --waitable --label=att-reap true &&
+	flux exec -r 0 --attach att-reap &&
+	test_expect_code 127 flux exec -r 0 --attach att-reap
+'
+test_expect_success 'rexec: second concurrent attach fails with EBUSY' '
+	flux exec -r 0 --bg --label=att-busy sleep 30 &&
+	{ flux exec -r 0 --attach att-busy >busy1.out 2>&1 & apid=$!; } &&
+	test_when_finished "kill $apid 2>/dev/null; $rkill -r 0 9 att-busy 2>/dev/null; true" &&
+	sleep 1 &&
+	test_must_fail flux exec -r 0 --attach att-busy 2>busy2.err &&
+	test_debug "cat busy2.err" &&
+	grep "already has a client attached" busy2.err
+'
+test_expect_success 'rexec: client disconnect reverts attach to background' '
+	flux exec -r 0 --bg --label=att-revert \
+	    sh -c "for i in \$(seq 30); do echo tick >&2; sleep 0.2; done; exit 6" &&
+	{ flux exec -r 0 --attach att-revert >revert.out 2>&1 & apid=$!; } &&
+	test_when_finished "$rkill -r 0 9 att-revert 2>/dev/null; true" &&
+	$waitfile --timeout=30 --pattern=tick revert.out &&
+	{ kill -KILL $apid 2>/dev/null; true; } &&
+	{ wait $apid 2>/dev/null; true; } &&
+	$rps | grep att-revert
+'
+# In attach mode SIGINT detaches (leaving the process running) and prints a
+# hint, rather than forwarding the signal to the process.  The process emits
+# output continuously so the attaching client can confirm it is attached
+# (via waitfile) before the signal is sent, avoiding a race.  Ticks go to
+# stderr because the client's stdout is block-buffered when redirected to a
+# file, so stdout ticks would not reach the file until the process exited.
+test_expect_success 'rexec: SIGINT detaches from attached process' '
+	flux exec -r 0 --bg --label=att-detach \
+	    sh -c "for i in \$(seq 50); do echo tick >&2; sleep 0.2; done; exit 3" &&
+	{ flux exec -r 0 --attach att-detach >att-detach.out 2>&1 & apid=$!; } &&
+	test_when_finished "$rkill -r 0 9 att-detach 2>/dev/null; true" &&
+	$waitfile --timeout=30 --pattern=tick att-detach.out &&
+	kill -INT $apid &&
+	wait $apid &&
+	test_debug "cat att-detach.out" &&
+	grep "detached" att-detach.out &&
+	grep "flux sproc kill att-detach" att-detach.out &&
+	$rps | grep att-detach
+'
+# wait and attach both consume the exit status, so a wait is rejected while
+# a client is attached (EBUSY).  N.B. the attached client is backgrounded
+# and its forwarded output is fully buffered to the file, so waitfile cannot
+# be used to confirm attachment; a short sleep lets the attach establish.
+test_expect_success 'rexec: wait fails while a client is attached' '
+	flux exec -r 0 --bg --waitable --label=att-wait sleep 30 &&
+	{ flux exec -r 0 --attach att-wait >att-wait.out 2>&1 & apid=$!; } &&
+	test_when_finished "kill -INT $apid 2>/dev/null; $rkill -r 0 9 att-wait 2>/dev/null; true" &&
+	sleep 1 &&
+	test_must_fail $rwait -r 0 att-wait 2>att-wait.err &&
+	test_debug "cat att-wait.err" &&
+	grep -i "client attached" att-wait.err
+'
+# A stream that reaches EOF while the process is in background mode produces
+# no EOF at that time (background output is not forwarded).  Per RFC 42 the
+# server must synthesize the EOF on attach so the client can complete.  Here
+# the process closes stdout before the attach.
+test_expect_success 'rexec: attach recovers status when stream closed in bg' '
+	flux exec -r 0 --bg --label=att-closed \
+	    sh -c "echo hi; exec 1>&-; sleep 2; exit 9" &&
+	$rps | grep att-closed &&
+	test_expect_code 9 flux exec -r 0 --attach att-closed
+'
+# A background process logs its output to the broker log throughout its life,
+# so the log has no gap while a client is attached.  The attached client only
+# receives lines emitted *during* the attach; assert those same lines are also
+# in the broker log (without the fix they would be missing = a gap).
+test_expect_success 'rexec: background output is logged while attached' '
+	flux dmesg -C &&
+	flux exec -r 0 --bg --label=att-log \
+	    sh -c "i=0; while true; do echo line\$i; i=\$((i+1)); sleep 0.2; done" &&
+	{ flux exec -r 0 --attach att-log >att-log.out 2>&1 & apid=$!; } &&
+	test_when_finished "$rkill -r 0 9 att-log 2>/dev/null; true" &&
+	sleep 1.5 &&
+	kill -INT $apid &&
+	wait $apid &&
+	flux dmesg >att-log.dmesg &&
+	test_debug "echo CLIENT SAW:; cat att-log.out; echo DMESG:; grep att-log att-log.dmesg" &&
+	seen=$(grep -o "line[0-9]*" att-log.out | tail -1) &&
+	test -n "$seen" &&
+	test_debug "echo checking that attach-seen line \$seen is logged" &&
+	grep "att-log.*$seen\$" att-log.dmesg
+'
 test_done


### PR DESCRIPTION
Problem: the `attach` method described in [RFC 42](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_42.html) is not implemented.

This adds `flux_rexec_attach()` which allows a process that's been started in background mode to be reattached.
It also adds support in the `rexec` subprocess server, and an `--attach` option to `flux-exec`.

When the subprocess is also waitable, the wait result is consumed by the attached client, so `wait` and `attach` are mutually exclusive.

Although the RFC allows there to be auxiliary output channels, this implementation forbids them since handling them would add extra complexity and test requirements and I couldn't think of a near term use case.

This really just demonstrates the attach protocol.  The real use case will be in the `sdexec` subprocess server for restarting with running jobs.