### PR TITLE
shell: initrc: source rcs before loading plugins

### DIFF
--- a/src/shell/initrc.lua
+++ b/src/shell/initrc.lua
@@ -1,8 +1,8 @@
--- Load all *.so plugins from plugin.searchpath
-plugin.load { file = "*.so", conf = {} }
-
 -- Source all rc files under shell.rcpath/lua.d/*.lua of shell rcpath:
 shell.source_rcpath ("*.lua")
+
+-- Load all *.so plugins from plugin.searchpath
+plugin.load { file = "*.so", conf = {} }
 
 -- Attempt to load an mpi version specific rc from rcpath:
 shell.source_rcpath_option ("mpi")


### PR DESCRIPTION
Problem: other rc files cannot impact plugins at load time because plugins are loaded first

Solution: swap order to source rc files first

This is partly a question about whether there is a strong reason to prefer loading the plugins before sourcing the rc files? 

Basically, I was trying to create a `lua.d/pmix.lua` file that would set
```lua
if shell.options['pmi'] == nil then
    shell.options['pmi'] = 'pmix'
end
```
and it took me a bit to figure out why nothing was happening, until I realized the `pmix.so` plugin had _already_ tried to load before the option was set, and at that point simply did nothing because the option value was still `nil`. One could petentially just reload the plugin after setting the option, à la https://github.com/flux-framework/flux-pmix/blob/main/t/etc/rc.lua.in, but it was definitely unintuitive to me that the option seemed to have no effect at first. So it might be nicer to switch the order unless this introduces some issue I haven't thought of?