### PR TITLE
job-exec: handle shell barrier as an RPC

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -64,6 +64,7 @@ struct exec_ctx {
     struct idset *barrier_pending_ranks;
     int barrier_enter_count;
     int barrier_completion_count;
+    struct flux_msglist *barrier_requests;
 
     /*  terminated_before_barrier will be set to true if one shell terminates
      *  before the first barrier *and* the first exception. This allows other
@@ -77,6 +78,25 @@ struct exec_ctx {
 
     flux_watcher_t *shell_barrier_timer;
 };
+
+static void barrier_release (struct exec_ctx *ctx, int errnum)
+{
+    const flux_msg_t *msg;
+    struct jobinfo *job = ctx->job;
+
+    if (!ctx->barrier_requests)
+        return;
+    while ((msg = flux_msglist_first (ctx->barrier_requests))) {
+        int rc;
+        if (errnum == 0)
+            rc = shell_barrier_respond (job->h, msg, NULL);
+        else
+            rc = shell_barrier_respond_error (job->h, msg, errnum, NULL);
+        if (rc < 0)
+            flux_log_error (job->h, "shell-barrier: error responding to shell");
+        flux_msglist_delete (ctx->barrier_requests);
+    }
+}
 
 static void barrier_timer_cb (flux_reactor_t *r,
                               flux_watcher_t *w,
@@ -118,6 +138,12 @@ static void exec_ctx_destroy (struct exec_ctx *tc)
 {
     if (tc) {
         int saved_errno = errno;
+        /*  Respond with an error to any requests still parked in the
+         *  barrier so those shells exit rather than blocking until killed.
+         */
+        if (tc->job)
+            barrier_release (tc, EIO);
+        flux_msglist_destroy (tc->barrier_requests);
         idset_destroy (tc->barrier_pending_ranks);
         flux_watcher_destroy (tc->shell_barrier_timer);
         free (tc);
@@ -131,12 +157,15 @@ static struct exec_ctx *exec_ctx_create (struct jobinfo *job,
 {
     json_error_t error;
     const char *service;
-    struct exec_ctx *ctx = calloc (1, sizeof (*ctx));
-    flux_reactor_t *r = flux_get_reactor (job->h);
+    flux_reactor_t *r;
+    struct exec_ctx *ctx = NULL;
     double barrier_timeout = config_get_default_barrier_timeout ();
 
-    if (!r || !ctx || !(ctx->barrier_pending_ranks = idset_copy (ranks))) {
-        errprintf (errp, "Out of memory");
+    if (!(r = flux_get_reactor (job->h))
+        || !(ctx = calloc (1, sizeof (*ctx)))
+        || !(ctx->barrier_requests = flux_msglist_create ())
+        || !(ctx->barrier_pending_ranks = idset_copy (ranks))) {
+        errprintf (errp, "%s", strerror (errno));
         goto error;
     }
 
@@ -221,37 +250,65 @@ static void barrier_timer_start (struct exec_ctx *ctx)
 }
 
 
-static int exec_barrier_enter (struct bulk_exec *exec, int rank)
+static int exec_barrier_enter (struct bulk_exec *exec, const flux_msg_t *msg)
 {
     struct exec_ctx *ctx = bulk_exec_aux_get (exec, "ctx");
+    int rank;
 
     if (!ctx)
         return -1;
 
+    if (flux_msg_unpack (msg, "{s:i}", "rank", &rank) < 0)
+        return -1;
+    /*  Reject a request whose rank is out of range or not pending
+     *  to avoid corrupting barrier accounting.
+     */
+    if (rank < 0 || !idset_test (ctx->barrier_pending_ranks, rank)) {
+        flux_error_t error;
+        errprintf (&error, "rank %d is not pending in barrier", rank);
+        if (shell_barrier_respond_error (ctx->job->h,
+                                         msg,
+                                         EINVAL,
+                                         error.text) < 0)
+            flux_log_error (ctx->job->h, "shell-barrier: error responding");
+        return 0;
+    }
     (void) idset_clear (ctx->barrier_pending_ranks, rank);
-    if (++ctx->barrier_enter_count == bulk_exec_total (exec)) {
-        if (bulk_exec_write (exec, "stdin", "exit=0\n", 7) < 0)
-            return -1;
+    ctx->barrier_enter_count++;
+
+    /*
+     *  Terminate barrier with error immediately when a shell enters after
+     *   one or more shells have already exited. The case where a shell exits
+     *   while a barrier is already in progress is handled in exit_cb().
+     */
+    if (ctx->exit_count > 0) {
+        if (shell_barrier_respond_error (ctx->job->h, msg, EIO, NULL) < 0)
+            flux_log_error (ctx->job->h, "shell-barrier: error responding");
+        return 0;
+    }
+
+    if (flux_msglist_append (ctx->barrier_requests, msg) < 0)
+        return -1;
+
+    if (ctx->barrier_enter_count == bulk_exec_total (exec)) {
+        barrier_release (ctx, 0);
         ctx->barrier_enter_count = 0;
         ctx->barrier_completion_count++;
         barrier_timer_stop (ctx);
-    }
-    else if (ctx->barrier_enter_count == 1 && ctx->exit_count > 0) {
-        /*
-         *  Terminate barrier with error immediately when a barrier is
-         *   started after one or more shells have already exited. The
-         *   case where a shell exits while a barrier is already in progress
-         *   is handled in exit_cb().
+        /*  Reset pending ranks for next barrier.  Failure is unlikely
+         *  since the set universe won't expand here.
          */
-        if (bulk_exec_write (exec, "stdin", "exit=1\n", 7) < 0)
-            return -1;
+        if (idset_add (ctx->barrier_pending_ranks,
+                       resource_set_ranks (ctx->job->R)) < 0) {
+            flux_log_error (ctx->job->h,
+                            "shell-barrier: failed to reset pending ranks");
+        }
     }
-
     /*  When the first shell enters the barrier, start a timer after
      *   which the job will be terminated if all shells have not reached
      *   the barrier.
      */
-    if (ctx->barrier_enter_count == 1)
+    else if (ctx->barrier_enter_count == 1)
         barrier_timer_start (ctx);
 
     return 0;
@@ -266,17 +323,7 @@ static void output_cb (struct bulk_exec *exec,
 {
     struct jobinfo *job = arg;
     const char *cmd = flux_cmd_arg (flux_subprocess_get_cmd (p), 0);
-    int rank = flux_subprocess_rank (p);
 
-    if (streq (stream, "stdout")
-        && len == 6
-        && strncmp (data, "enter\n", 6) == 0) {
-        if (exec_barrier_enter (exec, rank) < 0)
-            jobinfo_fatal_error (job,
-                                 errno,
-                                 "Failed to handle barrier");
-        return;
-    }
     jobinfo_log_output (job,
                         flux_subprocess_rank (p),
                         basename_simple (cmd),
@@ -681,20 +728,12 @@ static void exit_cb (struct bulk_exec *exec,
         free (hosts);
     }
 
-    /*  If a shell exited before the first barrier or there is a
-     *   barrier in progress (enter_count > 0), then terminate the
-     *   current/next barrier immediately with error. This will allow
-     *   shells currently waiting or entering the barrier in the future
-     *   to exit immediately, rather than being killed by exec system.
+    /*  Terminate any barrier in progress with error, releasing shells
+     *   currently waiting so they exit immediately rather than being killed
+     *   by the exec system.  Shells that enter the barrier later are
+     *   rejected by exec_barrier_enter() since exit_count is now nonzero.
      */
-    if (ctx->barrier_completion_count == 0
-        || ctx->barrier_enter_count > 0) {
-        if (bulk_exec_write (exec, "stdin", "exit=1\n", 7) < 0)
-            jobinfo_fatal_error (job,
-                                 0,
-                                 "failed to terminate barrier: %s",
-                                 strerror (errno));
-    }
+    barrier_release (ctx, EIO);
 
     /*  If a shell exits due to signal report the shell as lost to
      *  the leader shell. This avoids potential hangs in the leader
@@ -1160,6 +1199,11 @@ static struct idset *active_ranks (struct jobinfo *job)
     return NULL;
 }
 
+static int exec_barrier_enter_op (struct jobinfo *job, const flux_msg_t *msg)
+{
+    return exec_barrier_enter ((struct bulk_exec *) job->data, msg);
+}
+
 struct exec_implementation bulkexec = {
     .name =     "bulk-exec",
     .config =   exec_config,
@@ -1170,6 +1214,7 @@ struct exec_implementation bulkexec = {
     .cancel =   exec_cancel,
     .stats =    exec_stats,
     .active_ranks = active_ranks,
+    .barrier_enter = exec_barrier_enter_op,
 };
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1473,6 +1473,87 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
+static int barrier_respond (flux_t *h,
+                            const flux_msg_t *request,
+                            int errnum,
+                            const char *errstr)
+{
+    flux_msg_t *msg;
+    uint32_t matchtag;
+
+    if (flux_msg_get_matchtag (request, &matchtag) < 0
+        || !(msg = flux_msg_copy (request, false)))
+        return -1;
+    if (flux_msg_set_type (msg, FLUX_MSGTYPE_RESPONSE) < 0
+        || flux_msg_clear_flag (msg, FLUX_MSGFLAG_NORESPONSE) < 0
+        || flux_msg_set_matchtag (msg, matchtag) < 0
+        || (errnum && flux_msg_set_errnum (msg, errnum) < 0)
+        || (errstr && flux_msg_set_string (msg, errstr) < 0)
+        || flux_send_new (h, &msg, 0) < 0) {
+        flux_msg_destroy (msg);
+        return -1;
+    }
+    return 0;
+}
+
+int shell_barrier_respond (flux_t *h, const flux_msg_t *request, const char *s)
+{
+    return barrier_respond (h, request, 0, s);
+}
+
+int shell_barrier_respond_error (flux_t *h,
+                                 const flux_msg_t *request,
+                                 int errnum,
+                                 const char *errstr)
+{
+    if (errnum == 0)
+        errnum = EINVAL;
+    return barrier_respond (h, request, errnum, errstr);
+}
+
+/*  Handle a shell-barrier "enter" request from a job shell.  Look up the
+ *  job and dispatch to the exec implementation, which parks the request
+ *  until the barrier is released (see exec.c).  The reply is the barrier
+ *  exit status: an (empty) success response releases the shell, an error
+ *  response tells it to abort.
+ */
+static void shell_barrier_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    struct job_exec_ctx *ctx = arg;
+    flux_jobid_t id;
+    struct jobinfo *job;
+    flux_error_t error;
+    const char *errmsg = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        goto error;
+    if (!(job = zhashx_lookup (ctx->jobs, &id))) {
+        errprintf (&error, "job not found");
+        errmsg = error.text;
+        errno = ENOENT;
+        goto error;
+    }
+    if (flux_msg_authorize (msg, job->userid) < 0)
+        goto error;
+    if (!job->impl->barrier_enter) {
+        errprintf (&error,
+                   "%s does not support shell barrier",
+                   job->impl->name);
+        errmsg = error.text;
+        errno = ENOSYS;
+        goto error;
+    }
+    if (job->impl->barrier_enter (job, msg) < 0)
+        goto error;
+    return;
+error:
+    if (shell_barrier_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "%s: error responding", __FUNCTION__);
+}
+
 static void expiration_cb (flux_t *h,
                            flux_msg_handler_t *mh,
                            const flux_msg_t *msg,
@@ -1905,6 +1986,11 @@ static const struct flux_msg_handler_spec htab[]  = {
     { FLUX_MSGTYPE_REQUEST,
       "job-exec.critical-ranks",
        critical_ranks_cb,
+       FLUX_ROLE_USER
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "job-exec.shell-barrier",
+       shell_barrier_cb,
        FLUX_ROLE_USER
     },
     { FLUX_MSGTYPE_REQUEST, "job-exec.expiration", expiration_cb, 0 },

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -65,7 +65,25 @@ struct exec_implementation {
     int  (*cancel)  (struct jobinfo *job);
     json_t * (*stats) (struct jobinfo *job);
     struct idset * (*active_ranks) (struct jobinfo *job);
+
+    /*  Handle a shell-barrier "enter" request from a job shell.  The
+     *  implementation takes ownership of responding to the request (now or
+     *  when the barrier is released) via shell_barrier_respond() or
+     *  shell_barrier_respond_error().  Optional; NULL if the implementation
+     *  has no job shells (e.g. testexec).
+     */
+    int  (*barrier_enter) (struct jobinfo *job, const flux_msg_t *msg);
 };
+
+/*  Respond to a shell-barrier request.  These requests are sent with the
+ *  NORESPONSE flag, so flux_respond(3) will not reply to them; these helpers
+ *  build and send the response by hand.
+ */
+int shell_barrier_respond (flux_t *h, const flux_msg_t *request, const char *s);
+int shell_barrier_respond_error (flux_t *h,
+                                 const flux_msg_t *request,
+                                 int errnum,
+                                 const char *errstr);
 
 /*  Exec job information */
 struct jobinfo {

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -28,7 +28,6 @@ struct flux_shell {
     int broker_rank;
     uid_t broker_owner;
     char hostname [_POSIX_HOST_NAME_MAX + 1];
-    int protocol_fd[2];
 
     optparse_t *p;
     flux_t *h;

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1063,12 +1063,6 @@ static const char *shell_conf_get (const char *name)
     return flux_conf_builtin_get (name, FLUX_CONF_AUTO);
 }
 
-static void get_protocol_fd (int *pfd)
-{
-    pfd[0] = STDIN_FILENO;
-    pfd[1] = STDOUT_FILENO;
-}
-
 struct mustache_arg {
     flux_shell_t *shell;
     flux_shell_task_t *task;
@@ -1380,8 +1374,6 @@ static void shell_initialize (flux_shell_t *shell)
     if (gethostname (shell->hostname, sizeof (shell->hostname)) < 0)
         shell_die_errno (1, "gethostname");
 
-    get_protocol_fd (shell->protocol_fd);
-
     if (!(shell->completion_refs = zhashx_new ()))
         shell_die_errno (1, "zhashx_new");
     zhashx_set_destructor (shell->completion_refs, item_free);
@@ -1500,28 +1492,63 @@ int flux_shell_add_event_context (flux_shell_t *shell,
     return rc;
 }
 
-static int shell_barrier (flux_shell_t *shell, const char *name)
+static int shell_barrier (flux_shell_t *shell)
 {
-    char buf [8];
+    flux_future_t *f;
+    flux_msg_t *msg;
+    struct flux_match match = FLUX_MATCH_RESPONSE;
 
     if (shell->info->shell_size == 1)
         return 0; // NO-OP
 
-    if (dprintf (shell->protocol_fd[1], "enter\n") != 6)
-        shell_die_errno (1, "shell_barrier: dprintf");
-
-    /*  Note: The only expected values currently are "exit=0\n"
-     *   for success and "exit=1\n" for failure. Therefore, if
-     *   read(2) fails, or we don't receive exactly "exit=0\n",
-     *   then this barrier has failed. We exit immediately since
-     *   the reason for the failed barrier has likely been logged
-     *   elsewhere.
+    /*  Enter the barrier by sending a request to job-exec and blocking for
+     *   the response.  A successful (empty) response releases the barrier;
+     *   an error response means the barrier failed.  The request is routed
+     *   to the job-exec instance that owns the job (FLUX_NODEID_ANY).  The
+     *   broker rank is included so job-exec can identify shells that have
+     *   not yet entered.
+     *
+     *  The request is sent with FLUX_RPC_NORESPONSE so that the broker does
+     *   not allocate a matchtag or track it for disconnect: when a large job
+     *   aborts during the barrier, this avoids a storm of disconnect messages
+     *   to the job-exec leader.  Because there is no matchtag, the response
+     *   is matched on topic string; there is at most one barrier outstanding
+     *   per shell, and the response's route stack ensures it is delivered
+     *   here, so the topic match is unambiguous.
      */
-    memset (buf, 0, sizeof (buf));
-    if (read (shell->protocol_fd[0], buf, 7) < 0)
-        shell_die_errno (1, "shell_barrier: read");
-    if (!streq (buf, "exit=0\n"))
+    if (!(f = flux_rpc_pack (shell->h,
+                             "job-exec.shell-barrier",
+                             FLUX_NODEID_ANY,
+                             FLUX_RPC_NORESPONSE,
+                             "{s:I s:i}",
+                             "id", shell->jobid,
+                             "rank", shell->broker_rank)))
+        shell_die_errno (1, "shell_barrier: flux_rpc_pack");
+    flux_future_destroy (f);
+
+    /*  Block waiting for the barrier response.  The reactor is not running
+     *   at this point, so a synchronous flux_recv() is used.
+     */
+    match.topic_glob = "job-exec.shell-barrier";
+    if (!(msg = flux_recv (shell->h, match, 0)))
+        shell_die_errno (1, "shell_barrier: flux_recv");
+    if (flux_response_decode (msg, NULL, NULL) < 0) {
+        /*  EIO is the expected "barrier failed" response: job-exec has
+         *   already raised a job exception describing the cause, so a
+         *   diagnostic here would only duplicate it across every shell.
+         *   Any other error is not recorded elsewhere, so log it.
+         */
+        if (errno != EIO) {
+            const char *errstr;
+            if (flux_response_decode_error (msg, &errstr) == 0)
+                shell_log_error ("shell_barrier: %s", errstr);
+            else
+                shell_log_error ("shell_barrier: %s", strerror (errno));
+        }
+        flux_msg_destroy (msg);
         exit (1);
+    }
+    flux_msg_destroy (msg);
     return 0;
 }
 
@@ -2134,7 +2161,7 @@ int main (int argc, char *argv[])
 
     /* Barrier to ensure initialization has completed across all shells.
      */
-    if (shell_barrier (&shell, "init") < 0)
+    if (shell_barrier (&shell) < 0)
         shell_die_errno (1, "shell_barrier");
 
     /*  Emit an event after barrier completion from rank 0
@@ -2156,7 +2183,7 @@ int main (int argc, char *argv[])
     if (shell_start (&shell) < 0)
         shell_die_errno (1, "shell.start callback(s) failed");
 
-    if (shell_barrier (&shell, "start") < 0)
+    if (shell_barrier (&shell) < 0)
         shell_die_errno (1, "shell_barrier");
 
     /*  Emit an event after barrier completion from rank 0

--- a/t/job-exec/dummy.sh
+++ b/t/job-exec/dummy.sh
@@ -180,11 +180,21 @@ barrier_hang()
 }
 barrier() {
     if [[ ${NNODES} -gt 1 ]]; then
-        echo enter >&1
-        read -u 0 line
-        if [[ ${line##*=} -ne 0 ]]; then
-            exit ${line##*=}
-        fi
+        #  Enter the shell barrier by sending a NORESPONSE job-exec.shell-barrier
+        #  request and blocking for the response matched on topic string,
+        #  mirroring what the real job shell does.  An error response means the
+        #  barrier failed, so exit nonzero as the old byte protocol did on
+        #  "exit=1".
+        flux python -c "
+import flux
+from flux.constants import FLUX_RPC_NORESPONSE, FLUX_MSGTYPE_RESPONSE
+h = flux.Flux()
+h.rpc('job-exec.shell-barrier',
+      {'id': $JOBID, 'rank': $BROKER_RANK},
+      flags=FLUX_RPC_NORESPONSE)
+msg = h.recv(type_mask=FLUX_MSGTYPE_RESPONSE)
+msg.decode()
+" || exit 1
     fi
 }
 


### PR DESCRIPTION
Problem: the shell init/start barrier is implemented as a byte protocol on the job shell's stdin/stdout, but this is difficult to recover across an instance restart.

Add a job-exec.shell-barrier RPC method with the following characteristics:
- One request (barrier enter), one response (barrier exit or error)
- Request specifies rank and jobid; requestor must be job owner
- Same termination semantics (corner cases, timeouts) as before

Update job shell and the dummy.sh test shell to use the new protocol

Assisted-by: Claude:opus-4.8