### PR TITLE
add subprocess server caching of output for waitable subprocesses

### DIFF
--- a/doc/man1/flux-sproc.rst
+++ b/doc/man1/flux-sproc.rst
@@ -8,7 +8,7 @@ SYNOPSIS
 
 **flux** **sproc** *ps* [*-n*] [*--rank=RANK*] [*--service=SERVICE*] [*--format=FORMAT*]
 **flux** **sproc** *kill* [*-w*] [*--rank=RANK*] [*--service=SERVICE*] *SIGNUM* *PID|LABEL*
-**flux** **sproc** *wait* [*--rank=RANK*] [*--service=SERVICE*] *PID|LABEL*
+**flux** **sproc** *wait* [*-o*] [*--rank=RANK*] [*--service=SERVICE*] *PID|LABEL*
 
 
 DESCRIPTION
@@ -107,6 +107,12 @@ Wait for a waitable subprocess to complete and return its exit status.
 .. option:: -s, --service=NAME
 
    Wait via the specified service. The default is **rexec**.
+
+.. option:: -o, --output
+
+   Write any output retained by the server for the subprocess to stdout and
+   stderr, according to the stream of each output record. The amount of
+   retained output is server-defined and may be incomplete or empty.
 
 .. option:: PID|LABEL
 

--- a/src/bindings/python/flux/subprocess.py
+++ b/src/bindings/python/flux/subprocess.py
@@ -8,6 +8,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import base64
 import json
 import os
 import threading
@@ -228,6 +229,63 @@ class SubprocessWaitRPC(RPC):
                 os.WEXITSTATUS(), etc.
         """
         return self.get()["status"]
+
+    def get_output(self):
+        """
+        Return output retained by the server for a background subprocess.
+
+        The server may retain a bounded, possibly incomplete amount of the
+        most recent output produced by a waitable background subprocess. Each
+        element is an RFC 42 I/O object (a dict with keys ``stream``, ``rank``,
+        ``data``, and optionally ``encoding``). The list is empty if the server
+        retained no output.
+
+        Returns:
+            list: retained I/O objects in the order produced
+        """
+        return self.get().get("output", [])
+
+    def _stream_bytes(self, stream):
+        """Concatenate the decoded data of retained I/O objects for a stream."""
+        result = b""
+        for io in self.get_output():
+            if io.get("stream") != stream:
+                continue
+            data = io.get("data")
+            if data is None:
+                continue
+            if io.get("encoding") == "base64":
+                data = base64.b64decode(data)
+            else:
+                data = data.encode("utf-8", errors="surrogateescape")
+            result += data
+        return result
+
+    @property
+    def stdout(self):
+        """Retained standard output as bytes.
+
+        This concatenates the ``data`` of all retained stdout I/O objects,
+        matching the familiar interface of :obj:`subprocess.CompletedProcess`.
+        The result may be empty if the server retained no stdout.
+
+        Returns:
+            bytes: retained standard output
+        """
+        return self._stream_bytes("stdout")
+
+    @property
+    def stderr(self):
+        """Retained standard error as bytes.
+
+        This concatenates the ``data`` of all retained stderr I/O objects,
+        matching the familiar interface of :obj:`subprocess.CompletedProcess`.
+        The result may be empty if the server retained no stderr.
+
+        Returns:
+            bytes: retained standard error
+        """
+        return self._stream_bytes("stderr")
 
 
 def wait(

--- a/src/cmd/flux-sproc.py
+++ b/src/cmd/flux-sproc.py
@@ -9,6 +9,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import base64
 import errno
 import logging
 import os
@@ -45,6 +46,27 @@ def pid_or_label(arg):
     except ValueError:
         # arg is not an integer
         return None, str(arg)
+
+
+def print_output(output):
+    """
+    Write retained I/O objects to stdout/stderr by stream.
+
+    Each object is an RFC 42 I/O object as returned by the wait RPC. Data is
+    written to the file object matching its stream ("stdout" to stdout,
+    anything else to stderr) so that streams can be redirected independently.
+    """
+    for io in output:
+        data = io.get("data")
+        if data is None:
+            continue
+        if io.get("encoding") == "base64":
+            data = base64.b64decode(data)
+        else:
+            data = data.encode("utf-8", errors="surrogateescape")
+        fp = sys.stdout if io.get("stream") == "stdout" else sys.stderr
+        fp.buffer.write(data)
+        fp.buffer.flush()
 
 
 def kill(args):
@@ -90,7 +112,10 @@ def wait(args):
         rpc = subprocess.wait(
             h, pid=pid, label=label, service=args.service, nodeid=args.rank
         )
-        exit_with_status(rpc.get_status())
+        status = rpc.get_status()
+        if args.output:
+            print_output(rpc.get_output())
+        exit_with_status(status)
     except OSError as exc:
         LOGGER.error(f"wait: {exc}")
         sys.exit(1)
@@ -164,6 +189,12 @@ def main():
     wait_parser = subparsers.add_parser(
         "wait",
         parents=[common_parser],
+    )
+    wait_parser.add_argument(
+        "-o",
+        "--output",
+        action="store_true",
+        help="write any output retained by the server to stdout/stderr",
     )
     wait_parser.add_argument("pid")
     wait_parser.set_defaults(func=wait)

--- a/src/common/libioencode/ioencode.c
+++ b/src/common/libioencode/ioencode.c
@@ -116,8 +116,17 @@ static int decode_data_base64 (char *src,
         if (lenp)
             *lenp = rc;
     }
-    else if (lenp)
-        *lenp = size;
+    else if (lenp) {
+        /* Compute the exact decoded length without decoding: the base64
+         * buffer size overcounts by the number of '=' pad characters.
+         */
+        size_t npad = 0;
+        if (srclen >= 1 && src[srclen - 1] == '=')
+            npad++;
+        if (srclen >= 2 && src[srclen - 2] == '=')
+            npad++;
+        *lenp = size >= npad ? size - npad : 0;
+    }
     return 0;
 }
 
@@ -169,7 +178,10 @@ int iodecode (json_t *o,
     if (datap || lenp) {
         if (data) {
             if (encoding && streq (encoding, "base64")) {
-                if (decode_data_base64 (data, len, &bufp, &bin_len) < 0)
+                if (decode_data_base64 (data,
+                                        len,
+                                        datap ? &bufp : NULL,
+                                        &bin_len) < 0)
                     return -1;
             }
             else {

--- a/src/common/libioencode/test/ioencode.c
+++ b/src/common/libioencode/test/ioencode.c
@@ -133,6 +133,23 @@ static void binary_data (void)
     ok (len == sizeof (buffer),
         "len is correct");
     json_decref (o);
+
+    /* base64 of data whose length is not a multiple of 3 is padded with
+     * '=' characters.  Verify the NULL-data length query returns the exact
+     * decoded length rather than the padded buffer size.
+     */
+    for (int n = 13; n <= 14; n++) {
+        ok ((o = ioencode ("stdout", "1", buffer, n, false)) != NULL,
+            "ioencode of %d binary bytes works", n);
+        ok (json_unpack (o, "{s:s}", "encoding", &encoding) == 0
+            && streq (encoding, "base64"),
+            "ioencode used base64 encoding");
+        ok (iodecode (o, &stream, &rank, NULL, &len, &eof) == 0,
+            "iodecode length query succeeds");
+        ok (len == n,
+            "iodecode length query returns exact len %d (got %d)", n, len);
+        json_decref (o);
+    }
 }
 
 int main (int argc, char *argv[])

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -84,6 +84,11 @@
  *   a wait is rejected if a client is attached, and an attach is rejected if
  *   a wait is pending (both EBUSY).
  *
+ * - A waitable process retains a bounded amount of its most recent output
+ *   (RETAINED_OUTPUT_MAX) which is returned in the wait response "output"
+ *   array.  Output beyond the cap is dropped oldest-first.  This is distinct
+ *   from attach, which does not replay output produced before the attach.
+ *
  * ATTACH BEHAVIOR
  * ---------------
  * - A client may attach to a running background subprocess (by pid or label)
@@ -152,6 +157,13 @@
 #include "sigchld.h"
 
 extern char **environ;
+
+/* Coarse upper bound on the amount of a waitable background subprocess's
+ * output retained for delivery in the wait response (see wait_notify()).
+ * When exceeded, the oldest whole io objects are dropped so the most recent
+ * output is kept.  This bounds both server memory and wait response size.
+ */
+#define RETAINED_OUTPUT_MAX 8192
 
 /* Keys used to store subprocess server, exec request
  * (i.e. rexec.exec), and 'subprocesses' zlistx handle in the
@@ -361,10 +373,19 @@ static inline void clear_waitable (flux_subprocess_t *p)
 static void wait_notify (subprocess_server_t *s, flux_subprocess_t *p)
 {
     if (is_waitable (p) && !flux_subprocess_active (p) && p->waiter) {
-        if (flux_respond_pack (s->h,
-                               p->waiter,
-                               "{s:i}",
-                               "status", flux_subprocess_status (p)) < 0)
+        int rc;
+        if (p->retained_output && json_array_size (p->retained_output) > 0)
+            rc = flux_respond_pack (s->h,
+                                    p->waiter,
+                                    "{s:i s:O}",
+                                    "status", flux_subprocess_status (p),
+                                    "output", p->retained_output);
+        else
+            rc = flux_respond_pack (s->h,
+                                    p->waiter,
+                                    "{s:i}",
+                                    "status", flux_subprocess_status (p));
+        if (rc < 0)
             llog_error (s, "wait respond pid %d", flux_subprocess_pid (p));
         clear_waitable (p);
     }
@@ -668,6 +689,44 @@ error:
     return rv;
 }
 
+/* Retain a copy of one line/chunk of output from a waitable background
+ * subprocess for later delivery in the wait response.  'data' has length
+ * 'len' (> 0; EOF records are not retained since the wait response is itself
+ * the stream terminator).  Oldest whole io objects are dropped to keep the
+ * total retained data within RETAINED_OUTPUT_MAX.  A best effort operation:
+ * on failure the output is simply not retained.
+ */
+static void proc_retain_output (subprocess_server_t *s,
+                                flux_subprocess_t *p,
+                                const char *stream,
+                                const char *data,
+                                int len)
+{
+    char rankstr[64];
+    json_t *io;
+
+    if (!p->retained_output && !(p->retained_output = json_array ()))
+        return;
+    snprintf (rankstr, sizeof (rankstr), "%d", s->rank);
+    if (!(io = ioencode (stream, rankstr, data, len, false)))
+        return;
+    if (json_array_append_new (p->retained_output, io) < 0)
+        return;
+    p->retained_bytes += len;
+
+    /* Drop oldest io objects until back within the cap, but always keep at
+     * least one so a single oversized record is retained whole (uncapped).
+     */
+    while (p->retained_bytes > RETAINED_OUTPUT_MAX
+           && json_array_size (p->retained_output) > 1) {
+        json_t *old = json_array_get (p->retained_output, 0);
+        int oldlen = 0;
+        if (iodecode (old, NULL, NULL, NULL, &oldlen, NULL) == 0)
+            p->retained_bytes -= oldlen;
+        json_array_remove (p->retained_output, 0);
+    }
+}
+
 static void proc_output_cb (flux_subprocess_t *p, const char *stream)
 {
     subprocess_server_t *s = flux_subprocess_aux_get (p, srvkey);
@@ -715,6 +774,11 @@ static void proc_output_cb (flux_subprocess_t *p, const char *stream)
         else
             llog_info (s, "%s[%d]: %s", label, (int)p->pid, buf);
     }
+    /* A waitable background process retains a bounded amount of its most
+     * recent output for delivery in the wait response (ignore EOF).
+     */
+    if (is_waitable (p) && len)
+        proc_retain_output (s, p, stream, buf, len);
     return;
 
 error:

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -163,6 +163,8 @@ static void subprocess_free (flux_subprocess_t *p)
             sigchld_finalize ();
         }
 
+        json_decref (p->retained_output);
+
         free (p);
         errno = saved_errno;
     }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -231,6 +231,11 @@ flux_future_t *flux_rexec_bg (flux_t *h,
  * The future will be fulfilled with the RPC payload `{"status":i}` on
  * process completion, or with an error response if there is an error, and
  * may be unpacked with `flux_rpc_get_unpack(3)`.
+ *
+ * The payload MAY also contain an optional "output" key: an array of RFC 42
+ * I/O objects holding a bounded amount of the subprocess's most recent
+ * output retained by the server.  The retained output MAY be incomplete and
+ * the key is absent if the server retained none.
  */
 flux_future_t *flux_rexec_wait (flux_t *h,
                                 const char *service_name,

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -11,6 +11,7 @@
 #ifndef _SUBPROCESS_PRIVATE_H
 #define _SUBPROCESS_PRIVATE_H
 
+#include <jansson.h>
 #include <flux/idset.h>
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "subprocess.h"
@@ -122,6 +123,8 @@ struct flux_subprocess {
     const flux_msg_t *waiter;   /* subprocess wait request */
     int rexec_flags;            /* RFC 42 exec 'flags' proc was started with */
     bool attached;              /* a client is attached to this bg process */
+    json_t *retained_output;    /* array of recent io objects (waitable bg) */
+    size_t retained_bytes;      /* running total of retained data bytes */
 };
 
 void subprocess_check_completed (flux_subprocess_t *p);

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -979,6 +979,149 @@ void background_waitable_test (flux_t *h)
     bg_test (h, "stdin-eof", 1, cmd_cat, 0, false);
 }
 
+/* Concatenate the "data" of all retained io objects matching 'stream' in the
+ * wait response "output" array into 'buf' (NUL terminated).  Returns the
+ * number of matching io objects, or -1 if the output key is absent.
+ */
+static int collect_output (json_t *output, const char *stream, char *buf, size_t bufsize)
+{
+    size_t i;
+    int count = 0;
+
+    buf[0] = '\0';
+    if (!output)
+        return -1;
+    for (i = 0; i < json_array_size (output); i++) {
+        const char *s;
+        char *data = NULL;
+        int len = 0;
+        if (iodecode (json_array_get (output, i), &s, NULL, &data, &len, NULL) < 0)
+            continue;
+        if (data && streq (s, stream)) {
+            size_t used = strlen (buf);
+            if (used + len < bufsize) {
+                memcpy (buf + used, data, len);
+                buf[used + len] = '\0';
+            }
+            count++;
+        }
+        free (data);
+    }
+    return count;
+}
+
+/* Start a waitable background subprocess that emits known output, wait for
+ * it, and verify the retained output is returned in the wait response.
+ */
+void background_output_test (flux_t *h)
+{
+    char *av[] = { TEST_SUBPROCESS_DIR "test_echo", "-E", "foo", "bar", NULL };
+    flux_cmd_t *cmd;
+    flux_future_t *f;
+    int status = -1;
+    json_t *output = NULL;
+    char errbuf[1024];
+    int rc;
+
+    if (!(cmd = flux_cmd_create (ARRAY_SIZE (av) - 1, av, environ)))
+        BAIL_OUT ("flux_cmd_create failed");
+    ok (flux_cmd_set_label (cmd, "output") == 0,
+        "output: set cmd label");
+    f = flux_rexec_bg (h,
+                       SERVER_NAME,
+                       FLUX_NODEID_ANY,
+                       FLUX_SUBPROCESS_FLAGS_WAITABLE,
+                       cmd);
+    flux_cmd_destroy (cmd);
+    if (!f)
+        BAIL_OUT ("output: flux_rexec_bg failed");
+    ok (flux_rpc_get (f, NULL) == 0,
+        "output: flux_rexec_bg returned success");
+    flux_future_destroy (f);
+
+    f = flux_rexec_wait (h, SERVER_NAME, FLUX_NODEID_ANY, -1, "output");
+    if (!f)
+        BAIL_OUT ("output: flux_rexec_wait failed");
+    ok (flux_rpc_get_unpack (f, "{s:i s?o}", "status", &status, "output", &output) == 0,
+        "output: wait response unpacked");
+    ok (status == 0,
+        "output: exited 0 (got 0x%04x)", status);
+    rc = collect_output (output, "stderr", errbuf, sizeof (errbuf));
+    ok (rc > 0,
+        "output: wait response contains stderr output (%d objects)", rc);
+    ok (streq (errbuf, "foo\nbar\n"),
+        "output: retained stderr is correct (got '%s')", errbuf);
+    flux_future_destroy (f);
+}
+
+/* Emit far more output than RETAINED_OUTPUT_MAX and verify the wait response
+ * retains only a bounded, most-recent tail: the last line survives, the first
+ * is evicted, and the total retained data does not greatly exceed the cap.
+ */
+void background_output_cap_test (flux_t *h)
+{
+    /* NLINES args x ~LINELEN bytes each greatly exceeds the 8192 byte cap. */
+#define NLINES 40
+#define LINELEN 500
+    char lines[NLINES][LINELEN + 1];
+    char *av[NLINES + 3];
+    flux_cmd_t *cmd;
+    flux_future_t *f;
+    json_t *output = NULL;
+    char outbuf[65536];
+    int status = -1;
+    int i;
+
+    av[0] = TEST_SUBPROCESS_DIR "test_echo";
+    av[1] = "-O";
+    for (i = 0; i < NLINES; i++) {
+        /* Each line is "L<nnnnn>" followed by 'x' padding to LINELEN. */
+        int n = snprintf (lines[i], sizeof (lines[i]), "L%05d", i);
+        memset (lines[i] + n, 'x', LINELEN - n);
+        lines[i][LINELEN] = '\0';
+        av[i + 2] = lines[i];
+    }
+    av[NLINES + 2] = NULL;
+
+    if (!(cmd = flux_cmd_create (NLINES + 2, av, environ)))
+        BAIL_OUT ("flux_cmd_create failed");
+    ok (flux_cmd_set_label (cmd, "cap") == 0,
+        "cap: set cmd label");
+    f = flux_rexec_bg (h,
+                       SERVER_NAME,
+                       FLUX_NODEID_ANY,
+                       FLUX_SUBPROCESS_FLAGS_WAITABLE,
+                       cmd);
+    flux_cmd_destroy (cmd);
+    if (!f)
+        BAIL_OUT ("cap: flux_rexec_bg failed");
+    ok (flux_rpc_get (f, NULL) == 0,
+        "cap: flux_rexec_bg returned success");
+    flux_future_destroy (f);
+
+    f = flux_rexec_wait (h, SERVER_NAME, FLUX_NODEID_ANY, -1, "cap");
+    if (!f)
+        BAIL_OUT ("cap: flux_rexec_wait failed");
+    ok (flux_rpc_get_unpack (f,
+                             "{s:i s?o}",
+                             "status", &status,
+                             "output", &output) == 0,
+        "cap: wait response unpacked");
+    ok (status == 0,
+        "cap: exited 0 (got 0x%04x)", status);
+    (void)collect_output (output, "stdout", outbuf, sizeof (outbuf));
+    ok (strstr (outbuf, "L00039") != NULL,
+        "cap: most recent line retained");
+    ok (strstr (outbuf, "L00000") == NULL,
+        "cap: oldest line evicted");
+    ok (strlen (outbuf) <= 8192 + LINELEN + 1,
+        "cap: retained output bounded near cap (got %zu bytes)",
+        strlen (outbuf));
+    flux_future_destroy (f);
+#undef NLINES
+#undef LINELEN
+}
+
 /* Per RFC 42, the write-credit and stdio-fallthrough flags request input
  * handling and are not permitted in background mode.  Send raw exec RPCs to
  * verify each is rejected.
@@ -1082,6 +1225,10 @@ int main (int argc, char *argv[])
     sigstop_test (h);
     diag ("background_test");
     background_waitable_test (h);
+    diag ("background_output_test");
+    background_output_test (h);
+    diag ("background_output_cap_test");
+    background_output_cap_test (h);
     diag ("background_input_reject_test");
     background_input_reject_test (h);
     diag ("attach_test");

--- a/t/python/t0036-subprocess.py
+++ b/t/python/t0036-subprocess.py
@@ -341,6 +341,51 @@ class TestSubprocessWait(unittest.TestCase):
         with self.assertRaises(OSError):
             subprocess.wait(h, label="wait-twice").get()
 
+    def test_wait_output_retained(self):
+        """Test wait returns output retained by the server"""
+        h = flux.Flux()
+        rpc = subprocess.rexec_bg(h, ["sh", "-c", "echo hello >&2"], waitable=True)
+        pid = rpc.get_pid()
+        wait_rpc = subprocess.wait(h, pid=pid)
+        wait_rpc.get_status()
+        output = wait_rpc.get_output()
+        self.assertIsInstance(output, list)
+        data = "".join(io["data"] for io in output if io.get("stream") == "stderr")
+        self.assertIn("hello", data)
+
+    def test_wait_output_empty(self):
+        """Test get_output returns empty list when no output retained"""
+        h = flux.Flux()
+        rpc = subprocess.rexec_bg(h, ["true"], waitable=True)
+        pid = rpc.get_pid()
+        wait_rpc = subprocess.wait(h, pid=pid)
+        wait_rpc.get_status()
+        self.assertEqual(wait_rpc.get_output(), [])
+
+    def test_wait_stdout_stderr_properties(self):
+        """Test .stdout/.stderr properties return retained output as bytes"""
+        h = flux.Flux()
+        rpc = subprocess.rexec_bg(
+            h, ["sh", "-c", "echo out; echo err >&2"], waitable=True
+        )
+        pid = rpc.get_pid()
+        wait_rpc = subprocess.wait(h, pid=pid)
+        wait_rpc.get_status()
+        self.assertIsInstance(wait_rpc.stdout, bytes)
+        self.assertIsInstance(wait_rpc.stderr, bytes)
+        self.assertIn(b"out", wait_rpc.stdout)
+        self.assertIn(b"err", wait_rpc.stderr)
+
+    def test_wait_stdout_stderr_empty(self):
+        """Test .stdout/.stderr return empty bytes when no output retained"""
+        h = flux.Flux()
+        rpc = subprocess.rexec_bg(h, ["true"], waitable=True)
+        pid = rpc.get_pid()
+        wait_rpc = subprocess.wait(h, pid=pid)
+        wait_rpc.get_status()
+        self.assertEqual(wait_rpc.stdout, b"")
+        self.assertEqual(wait_rpc.stderr, b"")
+
     def test_wait_alternate_service(self):
         h = flux.Flux()
         with self.assertRaises(OSError) as ctx:

--- a/t/t0040-flux-sproc.t
+++ b/t/t0040-flux-sproc.t
@@ -162,6 +162,25 @@ test_expect_success 'flux sproc wait on already-reaped process fails' '
 	flux sproc wait already-reaped &&
 	test_must_fail flux sproc wait already-reaped 2>wait-reaped.err
 '
+test_expect_success 'flux sproc wait --output returns retained stderr' '
+	flux exec -r 0 --bg --waitable --label=wait-out \
+		sh -c "echo hello >&2" &&
+	flux sproc wait -o wait-out 2>wait-out.err &&
+	grep hello wait-out.err
+'
+test_expect_success 'flux sproc wait --output routes stdout to stdout' '
+	flux exec -r 0 --bg --waitable --label=wait-out2 \
+		sh -c "echo tothestdout" &&
+	flux sproc wait -o wait-out2 >wait-out2.out 2>wait-out2.err &&
+	grep tothestdout wait-out2.out &&
+	test_must_fail grep tothestdout wait-out2.err
+'
+test_expect_success 'flux sproc wait without --output suppresses retained output' '
+	flux exec -r 0 --bg --waitable --label=wait-noout \
+		sh -c "echo quiet >&2" &&
+	flux sproc wait wait-noout 2>wait-noout.err &&
+	test_must_fail grep quiet wait-noout.err
+'
 test_expect_success 'flux sproc with --service option works' '
 	flux sproc ps --service rexec >service-rexec.out &&
 	test_debug "cat service-rexec.out"


### PR DESCRIPTION
This implements the recently merged RFC 42 `output` key in the waitable subprocess response payload.