### PR TITLE
job-manager: pick up queue config changes on reload

### DIFF
--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -542,12 +542,21 @@ static int queue_configure (const flux_conf_t *conf,
          * named queues default to being enabled/stopped.  On initial
          * module load, job-manager may change that state based on
          * prior checkpointed information.
+         * For queues that already exist, refresh config-derived state
+         * (currently only q->requires) from the new config entry.
          */
         json_object_foreach (queues, name, value) {
-            if (!zhashx_lookup (qctx->named, name)) {
+            if (!(q = zhashx_lookup (qctx->named, name))) {
                 if (!(q = queue_create (name, value)))
                     goto nomem;
                 (void)zhashx_insert (qctx->named, name, q);
+            }
+            else {
+                json_t *requires = NULL;
+                if (json_unpack (value, "{s?O}", "requires", &requires) < 0)
+                    goto nomem;
+                json_decref (q->requires);
+                q->requires = requires;
             }
         }
     }

--- a/t/t2291-job-update-queue.t
+++ b/t/t2291-job-update-queue.t
@@ -162,4 +162,40 @@ test_expect_success 'updates are reenabled' '
 	  | grep jobspec-update \
 	  | grep attributes.system.queue=\"batch\"
 '
+#
+# Test that queue config changes are picked up on reload.
+# The debug queue initially requires property "debug". We reload
+# config changing it to require property "batch" instead. A job
+# updated into the debug queue after reload must pick up the new
+# constraint ("batch"), not the stale one ("debug").
+#
+test_expect_success 'reload config: change debug queue requires to batch property' '
+	flux config load <<-EOT
+	[queues.batch]
+	requires = [ "batch" ]
+	policy.limits.duration = "1h"
+	policy.jobspec.defaults.system.duration = "1h"
+
+	[queues.debug]
+	requires = [ "batch" ]
+	policy.limits.duration = "1m"
+	policy.jobspec.defaults.system.duration = "1m"
+
+	[queues.other]
+
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+'
+test_expect_success 'queue update uses refreshed requires after reload' '
+	jobid=$(flux submit -t 1m --urgency=hold -q other hostname) &&
+	flux update --wait $jobid queue=debug &&
+	test_debug "flux job info $jobid jobspec | jq .attributes.system.constraints" &&
+	flux job info $jobid jobspec \
+	  | jq -e ".attributes.system.constraints.properties == [\"batch\"]"
+'
+test_expect_success 'cleanup: cancel held job' '
+	flux cancel $jobid &&
+	flux job wait-event $jobid clean
+'
 test_done


### PR DESCRIPTION
Problem: When [queues] configuration is reloaded, a queue that exists in both the old and new config is not updated, so a change to a queue's "requires" list is silently ignored until the job-manager module is reloaded. The builtin .update-queue plugin then validates and rewrites job constraints using stale properties.

Refresh q->requires from the new config entry for queues that already exist in the hash. Add a test that exercises the bug.