### PR TITLE
job-exec: support reloading with running jobs

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -1052,19 +1052,6 @@ static int exec_start (struct jobinfo *job)
         return -1;
     }
 
-    /*  The bulk-exec implementation cannot yet reattach to the job shells of
-     *  a job that was running before a restart.  Rather than silently launch
-     *  a fresh set of shells for a job the rest of the instance believes is
-     *  already running, fail the job explicitly.  Reattach is currently only
-     *  implemented by the testexec implementation.
-     */
-    if (job->reattach) {
-        jobinfo_fatal_error (job,
-                             ENOSYS,
-                             "reattach to running job is not implemented");
-        return -1;
-    }
-
     if (streq (exec_mock_exception (exec), "init")) {
         /* If creating an "init" mock exception, generate it and
          *  then return to simulate an exception that came in before

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1047,6 +1047,9 @@ error_release:
     return -1;
 }
 
+/*  Start execution of the job shells.  On failure, a fatal exception has
+ *   already been raised, so the caller need not raise another.
+ */
 static int jobinfo_start_execution (struct jobinfo *job)
 {
     if (job->reattach)
@@ -1108,10 +1111,8 @@ static void jobinfo_start_continue (flux_future_t *f, void *arg)
         jobinfo_fatal_error (job, errno, "failed to initialize implementation");
         goto done;
     }
-    if (jobinfo_start_execution (job) < 0) {
-        jobinfo_fatal_error (job, errno, "failed to start execution");
+    if (jobinfo_start_execution (job) < 0)
         goto done;
-    }
 done:
     jobinfo_decref (job); /* clear init reference */
     flux_future_destroy (f);

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1063,10 +1063,32 @@ error_release:
     return -1;
 }
 
-/*  Start execution of the job shells.  On failure, a fatal exception has
- *   already been raised, so the caller need not raise another.
+/*  Return 1 if the decoded exec eventlog array contains an event named
+ *   `name`, 0 if it does not, or -1 on an eventlog parse error (errno set).
+ *   A parse error is distinct from absence so the caller can report a
+ *   corrupt eventlog rather than misattributing it to a missing event.
  */
-static int jobinfo_start_execution (struct jobinfo *job)
+static int exec_eventlog_has_event (json_t *eventlog, const char *name)
+{
+    size_t index;
+    json_t *value;
+
+    json_array_foreach (eventlog, index, value) {
+        const char *n;
+        if (eventlog_entry_parse (value, NULL, &n, NULL) < 0)
+            return -1;
+        if (streq (n, name))
+            return 1;
+    }
+    return 0;
+}
+
+/*  Start (or, on reattach, re-attach to) the job shells.  On a reattach the
+ *   decoded exec eventlog is passed to the implementation for replay state;
+ *   it is NULL on a fresh start.  On failure, a fatal exception has already
+ *   been raised, so the caller need not raise another.
+ */
+static int jobinfo_start_execution (struct jobinfo *job, json_t *eventlog)
 {
     if (job->reattach)
         jobinfo_emit_event_pack_nowait (job, "re-starting", NULL);
@@ -1077,7 +1099,7 @@ static int jobinfo_start_execution (struct jobinfo *job)
      */
     job->started = 1;
     if (job->reattach) {
-        if ((*job->impl->reattach) (job, NULL) < 0) {
+        if ((*job->impl->reattach) (job, eventlog) < 0) {
             jobinfo_fatal_error (job,
                                  errno,
                                  "%s: reattach failed",
@@ -1115,19 +1137,60 @@ static int jobinfo_load_implementation (struct jobinfo *job)
     return -1;
 }
 
-/*  Dispatch a reattach.  A backend that does not implement reattach cannot
- *   recover running shells, so raise a fatal exception rather than silently
- *   relaunching the job.
+/*  Gate a reattach on the RFC 50 "recoverable" event and the loaded
+ *   implementation's ability to recover.  The job's exec.eventlog was read
+ *   from the guest namespace as the tail of the "ns" child future (see
+ *   ns_read_eventlog ()).  Require that the backend implements reattach and
+ *   that the eventlog contains a "recoverable" event, raising a fatal
+ *   exception rather than silently relaunching the job if either is missing.
+ *   The decoded eventlog is passed to the implementation for any replay state
+ *   it needs.  Returns 0 on success (execution started), -1 on failure (a
+ *   fatal exception has been raised).
  */
-static int jobinfo_reattach (struct jobinfo *job)
+static int jobinfo_reattach (struct jobinfo *job, flux_future_t *nsf)
 {
+    const char *s;
+    json_t *eventlog = NULL;
+    int rc = -1;
+
     if (!job->impl->reattach) {
         jobinfo_fatal_error (job,
                              ENOSYS,
                              "reattach to running job is not implemented");
-        return -1;
+        goto done;
     }
-    return jobinfo_start_execution (job);
+    if (flux_kvs_lookup_get (nsf, &s) < 0) {
+        jobinfo_fatal_error (job,
+                             errno,
+                             "reattach: failed to read exec.eventlog");
+        goto done;
+    }
+    if (!(eventlog = eventlog_decode (s))) {
+        jobinfo_fatal_error (job,
+                             errno,
+                             "reattach: failed to parse exec.eventlog");
+        goto done;
+    }
+    switch (exec_eventlog_has_event (eventlog, "recoverable")) {
+        case -1:
+            jobinfo_fatal_error (job,
+                                 errno,
+                                 "reattach: corrupt exec.eventlog");
+            goto done;
+        case 0:
+            jobinfo_fatal_error (job,
+                                 0,
+                                 "job is not recoverable: no recoverable event");
+            goto done;
+    }
+    /*  jobinfo_start_execution () raises its own fatal exception on failure.
+     */
+    if (jobinfo_start_execution (job, eventlog) < 0)
+        goto done;
+    rc = 0;
+done:
+    json_decref (eventlog);
+    return rc;
 }
 
 /*  Completion for jobinfo_start_init (), finish init of jobinfo using
@@ -1136,8 +1199,9 @@ static int jobinfo_reattach (struct jobinfo *job)
 static void jobinfo_start_continue (flux_future_t *f, void *arg)
 {
     struct jobinfo *job = arg;
+    flux_future_t *nsf = flux_future_get_child (f, "ns");
 
-    if (flux_future_get (flux_future_get_child (f, "ns"), NULL) < 0) {
+    if (flux_future_get (nsf, NULL) < 0) {
         jobinfo_fatal_error (job, errno, "failed to create guest ns");
         goto done;
     }
@@ -1152,18 +1216,46 @@ static void jobinfo_start_continue (flux_future_t *f, void *arg)
         goto done;
     }
     if (job->reattach) {
-        (void)jobinfo_reattach (job);
+        /*  On reattach the "ns" child future carries the job's exec.eventlog
+         *   (read once the namespace was established); gate the reattach on
+         *   the recoverable event before dispatching to the implementation.
+         */
+        (void)jobinfo_reattach (job, nsf);
         goto done;
     }
-    if (jobinfo_start_execution (job) < 0)
+    if (jobinfo_start_execution (job, NULL) < 0)
         goto done;
 done:
     jobinfo_decref (job); /* clear init reference */
     flux_future_destroy (f);
 }
 
+/*  Continuation chained onto the reattach namespace future once the guest
+ *   namespace is live: read the job's exec.eventlog from the namespace and
+ *   continue with the lookup future so jobinfo_start_continue () can consume
+ *   it via flux_kvs_lookup_get () on the "ns" child.  The recoverable-event
+ *   gate (RFC 50) is applied there.
+ */
+static void ns_read_eventlog (flux_future_t *fprev, void *arg)
+{
+    struct jobinfo *job = arg;
+    flux_t *h = flux_future_get_flux (fprev);
+    flux_future_t *f;
+
+    if (!(f = flux_kvs_lookup (h, job->ns, 0, "exec.eventlog"))) {
+        flux_future_continue_error (fprev, errno, NULL);
+        flux_future_destroy (fprev);
+        return;
+    }
+    flux_future_continue (fprev, f);
+    flux_future_destroy (fprev);
+}
+
 /*  Post the init/reattach event and (re)establish the job.<id>.guest symlink
  *   to the live guest namespace, continuing `fprev` with the combined future.
+ *   On reattach, chain a read of the job's exec.eventlog onto the combined
+ *   future so the recoverable-event gate can be applied once the namespace is
+ *   established.
  */
 static void ns_emit_and_symlink (flux_future_t *fprev, struct jobinfo *job)
 {
@@ -1186,6 +1278,12 @@ static void ns_emit_and_symlink (flux_future_t *fprev, struct jobinfo *job)
     if (!(f = namespace_symlink (h, job->id, job->ns))
         || flux_future_push (cf, "link guestns", f) < 0)
         goto error;
+    if (job->reattach) {
+        flux_future_t *ef;
+        if (!(ef = flux_future_and_then (cf, ns_read_eventlog, job)))
+            goto error;
+        cf = ef;
+    }
     flux_future_continue (fprev, cf);
     flux_future_destroy (fprev);
     return;

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1072,11 +1072,20 @@ static int jobinfo_start_execution (struct jobinfo *job)
         jobinfo_emit_event_pack_nowait (job, "re-starting", NULL);
     else
         jobinfo_emit_event_pack_nowait (job, "starting", NULL);
-    /* Set started flag before calling 'start' method because we want to
-     *  be sure to clean up properly if an exception occurs
+    /* Set started flag before calling start/reattach method because we want
+     *  to be sure to clean up properly if an exception occurs
      */
     job->started = 1;
-    if ((*job->impl->start) (job) < 0) {
+    if (job->reattach) {
+        if ((*job->impl->reattach) (job, NULL) < 0) {
+            jobinfo_fatal_error (job,
+                                 errno,
+                                 "%s: reattach failed",
+                                 job->impl->name);
+            return -1;
+        }
+    }
+    else if ((*job->impl->start) (job) < 0) {
         jobinfo_fatal_error (job, errno, "%s: start failed", job->impl->name);
         return -1;
     }
@@ -1106,6 +1115,21 @@ static int jobinfo_load_implementation (struct jobinfo *job)
     return -1;
 }
 
+/*  Dispatch a reattach.  A backend that does not implement reattach cannot
+ *   recover running shells, so raise a fatal exception rather than silently
+ *   relaunching the job.
+ */
+static int jobinfo_reattach (struct jobinfo *job)
+{
+    if (!job->impl->reattach) {
+        jobinfo_fatal_error (job,
+                             ENOSYS,
+                             "reattach to running job is not implemented");
+        return -1;
+    }
+    return jobinfo_start_execution (job);
+}
+
 /*  Completion for jobinfo_start_init (), finish init of jobinfo using
  *   data fetched from KVS
  */
@@ -1125,6 +1149,10 @@ static void jobinfo_start_continue (flux_future_t *f, void *arg)
         goto done;
     if (jobinfo_load_implementation (job) < 0) {
         jobinfo_fatal_error (job, errno, "failed to initialize implementation");
+        goto done;
+    }
+    if (job->reattach) {
+        (void)jobinfo_reattach (job);
         goto done;
     }
     if (jobinfo_start_execution (job) < 0)

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -936,20 +936,31 @@ static void ns_copy (flux_future_t *f, void *arg)
     flux_future_destroy (f);
 }
 
-/*  Graft the guest namespace for `job` into the primary namespace and
- *   remove it, first quiescing the exec.eventlog.  If `event` is non-NULL
- *   it is posted to the exec.eventlog as the final entry (e.g. "done" on
- *   job completion); pass NULL to preserve a still-running job across a
- *   restart without terminating its eventlog.
+/*  Graft the guest namespace for `job` into the primary namespace, first
+ *   quiescing the exec.eventlog.  If `event` is non-NULL it is posted to the
+ *   exec.eventlog as the final entry (e.g. "done" on job completion); pass
+ *   NULL to preserve a still-running job across a restart without terminating
+ *   its eventlog.
  *
- *  The process is a chained future of 3 parts:
+ *  If `remove` is true, remove the guest namespace after grafting (the job
+ *   has terminated, so its guest KVS content lives on only as the graft).
+ *   If false, leave the live namespace in place: the job is still running and
+ *   job-exec may be reloaded within the same KVS session, in which case
+ *   reattach adopts the still-live namespace rather than recreating it from
+ *   the graft (recreation would race the KVS async removal of the same name).
+ *   On a full broker restart the KVS restarts and the live namespace vanishes
+ *   regardless; reattach then recreates it from the graft.
+ *
+ *  The process is a chained future of 2 or 3 parts:
  *   1. Post the final event (if any) and commit the exec.eventlog, so its
  *      buffered entries are flushed to the guest namespace before it is
  *      grafted and becomes read-only.
  *   2. Graft the namespace into the primary namespace.
- *   3. Remove the guest namespace.
+ *   3. Remove the guest namespace (only if `remove`).
  */
-static flux_future_t * ns_move (struct jobinfo *job, const char *event)
+static flux_future_t * ns_move (struct jobinfo *job,
+                                const char *event,
+                                bool remove)
 {
     flux_t *h = job->ctx->h;
     flux_future_t *f = NULL;
@@ -963,8 +974,13 @@ static flux_future_t * ns_move (struct jobinfo *job, const char *event)
         goto error;
     }
     if (!(f1 = flux_future_and_then (f, ns_copy, job))
-        || !(f1 = flux_future_or_then (f, ns_copy, job))
-        || !(f2 = flux_future_and_then (f1, ns_delete, job))
+        || !(f1 = flux_future_or_then (f, ns_copy, job))) {
+        flux_log_error (h, "ns_move: flux_future_and_then");
+        goto error;
+    }
+    if (!remove)
+        return f1;
+    if (!(f2 = flux_future_and_then (f1, ns_delete, job))
         || !(f2 = flux_future_or_then (f1, ns_delete, job))) {
         flux_log_error (h, "ns_move: flux_future_and_then");
         goto error;
@@ -1033,7 +1049,7 @@ static int jobinfo_finalize (struct jobinfo *job)
     job->finalizing = 1;
 
     if (job->has_namespace) {
-        if (!(f = ns_move (job, "done"))
+        if (!(f = ns_move (job, "done", true))
             || flux_future_then (f, -1., ns_move_cb, job) < 0)
             goto error;
     }
@@ -1118,11 +1134,13 @@ done:
     flux_future_destroy (f);
 }
 
-static void ns_link (flux_future_t *fprev, void *arg)
+/*  Post the init/reattach event and (re)establish the job.<id>.guest symlink
+ *   to the live guest namespace, continuing `fprev` with the combined future.
+ */
+static void ns_emit_and_symlink (flux_future_t *fprev, struct jobinfo *job)
 {
     int saved_errno;
     flux_t *h = flux_future_get_flux (fprev);
-    struct jobinfo *job = arg;
     flux_future_t *cf = NULL;
     flux_future_t *f = NULL;
 
@@ -1150,6 +1168,34 @@ error:
     flux_future_destroy (fprev);
 }
 
+static void ns_link (flux_future_t *fprev, void *arg)
+{
+    ns_emit_and_symlink (fprev, arg);
+}
+
+/*  Error continuation for the reattach namespace create.  A reattaching job
+ *   whose guest namespace is still live in the same KVS session (e.g. a
+ *   job-exec module reload rather than a full broker restart) gets EEXIST
+ *   from namespace_create: the namespace was grafted but not removed on
+ *   unload, so it is still present and current.  Adopt it in place --
+ *   re-post the reattach event and restore the symlink -- rather than
+ *   failing the job.  Any other error is fatal.
+ */
+static void ns_adopt (flux_future_t *fprev, void *arg)
+{
+    struct jobinfo *job = arg;
+    int errnum = 0;
+
+    if (flux_future_get (fprev, NULL) < 0)
+        errnum = errno;
+    if (job->reattach && errnum == EEXIST) {
+        ns_emit_and_symlink (fprev, job);
+        return;
+    }
+    flux_future_continue_error (fprev, errnum, NULL);
+    flux_future_destroy (fprev);
+}
+
 static flux_future_t *ns_create_and_link (flux_t *h, struct jobinfo *job)
 {
     flux_future_t *f = NULL;
@@ -1164,7 +1210,9 @@ static flux_future_t *ns_create_and_link (flux_t *h, struct jobinfo *job)
      */
     job->has_namespace = 1;
 
-    if (!f || !(f2 = flux_future_and_then (f, ns_link, job))) {
+    if (!f
+        || !(f2 = flux_future_and_then (f, ns_link, job))
+        || !(f2 = flux_future_or_then (f, ns_adopt, job))) {
         flux_log_error (h, "ns_create_and_link: flux_future_and_then");
         flux_future_destroy (f);
         return NULL;
@@ -1762,11 +1810,13 @@ static int configure_implementations (flux_t *h, int argc, char **argv)
 }
 
 /*  On module unload, graft each running job's guest namespace into the
- *   primary namespace (as a dirref at job.<id>.guest) and remove it, so the
- *   namespace is preserved across a restart: its content is reachable from
- *   the primary root, protected by KVS garbage collection and captured by
- *   the shutdown content dump.  No terminating event is posted since the
- *   jobs are still running and will be reattached.
+ *   primary namespace (as a dirref at job.<id>.guest) without removing the
+ *   live namespace, so the content is preserved across a restart: it is
+ *   reachable from the primary root, protected by KVS garbage collection and
+ *   captured by the shutdown content dump.  Retaining the live namespace lets
+ *   a same-KVS reload reattach by adopting it in place (see ns_adopt()).  No
+ *   terminating event is posted since the jobs are still running and will be
+ *   reattached.
  */
 static int graft_running_ns (struct job_exec_ctx *ctx)
 {
@@ -1782,7 +1832,7 @@ static int graft_running_ns (struct job_exec_ctx *ctx)
                     goto cleanup;
                 flux_future_set_flux (fall, ctx->h);
             }
-            if (!(f = ns_move (job, NULL)))
+            if (!(f = ns_move (job, NULL, false)))
                 goto cleanup;
             if (flux_future_push (fall, job->ns, f) < 0)
                 goto cleanup;

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -40,6 +40,15 @@ struct jobinfo;
  *
  *   - start:   start execution of job
  *
+ *   - reattach:
+ *              (optional) reattach to the already-running job shells of a
+ *              recovered job. Present if and only if the implementation can
+ *              recover running shells; a NULL reattach means the
+ *              implementation cannot reattach, and a reattach attempt is a
+ *              fatal error. The decoded exec eventlog (RFC 50) is passed in
+ *              for the implementation to consult for replay state; ownership
+ *              is retained by the caller. See also the "recoverable" event.
+ *
  *   - kill:    signal executing job shells, e.g. due to exception or other
  *              fatal error.
  *
@@ -61,6 +70,7 @@ struct exec_implementation {
     int  (*init)    (struct jobinfo *job);
     void (*exit)    (struct jobinfo *job);
     int  (*start)   (struct jobinfo *job);
+    int  (*reattach) (struct jobinfo *job, json_t *eventlog);
     int  (*kill)    (struct jobinfo *job, int signum);
     int  (*cancel)  (struct jobinfo *job);
     json_t * (*stats) (struct jobinfo *job);

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -199,8 +199,13 @@ static int start_timer (flux_t *h, struct testexec *te, double t)
         }
         if (te->job->reattach)
             jobinfo_reattached (te->job);
-        else
+        else {
             jobinfo_started (te->job);
+            /*  testexec is always recoverable: post the RFC 50 recoverable
+             *   event so a reattach after a restart is permitted.
+             */
+            jobinfo_emit_event_pack_nowait (te->job, "recoverable", NULL);
+        }
     }
     else
         return -1;

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -326,23 +326,27 @@ static int testexec_start (struct jobinfo *job)
 {
     struct testexec *te = job->data;
 
-    if (job->reattach) {
-        if (testexec_reattach (te) < 0)
-            return -1;
+    if (!te->conf.override && start_timer (job->h,
+                                           te,
+                                           te->conf.run_duration) < 0) {
+        jobinfo_fatal_error (job, errno, "unable to start test exec timer");
+        return -1;
     }
-    else {
-        if (!te->conf.override && start_timer (job->h,
-                                               te,
-                                               te->conf.run_duration) < 0) {
-            jobinfo_fatal_error (job, errno, "unable to start test exec timer");
-            return -1;
-        }
-        if (testconf_mock_exception (&te->conf, "run")) {
-            jobinfo_fatal_error (job, 0, "mock run exception generated");
-            return -1;
-        }
+    if (testconf_mock_exception (&te->conf, "run")) {
+        jobinfo_fatal_error (job, 0, "mock run exception generated");
+        return -1;
     }
     return 0;
+}
+
+static int testexec_reattach_op (struct jobinfo *job, json_t *eventlog)
+{
+    struct testexec *te = job->data;
+
+    /*  testexec recovers its state from the job eventlog start timestamp and
+     *   does not consult the exec eventlog replay state.
+     */
+    return testexec_reattach (te);
 }
 
 static int testexec_kill (struct jobinfo *job, int signum)
@@ -519,6 +523,7 @@ struct exec_implementation testexec = {
     .init =     testexec_init,
     .exit =     testexec_exit,
     .start =    testexec_start,
+    .reattach = testexec_reattach_op,
     .kill =     testexec_kill,
     .stats =    NULL,
 };

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -664,6 +664,9 @@ int event_job_update (struct job *job, json_t *event)
         if (job->state == FLUX_JOB_STATE_SCHED)
             job->state = FLUX_JOB_STATE_RUN;
     }
+    else if (streq (name, "start")) {
+        job->started = 1;
+    }
     else if (streq (name, "free")) {
         job->has_resources = 0;
     }

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -78,6 +78,7 @@ void disconnect_rpc (flux_t *h,
      * which services a client used, so we must check all services for
      * cleanup */
     alloc_disconnect_rpc (h, mh, msg, arg);
+    start_disconnect_rpc (h, mh, msg, arg);
     wait_disconnect_rpc (h, mh, msg, arg);
     journal_listeners_disconnect_rpc (h, mh, msg, arg);
 }

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -44,7 +44,7 @@ struct job {
     uint8_t free_posted:1;  // free event already posted
     uint8_t has_resources:1;
     uint8_t start_pending:1;// start request sent to job-exec
-    uint8_t reattach:1;
+    uint8_t started:1;      // exec confirmed shells started (start event seen)
     uint8_t eventlog_readonly:1;// job is inactive or invalid
     uint8_t hold_events:1;  // queue events instead of posting immediately
     uint8_t immutable:1;    // user job updates are disabled

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -580,7 +580,6 @@ int restart_from_kvs (struct job_manager *ctx)
         }
         else if ((job->state & FLUX_JOB_STATE_RUNNING) != 0) {
             ctx->running_jobs++;
-            job->reattach = 1;
             if ((job->flags & FLUX_JOB_DEBUG)) {
                 if (event_job_post_pack (ctx->event,
                                          job,

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -225,11 +225,12 @@ static void start_response_cb (flux_t *h,
         goto error;
     }
     if (streq (type, "start")) {
-        if (job->reattach)
+        if (job->started) {
             flux_log (h,
                       LOG_ERR,
                       "start response: id=%s should not get start event",
                       idf58 (id));
+        }
         else {
             if (event_job_post_pack (ctx->event, job, "start", 0, NULL) < 0)
                 goto error_post;
@@ -336,7 +337,7 @@ int start_send_request (struct start *start, struct job *job)
                            "id", job->id,
                            "userid", (json_int_t) job->userid,
                            "jobspec", job->jobspec_redacted,
-                           "reattach", job->reattach,
+                           "reattach", job->started,
                            "R", job->R_redacted) < 0)
             goto error;
         if (flux_send (ctx->h, msg, 0) < 0)

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -100,6 +100,7 @@ struct start {
     flux_msg_handler_t **handlers;
     char *topic;
     char *update_topic;
+    const flux_msg_t *hello_request;
 };
 
 static void hello_cb (flux_t *h,
@@ -134,6 +135,12 @@ static void hello_cb (flux_t *h,
     if (asprintf (&start->topic, "%s.start", service_name) < 0
         || asprintf (&start->update_topic, "%s.expiration", service_name) < 0)
         goto error;
+    /* Cache the request so a later disconnect can be matched to the
+     * registering service (sender uuid + credentials).  See
+     * start_disconnect_rpc().
+     */
+    flux_msg_decref (start->hello_request);
+    start->hello_request = flux_msg_incref (msg);
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     /* Response has been sent, now take action on jobs in run state.
@@ -161,16 +168,21 @@ static void interface_teardown (struct start *start, char *s, int errnum)
         struct job_manager *ctx = start->ctx;
         struct job *job;
 
-        flux_log (ctx->h,
-                  LOG_DEBUG,
-                  "start: stop due to %s: %s",
-                  s,
-                  flux_strerror (errnum));
+        if (errnum)
+            flux_log (ctx->h,
+                      LOG_DEBUG,
+                      "start: stop due to %s: %s",
+                      s,
+                      flux_strerror (errnum));
+        else
+            flux_log (ctx->h, LOG_DEBUG, "start: stop due to %s", s);
 
         free (start->topic);
         free (start->update_topic);
+        flux_msg_decref (start->hello_request);
         start->topic = NULL;
         start->update_topic = NULL;
+        start->hello_request = NULL;
 
         job = zhashx_first (ctx->active_jobs);
         while (job) {
@@ -187,6 +199,19 @@ static void interface_teardown (struct start *start, char *s, int errnum)
             job = zhashx_next (ctx->active_jobs);
         }
     }
+}
+
+void start_disconnect_rpc (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct start *start = ctx->start;
+
+    if (start->hello_request
+        && flux_disconnect_match (msg, start->hello_request))
+        interface_teardown (start, "disconnect", 0);
 }
 
 static void start_response_cb (flux_t *h,
@@ -416,6 +441,7 @@ void start_ctx_destroy (struct start *start)
         flux_msg_handler_delvec (start->handlers);
         free (start->topic);
         free (start->update_topic);
+        flux_msg_decref (start->hello_request);
         free (start);
         errno = saved_errno;
     }

--- a/src/modules/job-manager/start.h
+++ b/src/modules/job-manager/start.h
@@ -24,6 +24,11 @@ int start_send_expiration_update (struct start *start,
                                   struct job *job,
                                   json_t *context);
 
+void start_disconnect_rpc (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg);
+
 #endif /* ! _FLUX_JOB_MANAGER_START_H */
 
 /*

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -52,6 +52,7 @@ LONGTESTSCRIPTS = \
 	t3200-instance-restart.t \
 	t3202-instance-restart-testexec.t \
 	t3203-instance-recovery.t \
+	t3204-job-exec-reattach-reload.t \
 	t4000-issues-test-driver.t \
 	t2800-jobs-cmd.t \
 	t2801-top-cmd.t \

--- a/t/job-manager/exec-service.lua
+++ b/t/job-manager/exec-service.lua
@@ -55,8 +55,13 @@ assert (f:msghandler {
     handler = function (f, msg, mh)
         local id = msg.data.id
         jobs[id] = { msg = msg }
-        printf ("%s: start: %d\n", service, id)
-        assert (msg:respond {id = id, type = "start", data = {}})
+        if msg.data.reattach then
+            printf ("%s: reattach: %d\n", service, id)
+            assert (msg:respond {id = id, type = "reattached", data = {}})
+        else
+            printf ("%s: start: %d\n", service, id)
+            assert (msg:respond {id = id, type = "start", data = {}})
+        end
 
         -- Launch job timer:
         jobs[id].timer = assert (f:timer {

--- a/t/t2401-job-exec-hello.t
+++ b/t/t2401-job-exec-hello.t
@@ -40,7 +40,7 @@ test_expect_success NO_CHAIN_LINT 'exec hello: job start events are paused' '
 	id=$(flux submit --flags=debug hostname) &&
 	flux job wait-event -vt 5 ${id} alloc &&
 	test_debug "flux job eventlog ${id}" &&
-	test $(lastevent ${id}) = "debug.start-lost"
+	test $(lastevent ${id}) = "alloc"
 '
 test_expect_success NO_CHAIN_LINT 'exec hello: start server with job timer' '
 	${execservice} test-exec3 30 > server3.log &
@@ -60,6 +60,34 @@ test_expect_success NO_CHAIN_LINT 'exec hello: terminate all jobs and servers' '
 	test_debug "cat server3.log" &&
 	flux job wait-event -t 2.5 ${id} clean &&
 	kill ${SERVER3}
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: start server for disconnect test' '
+	${execservice} test-exec5 30 > server5.log &
+	SERVER5=$! &&
+	flux kvs get -c 1 --watch --waitcreate test.exec-hello.test-exec5 &&
+	id5=$(flux submit --flags=debug hostname) &&
+	flux job wait-event -t 5 ${id5} start
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: removing service posts start-lost' '
+	kill -9 ${SERVER5} &&
+	wait ${SERVER5} || : &&
+	flux job wait-event -t 5 ${id5} debug.start-lost &&
+	test_debug "flux job eventlog ${id5}" &&
+	flux job wait-event -t 5 --match-context=note=disconnect \
+		${id5} debug.start-lost
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: new service reattaches lost job' '
+	${execservice} test-exec6 30 > server6.log &
+	SERVER6=$! &&
+	flux kvs get -c 1 --watch --waitcreate test.exec-hello.test-exec6 &&
+	flux job wait-event -t 5 ${id5} debug.exec-reattach-finish &&
+	test_debug "cat server6.log" &&
+	grep "test-exec6: reattach: $(flux job id ${id5})" server6.log
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: terminate disconnect-test job' '
+	flux cancel ${id5} &&
+	flux job wait-event -t 5 ${id5} clean &&
+	kill ${SERVER6}
 '
 
 test_done

--- a/t/t3204-job-exec-reattach-reload.t
+++ b/t/t3204-job-exec-reattach-reload.t
@@ -49,4 +49,59 @@ test_expect_success 'cancel job and wait for it to clean up' '
 	flux cancel ${id} &&
 	flux job wait-event -t 60 ${id} clean
 '
+# The recoverable event (RFC 50) gates reattach: without it, generic job-exec
+# code raises a fatal exception rather than relaunching the job's shells.
+# Strip the event from a running job's exec.eventlog, then reload to confirm
+# the gate fires.
+test_expect_success 'submit another job and wait for recoverable event' '
+	id2=$(flux submit --flags=debug \
+	                  --setattr=system.exec.test.run_duration=100s \
+	                  hostname) &&
+	ns2=$(flux job namespace ${id2}) &&
+	flux job wait-event -t 60 ${id2} start &&
+	run_timeout 60 flux kvs eventlog wait-event -N ${ns2} \
+	    exec.eventlog recoverable
+'
+test_expect_success 'strip recoverable event from exec.eventlog' '
+	flux kvs eventlog get -u -N ${ns2} exec.eventlog \
+	    | jq -c "select(.name != \"recoverable\")" >stripped.out &&
+	flux kvs put --raw -N ${ns2} exec.eventlog=- <stripped.out
+'
+test_expect_success 'reload job-exec module' '
+	flux module reload job-exec
+'
+test_expect_success 'non-recoverable job raises exec exception on reattach' '
+	flux job wait-event -t 60 ${id2} exception &&
+	flux job eventlog ${id2} >eventlog2.out &&
+	test_debug "cat eventlog2.out" &&
+	grep -q "type=\"exec\"" eventlog2.out &&
+	grep -q "job is not recoverable" eventlog2.out
+'
+test_expect_success 'clean up non-recoverable job' '
+	flux job wait-event -t 60 ${id2} clean
+'
+# The real (bulk-exec) executor does not implement reattach, so the generic
+# gate raises a fatal exception rather than relaunching the shells -- the same
+# terminal behavior as a full restart (t3202), but reached via the module
+# reload / in-place namespace adoption path.  --input=/dev/null avoids the
+# shell's KVS stdin watcher, which is not torn down by a bare module reload
+# but is left in flight otherwise; dropping it keeps the reattach reject the
+# only thing that can fail the job.
+test_expect_success 'submit a real (bulk-exec) job and wait for start' '
+	id3=$(flux submit --flags=debug --input=/dev/null \
+	                  --wait-event=start sleep 300)
+'
+test_expect_success 'reload job-exec module' '
+	flux module reload job-exec
+'
+test_expect_success 'bulk-exec job raises exec exception on reattach' '
+	flux job wait-event -t 60 ${id3} exception &&
+	flux job eventlog ${id3} >eventlog3.out &&
+	test_debug "cat eventlog3.out" &&
+	grep -q "type=\"exec\"" eventlog3.out &&
+	grep -q "reattach to running job is not implemented" eventlog3.out
+'
+test_expect_success 'clean up bulk-exec job' '
+	flux job wait-event -t 60 ${id3} clean
+'
 test_done

--- a/t/t3204-job-exec-reattach-reload.t
+++ b/t/t3204-job-exec-reattach-reload.t
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+test_description='Test job-exec reattach across a module reload'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+# A running job's guest namespace is grafted into the primary namespace at
+# job.<id>.guest when job-exec unloads, but (unlike a full instance restart)
+# the live namespace is retained across a module reload since the KVS
+# persists.  On reload, the job manager re-issues the job's start request with
+# reattach set, and job-exec recreates the namespace from the graft -- which
+# collides with the retained live namespace (EEXIST) and is resolved by
+# adopting the live namespace in place.  This exercises the same-KVS reattach
+# path that a full restart (t3202) does not.
+
+lastevent() { flux job eventlog $1 | awk 'END{print $2}'; }
+
+test_expect_success 'submit a long-running testexec job and wait for start' '
+	id=$(flux submit --flags=debug \
+	                 --setattr=system.exec.test.run_duration=100s \
+	                 hostname) &&
+	flux job wait-event -t 60 ${id} start
+'
+test_expect_success 'write a canary into the job guest namespace' '
+	ns=$(flux job namespace ${id}) &&
+	flux kvs put -N ${ns} warmstart.canary=hello-3204
+'
+test_expect_success 'reload job-exec module' '
+	flux module reload job-exec
+'
+test_expect_success 'job is reattached rather than relaunched' '
+	flux job wait-event -t 60 ${id} debug.exec-reattach-finish &&
+	flux job eventlog ${id} >eventlog.out &&
+	test_debug "cat eventlog.out" &&
+	grep "debug.start-lost" eventlog.out &&
+	grep "debug.exec-reattach-finish" eventlog.out
+'
+test_expect_success 'job remains in RUN state after reload' '
+	test $(flux jobs -no "{state}" ${id}) = RUN
+'
+test_expect_success 'guest namespace was adopted, canary survives' '
+	ns=$(flux job namespace ${id}) &&
+	flux kvs get -N ${ns} warmstart.canary >canary.out &&
+	grep hello-3204 canary.out
+'
+test_expect_success 'cancel job and wait for it to clean up' '
+	flux cancel ${id} &&
+	flux job wait-event -t 60 ${id} clean
+'
+test_done


### PR DESCRIPTION
This builds some infrastructure into `job-exec` and `job-manager` to support a future exec implementation that can handle restart with running jobs, and also (for simpler early testing), `job-exec` module reload with running jobs:
- allow the job's private KVS namespace to persist across a module reload
- add a new optional `reattach` implementation method (implemented by `testexec`) to promote a separation of concerns between start and reattach
- support the RFC 50 `recoverable` event so the implementation can record when initialization is complete (e.g. shell barriers)
- send a normal start request when the `start` event had not been posted, instead of attempting reattach (the implementation will need to detect and clean up any stragglers from a previous partial job startup)

Future upcoming work that builds on this
- a libsubprocess "bgexec" class, similar to bulkexec, based on `flux_rexec_bg()` and `flux_rexec_wait()`
- a `job-exec` "bgexec" exec implementation that uses the above and implements reattach to labeled shells
- some `job-exec` refactoring to separate out some code that can be used by multiple exec implementations

I figured it was safer to develop a new back end than to try to modify the existing bulkexec implementation to handle reattach, since that would let us roll out support incrementally and with a fallback option if things go horribly wrong.

Edit: note that the "service override" feature used by flux-fiction is retained here, with existing safeguards against override with running jobs.  I had brought up the idea of dropping it, so to be clear, that did not happen in this PR.  See also
- flux-framework/flux-fiction#48
