### PR TITLE
job-manager: split queue configuration/state into a standalone queues class

### DIFF
--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -63,6 +63,8 @@ libjob_manager_la_SOURCES = \
 	getattr.c \
 	prioritize.h \
 	prioritize.c \
+	queues.h \
+	queues.c \
 	queue.h \
 	queue.c \
 	jobtap-internal.h \

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -128,6 +128,7 @@ TESTS = \
 	test_raise.t \
 	test_kill.t \
 	test_restart.t \
+	test_queues.t \
 	test_annotate.t
 
 test_ldadd = \
@@ -191,6 +192,14 @@ test_restart_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/restart.o \
         $(test_ldadd)
 test_restart_t_LDFLAGS = \
+        $(test_ldflags)
+
+test_queues_t_SOURCES = test/queues.c
+test_queues_t_CPPFLAGS = $(test_cppflags)
+test_queues_t_LDADD = \
+        $(top_builddir)/src/modules/job-manager/queues.o \
+        $(test_ldadd)
+test_queues_t_LDFLAGS = \
         $(test_ldflags)
 
 test_annotate_t_SOURCES = test/annotate.c

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -8,20 +8,28 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* queue.c - job queues
+/* queue.c - job queue service layer
  *
- * The job manager currently has only one actual queue in alloc.c,
- * a vestigial design from before named queues.  Therefore, 'struct queue'
- * below is currently a container for queue state, not for jobs as one
- * might reasonably expect.
+ * This is the service layer for job queues.  All queue-table state is
+ * delegated to struct queues (queues.[ch]).  This file owns:
+ *
+ * - struct queue_ctx: job_manager back-pointer, msg handlers, queues
+ *   object, and stop_on_restart flag.
+ * - Four RPC callbacks: queue-list, queue-status, queue-enable, queue-start.
+ * - queue_configure: flux_conf_t glue.
+ * - enqueue_jobs/dequeue_jobs: driven from the change-notification callback.
+ * - queue_submit_check: submission gate.
+ * - queue_started: alloc helper.
+ * - queue_ctx_save/restore: checkpoint delegation.
+ * - .update-queue jobtap plugin.
  *
  * Notes:
- * - By default, only a single anonymous queue is defined.  If any named queues
- *   are defined, the anonymous queue is removed.
+ * - By default, only a single anonymous queue is defined.  If any named
+ *   queues are defined, the anonymous queue is removed.
  *
  * - A job requests to be in a particular queue by requiring the resource
  *   property associated with the nodes in the queue.  If it requires nothing,
- *   the anonymous queue is assumed.  the 'default' frobnicator plugin may be
+ *   the anonymous queue is assumed.  The 'default' frobnicator plugin may be
  *   configured to add a default queue name when one is unspecified.
  *
  * - When a queue is enabled, jobs submitted for that queue are accepted.
@@ -52,7 +60,6 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/jpath.h"
 #include "src/common/libutil/errno_safe.h"
-#include "src/common/libjob/idf58.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "ccan/str/str.h"
 
@@ -62,437 +69,46 @@
 #include "jobtap.h"
 #include "conf.h"
 #include "restart.h"
+#include "queues.h"
 #include "queue.h"
-
-struct queue {
-    char *name;
-    bool is_enabled;    // jobs may be submitted to this queue
-    char *disable_reason;   // reason if disabled
-    bool is_started;    // current queue state
-    bool is_started_sticky; // tracks is_started unless --nocheckpoint
-    char *stop_reason; // reason if stopped (optionally set)
-    json_t *requires;  // required properties array
-};
 
 struct queue_ctx {
     struct job_manager *ctx;
     flux_msg_handler_t **handlers;
-    union {
-        struct queue *anon;
-        zhashx_t *named;
-    };
-    bool have_named_queues;
+    struct queues *queues;
     bool stop_on_restart;   // stop started queues on restart
 };
 
+static int enqueue_jobs (struct queue_ctx *qctx, const char *name);
 static void dequeue_jobs (struct queue_ctx *qctx, const char *name);
 
-static void queue_destroy (struct queue *q)
+/* Queue change-notification callback: drives enqueue/dequeue side effects.
+ *
+ * Events and their actions:
+ *  "start"  -> enqueue_jobs (name)
+ *  "stop"   -> dequeue_jobs (name)
+ *  "remove" -> no dequeue (leave active jobs in removed queue)
+ *  all others -> no action
+ *
+ * Notifications are never fired while queues_restore() replays
+ * checkpointed state, so these side effects apply only to live
+ * administrative changes. queue_ctx_restore() cancels alloc requests
+ * for queues restored in a stopped state.
+ */
+static void on_queue_change (struct queues *queues,
+                             struct queue *q,
+                             const char *event,
+                             void *arg)
 {
-    if (q) {
-        int saved_errno = errno;
-        json_decref (q->requires);
-        free (q->name);
-        free (q->disable_reason);
-        free (q->stop_reason);
-        free (q);
-        errno = saved_errno;
+    struct queue_ctx *qctx = arg;
+
+    if (streq (event, "start")) {
+        if (enqueue_jobs (qctx, queue_name (q)) < 0)
+            flux_log_error (qctx->ctx->h,
+                            "error enqueueing jobs for started queue");
     }
-}
-
-// zhashx_destructor_fn signature
-static void queue_destructor (void **item)
-{
-    if (item) {
-        queue_destroy (*item);
-        *item = NULL;
-    }
-}
-
-static struct queue *queue_create (const char *name, json_t *config)
-{
-    struct queue *q;
-
-    if (!(q = calloc (1, sizeof (*q))))
-        return NULL;
-    if (name && !(q->name = strdup (name)))
-        goto error;
-    q->is_enabled = true;
-
-    if (config && json_unpack (config, "{s?O}", "requires", &q->requires) < 0)
-        goto error;
-
-    /* The anonymous queue begins life started, while named queues do not.
-     */
-    if (name)
-        q->is_started_sticky = q->is_started = false;
-    else
-        q->is_started_sticky = q->is_started = true;
-    return q;
-error:
-    queue_destroy (q);
-    return NULL;
-}
-
-static struct queue *queue_first (struct queue_ctx *qctx)
-{
-    if (qctx->have_named_queues)
-        return zhashx_first (qctx->named);
-    return qctx->anon;
-}
-
-static struct queue *queue_next (struct queue_ctx *qctx)
-{
-    if (qctx->have_named_queues)
-        return zhashx_next (qctx->named);
-    return NULL;
-}
-
-static int queue_enable (struct queue *q)
-{
-    q->is_enabled = true;
-    free (q->disable_reason);
-    q->disable_reason = NULL;
-    return 0;
-}
-
-static int queue_disable (struct queue *q, const char *reason)
-{
-    char *cpy;
-    if (!(cpy = strdup (reason)))
-        return -1;
-    free (q->disable_reason);
-    q->disable_reason = cpy;
-    q->is_enabled = false;
-    return 0;
-}
-
-static int queue_start (struct queue *q, bool nocheckpoint)
-{
-    q->is_started = true;
-    if (!nocheckpoint)
-        q->is_started_sticky = q->is_started;
-    free (q->stop_reason);
-    q->stop_reason = NULL;
-    return 0;
-}
-
-static int queue_stop (struct queue *q, const char *reason, bool nocheckpoint)
-{
-    char *cpy = NULL;
-    if (reason) {
-        if (!(cpy = strdup (reason)))
-            return -1;
-    }
-    free (q->stop_reason);
-    q->stop_reason = cpy;
-    q->is_started = false;
-    if (!nocheckpoint)
-        q->is_started_sticky = q->is_started;
-    return 0;
-}
-
-static int queue_enable_all (struct queue_ctx *qctx)
-{
-    struct queue *q = queue_first (qctx);
-    while (q) {
-        if (queue_enable (q) < 0)
-            return -1;
-        q = queue_next (qctx);
-    }
-    return 0;
-}
-
-static int queue_disable_all (struct queue_ctx *qctx, const char *reason)
-{
-    struct queue *q = queue_first (qctx);
-    while (q) {
-        if (queue_disable (q, reason) < 0)
-            return -1;
-        q = queue_next (qctx);
-    }
-    return 0;
-}
-
-static int queue_start_all (struct queue_ctx *qctx, bool nocheckpoint)
-{
-    struct queue *q = queue_first (qctx);
-    while (q) {
-        if (queue_start (q, nocheckpoint) < 0)
-            return -1;
-        q = queue_next (qctx);
-    }
-    return 0;
-}
-
-static int queue_stop_all (struct queue_ctx *qctx,
-                           const char *reason,
-                           bool nocheckpoint)
-{
-    struct queue *q = queue_first (qctx);
-    while (q) {
-        if (queue_stop (q, reason, nocheckpoint) < 0)
-            return -1;
-        q = queue_next (qctx);
-    }
-    dequeue_jobs (qctx, NULL);
-    return 0;
-}
-
-static int queue_stop_one (struct queue_ctx *qctx,
-                           struct queue *q,
-                           const char *reason,
-                           bool nocheckpoint)
-{
-    if (queue_stop (q, reason, nocheckpoint) < 0)
-        return -1;
-    dequeue_jobs (qctx, q->name);
-    return 0;
-}
-
-struct queue *queue_lookup (struct queue_ctx *qctx,
-                            const char *name,
-                            flux_error_t *error)
-{
-    if (name) {
-        struct queue *q;
-
-        if (!qctx->have_named_queues
-            || !(q = zhashx_lookup (qctx->named, name))) {
-            errprintf (error, "'%s' is not a valid queue", name);
-            return NULL;
-        }
-        return q;
-    }
-    else {
-        if (qctx->have_named_queues) {
-            errprintf (error, "a named queue is required");
-            return NULL;
-        }
-        return qctx->anon;
-    }
-}
-
-static int set_string (json_t *o, const char *key, const char *val)
-{
-    json_t *s = json_string (val);
-    if (!s || json_object_set_new (o, key, s) < 0) {
-        // jansson decrefs the new object on failure
-        errno = ENOMEM;
-        return -1;
-    }
-    return 0;
-}
-
-static int queue_ctx_save_one (json_t *a, struct queue *q)
-{
-    json_t *entry;
-
-    if (!(entry = json_pack ("{s:b s:b}",
-                             "enable", q->is_enabled,
-                             "start", q->is_started_sticky)))
-        goto nomem;
-    if (q->name) {
-        if (set_string (entry, "name", q->name) < 0)
-            goto error;
-    }
-    if (!entry)
-        goto nomem;
-    if (!q->is_enabled) {
-        if (set_string (entry, "disable_reason", q->disable_reason) < 0)
-            goto error;
-    }
-    if (!q->is_started_sticky && q->stop_reason) {
-        if (set_string (entry, "stop_reason", q->stop_reason) < 0)
-            goto error;
-    }
-    if (json_array_append_new (a, entry) < 0)
-        goto nomem;
-    return 0;
-nomem:
-    errno = ENOMEM;
-error:
-    ERRNO_SAFE_WRAP (json_decref, entry);
-    return -1;
-}
-
-json_t *queue_ctx_save (struct queue_ctx *qctx)
-{
-    json_t *a;
-    struct queue *q;
-
-    if (!(a = json_array ())) {
-        errno = ENOMEM;
-        return NULL;
-    }
-    q = queue_first (qctx);
-    while (q) {
-        if (queue_ctx_save_one (a, q) < 0)
-            goto error;
-        q = queue_next (qctx);
-    }
-    return a;
-error:
-    ERRNO_SAFE_WRAP (json_decref, a);
-    return NULL;
-}
-
-static int restore_state_v0 (struct queue_ctx *qctx, json_t *entry)
-{
-    const char *name = NULL;
-    const char *reason = NULL;
-    const char *disable_reason = NULL;
-    int enable;
-    struct queue *q = NULL;
-
-    if (json_unpack (entry,
-                     "{s?s s:b s?s s?s}",
-                     "name", &name,
-                     "enable", &enable,
-                     "reason", &reason,
-                     "disable_reason", &disable_reason) < 0) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    /* "reason" is backwards compatible field name for "disable_reason" */
-    if (!disable_reason && reason)
-        disable_reason = reason;
-
-    if ((q = queue_lookup (qctx, name, NULL))) {
-        if (enable) {
-            if (queue_enable (q) < 0)
-                return -1;
-        }
-        else {
-            if (queue_disable (q, disable_reason) < 0)
-                return -1;
-        }
-    }
-    return 0;
-}
-
-static int restore_state_v1 (struct queue_ctx *qctx, json_t *entry)
-{
-    const char *name = NULL;
-    const char *disable_reason = NULL;
-    const char *stop_reason = NULL;
-    int enable;
-    int start;
-    struct queue *q = NULL;
-
-    if (json_unpack (entry,
-                     "{s?s s:b s?s s:b s?s}",
-                     "name", &name,
-                     "enable", &enable,
-                     "disable_reason", &disable_reason,
-                     "start", &start,
-                     "stop_reason", &stop_reason) < 0) {
-        errno = EINVAL;
-        return -1;
-    }
-    if (name && qctx->have_named_queues)
-        q = zhashx_lookup (qctx->named, name);
-    else if (!name && !qctx->have_named_queues)
-        q = qctx->anon;
-    if (q) {
-        if (enable) {
-            if (queue_enable (q) < 0)
-                return -1;
-        }
-        else {
-            if (queue_disable (q, disable_reason) < 0)
-                return -1;
-        }
-        if (start) {
-            /* If job-manager.stop-queues-on-restart is enabled, then
-             * stop this started queue with an automated message, otherwise
-             * leave the queue started.
-             */
-            if (qctx->stop_on_restart) {
-                if (queue_stop_one (qctx,
-                                    q,
-                                    "Automatically stopped due to restart",
-                                    false) < 0)
-                    return -1;
-            }
-            else if (queue_start (q, false) < 0)
-                return -1;
-        }
-        else {
-            if (queue_stop_one (qctx, q, stop_reason, false) < 0)
-                return -1;
-        }
-    }
-    return 0;
-}
-
-int queue_ctx_restore (struct queue_ctx *qctx, int version, json_t *o)
-{
-    size_t index;
-    json_t *entry;
-
-    if ((version != 0 && version != 1)
-        || !o
-        || !json_is_array (o)) {
-        errno = EINVAL;
-        return -1;
-    }
-    json_array_foreach (o, index, entry) {
-        if (version == 0) {
-            if (restore_state_v0 (qctx, entry) < 0)
-                return -1;
-        }
-        else { /* version == 1 */
-            if (restore_state_v1 (qctx, entry) < 0)
-                return -1;
-        }
-    }
-    return 0;
-}
-
-int queue_submit_check (struct queue_ctx *qctx,
-                        json_t *jobspec,
-                        flux_error_t *error)
-{
-    struct queue *q;
-    json_t *o;
-    const char *name = NULL;
-
-    if ((o = jpath_get (jobspec, "attributes.system.queue")))
-        name = json_string_value (o);
-
-    if (!(q = queue_lookup (qctx, name, error))) {
-        errno = EINVAL;
-        return -1;
-    }
-    if (!q->is_enabled) {
-        errprintf (error, "job submission%s%s is disabled: %s",
-                   name ? " to " : "",
-                   name ? name : "",
-                   q->disable_reason);
-        errno = EINVAL;
-        return -1;
-    }
-    return 0;
-}
-
-bool queue_started (struct queue_ctx *qctx, struct job *job)
-{
-    if (qctx->have_named_queues) {
-        struct queue *q;
-        if (!job->queue)
-            return false;
-        if (!(q = zhashx_lookup (qctx->named, job->queue))) {
-            flux_log (qctx->ctx->h, LOG_ERR,
-                      "%s: job %s invalid queue: %s",
-                      __FUNCTION__, idf58 (job->id), job->queue);
-            return false;
-        }
-        return q->is_started;
-    }
-
-    return qctx->anon->is_started;
+    else if (streq (event, "stop"))
+        dequeue_jobs (qctx, queue_name (q));
 }
 
 /* N.B. the basic queue configuration should have already been validated by
@@ -504,75 +120,22 @@ static int queue_configure (const flux_conf_t *conf,
                             void *arg)
 {
     struct queue_ctx *qctx = arg;
-    json_t *queues;
+    json_t *config = NULL;
 
+    /* N.B. both keys are optional, so unpack fails only on an internal
+     * error such as out of memory.
+     */
     if (flux_conf_unpack (conf,
-                          NULL,
-                          "{s?{s?b} s:o}",
+                          error,
+                          "{s?{s?b} s?o}",
                           "job-manager",
-                            "stop-queues-on-restart", &qctx->stop_on_restart,
-                          "queues", &queues) == 0
-        && json_object_size (queues) > 0) {
-        const char *name;
-        json_t *value;
-        struct queue *q;
-        zlistx_t *keys;
-
-        /* destroy anon queue and create hash if necessary
-         */
-        if (!qctx->have_named_queues) {
-            qctx->have_named_queues = true;
-            queue_destroy (qctx->anon);
-            if (!(qctx->named = zhashx_new ()))
-                goto nomem;
-            zhashx_set_destructor (qctx->named, queue_destructor);
-        }
-        /* remove any queues that disappeared from config
-         */
-        if (!(keys = zhashx_keys (qctx->named)))
-            goto nomem;
-        name = zlistx_first (keys);
-        while (name) {
-            if (!json_object_get (queues, name))
-                zhashx_delete (qctx->named, name);
-            name = zlistx_next (keys);
-        }
-        zlistx_destroy (&keys);
-        /* add any new queues that appeared in config.  Note that
-         * named queues default to being enabled/stopped.  On initial
-         * module load, job-manager may change that state based on
-         * prior checkpointed information.
-         * For queues that already exist, refresh config-derived state
-         * (currently only q->requires) from the new config entry.
-         */
-        json_object_foreach (queues, name, value) {
-            if (!(q = zhashx_lookup (qctx->named, name))) {
-                if (!(q = queue_create (name, value)))
-                    goto nomem;
-                (void)zhashx_insert (qctx->named, name, q);
-            }
-            else {
-                json_t *requires = NULL;
-                if (json_unpack (value, "{s?O}", "requires", &requires) < 0)
-                    goto nomem;
-                json_decref (q->requires);
-                q->requires = requires;
-            }
-        }
-    }
-    else {
-        if (qctx->have_named_queues) {
-            qctx->have_named_queues = false;
-            zhashx_destroy (&qctx->named);
-            if (!(qctx->anon = queue_create (NULL, NULL)))
-                goto nomem;
-        }
-    }
+                            "stop-queues-on-restart",
+                              &qctx->stop_on_restart,
+                          "queues", &config) < 0)
+        return -1;
+    if (queues_configure (qctx->queues, config, error) < 0)
+        return -1;
     return 1;
-nomem:
-    errprintf (error, "out of memory while processing queue configuration");
-    errno = ENOMEM;
-    return -1;
 }
 
 static void queue_list_cb (flux_t *h,
@@ -581,28 +144,12 @@ static void queue_list_cb (flux_t *h,
                            void *arg)
 {
     struct queue_ctx *qctx = arg;
-    struct queue *q;
-    json_t *a = NULL;;
+    json_t *a = NULL;
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
-    if (!(a = json_array ())) {
-        errno = ENOMEM;
+    if (!(a = queues_list_encode (qctx->queues)))
         goto error;
-    }
-    if (qctx->have_named_queues) {
-        q = zhashx_first (qctx->named);
-        while (q) {
-            json_t *o;
-            if (!(o = json_string (q->name))
-                || json_array_append_new (a, o) < 0) {
-                // jansson decrefs the new object on failure
-                errno = ENOMEM;
-                goto error;
-            }
-            q = zhashx_next (qctx->named);
-        }
-    }
     if (flux_respond_pack (h, msg, "{s:O}", "queues", a) < 0)
         flux_log_error (h, "error responding to job-manager.queue-list");
     json_decref (a);
@@ -624,41 +171,16 @@ static void queue_status_cb (flux_t *h,
     const char *name = NULL;
     struct queue *q;
     json_t *o = NULL;
-    bool start;
-    const char *stop_reason = NULL;
 
     if (flux_request_unpack (msg, NULL, "{s?s}", "name", &name) < 0)
         goto error;
-    if (!(q = queue_lookup (qctx, name, &error))) {
+    if (!(q = queues_lookup (qctx->queues, name, &error))) {
         errmsg = error.text;
         errno = EINVAL;
         goto error;
     }
-    /* If the scheduler is not loaded the queue is considered stopped
-     * with special reason "Scheduler is offline".
-     */
-    if (!alloc_sched_ready (qctx->ctx->alloc)) {
-        start = false;
-        stop_reason = "Scheduler is offline";
-    }
-    else {
-        start = q->is_started;
-        stop_reason = q->stop_reason;
-    }
-    if (!(o = json_pack ("{s:b s:b}",
-                         "enable", q->is_enabled,
-                         "start", start))) {
-        errno = ENOMEM;
+    if (!(o = queue_status_encode (q, alloc_sched_ready (qctx->ctx->alloc))))
         goto error;
-    }
-    if (!q->is_enabled) {
-        if (set_string (o, "disable_reason", q->disable_reason) < 0)
-            goto error;
-    }
-    if (!start && stop_reason) {
-        if (set_string (o, "stop_reason", stop_reason) < 0)
-            goto error;
-    }
     if (flux_respond_pack (h, msg, "O", o) < 0)
         flux_log_error (h, "error responding to job-manager.queue-status");
     json_decref (o);
@@ -695,35 +217,26 @@ static void queue_enable_cb (flux_t *h,
         errno = EINVAL;
         goto error;
     }
-    if (!name) {
-        if (qctx->have_named_queues && !all) {
-            errmsg = "Use --all to apply this command to all queues";
-            errno = EINVAL;
-            goto error;
-        }
-        if (enable) {
-            if (queue_enable_all (qctx))
-                goto error;
-        }
-        else {
-            if (queue_disable_all (qctx, disable_reason))
-                goto error;
-        }
+    if (!name && queues_have_named (qctx->queues) && !all) {
+        errmsg = "Use --all to apply this command to all queues";
+        errno = EINVAL;
+        goto error;
     }
-    else {
-        struct queue *q;
-        if (!(q = queue_lookup (qctx, name, &error))) {
+    if (enable) {
+        if (queues_enable_queue (qctx->queues, name, &error) < 0) {
             errmsg = error.text;
             errno = EINVAL;
             goto error;
         }
-        if (enable) {
-            if (queue_enable (q) < 0)
-                goto error;
-        }
-        else {
-            if (queue_disable (q, disable_reason) < 0)
-                goto error;
+    }
+    else {
+        if (queues_disable_queue (qctx->queues,
+                                  name,
+                                  disable_reason,
+                                  &error) < 0) {
+            errmsg = error.text;
+            errno = EINVAL;
+            goto error;
         }
     }
     if (flux_respond (h, msg, NULL) < 0)
@@ -793,39 +306,30 @@ static void queue_start_cb (flux_t *h,
                              "all", &all,
                              "nocheckpoint", &nocheckpoint) < 0)
         goto error;
-    if (!name) {
-        if (qctx->have_named_queues && !all) {
-            errmsg = "Use --all to apply this command to all queues";
-            errno = EINVAL;
-            goto error;
-        }
-        if (start) {
-            if (queue_start_all (qctx, nocheckpoint))
-                goto error;
-            if (enqueue_jobs (qctx, NULL) < 0)
-                goto error;
-        }
-        else {
-            if (queue_stop_all (qctx, stop_reason, nocheckpoint))
-                goto error;
-        }
+    if (!name && queues_have_named (qctx->queues) && !all) {
+        errmsg = "Use --all to apply this command to all queues";
+        errno = EINVAL;
+        goto error;
     }
-    else {
-        struct queue *q;
-        if (!(q = queue_lookup (qctx, name, &error))) {
+    if (start) {
+        if (queues_start_queue (qctx->queues,
+                                name,
+                                nocheckpoint,
+                                &error) < 0) {
             errmsg = error.text;
             errno = EINVAL;
             goto error;
         }
-        if (start) {
-            if (queue_start (q, nocheckpoint) < 0)
-                goto error;
-            if (enqueue_jobs (qctx, name) < 0)
-                goto error;
-        }
-        else {
-            if (queue_stop_one (qctx, q, stop_reason, nocheckpoint) < 0)
-                goto error;
+    }
+    else {
+        if (queues_stop_queue (qctx->queues,
+                               name,
+                               stop_reason,
+                               nocheckpoint,
+                               &error) < 0) {
+            errmsg = error.text;
+            errno = EINVAL;
+            goto error;
         }
     }
     if (flux_respond (h, msg, NULL) < 0)
@@ -870,10 +374,7 @@ void queue_ctx_destroy (struct queue_ctx *qctx)
         int saved_errno = errno;
         conf_unregister_callback (qctx->ctx->conf, queue_configure);
         flux_msg_handler_delvec (qctx->handlers);
-        if (qctx->have_named_queues)
-            zhashx_destroy (&qctx->named);
-        else
-            queue_destroy (qctx->anon);
+        queues_destroy (qctx->queues);
         free (qctx);
         errno = saved_errno;
     }
@@ -908,14 +409,15 @@ static int constraints_match_check (struct queue_ctx *qctx,
      *  can't validate current constraints (This should not happen in normal
      *  situations).
      */
-    if (!(q = queue_lookup (qctx, name, errp)))
+    if (!(q = queues_lookup (qctx->queues, name, errp)))
         return -1;
 
     /*  If current queue has constraints, then create a constraint object
      *  for equivalence test below:
      */
-    if (q->requires
-        && !(expected = json_pack ("{s:O}", "properties", q->requires))) {
+    if (queue_requires (q)
+        && !(expected = json_pack ("{s:O}",
+                                   "properties", queue_requires (q)))) {
         errprintf (errp, "failed to get constraints for current queue");
         goto out;
     }
@@ -980,11 +482,11 @@ static int queue_update_cb (flux_plugin_t *p,
                            name);
         return -1;
     }
-    if (!(newq = queue_lookup (qctx, name, &error))) {
+    if (!(newq = queues_lookup (qctx->queues, name, &error))) {
         flux_jobtap_error (p, args, "%s", error.text);
         return -1;
     }
-    if (!newq->is_enabled) {
+    if (!queue_is_enabled (newq)) {
         flux_jobtap_error (p,
                            args,
                            "queue %s is currently disabled",
@@ -1004,7 +506,7 @@ static int queue_update_cb (flux_plugin_t *p,
      *  This is done via two different calls below dependent on whether the
      *  new queue has any constraints.
      */
-    if (newq->requires) {
+    if (queue_requires (newq)) {
         /*  Replace current constraints with those of the new queue
          */
         rc = flux_plugin_arg_pack (args,
@@ -1013,7 +515,7 @@ static int queue_update_cb (flux_plugin_t *p,
                                    "feasibility", 1,
                                    "updates",
                                     "attributes.system.constraints",
-                                     "properties", newq->requires);
+                                     "properties", queue_requires (newq));
     }
     else {
         /*  New queue has no requirements. Set constraints to empty object.
@@ -1044,6 +546,102 @@ static int update_queue_plugin_init (flux_plugin_t *p, void *arg)
                                     arg);
 }
 
+json_t *queue_ctx_save (struct queue_ctx *qctx)
+{
+    return queues_save (qctx->queues);
+}
+
+/* Apply post-restore side effects for one queue: if stop_on_restart
+ * is set, override a restored started state to stopped with an
+ * automated reason (fires notify, which dequeues); otherwise cancel
+ * alloc requests for a queue restored in a stopped state.
+ */
+static int restore_side_effects (struct queue_ctx *qctx, struct queue *q)
+{
+    if (queue_is_started (q) && qctx->stop_on_restart) {
+        if (queue_stop (q,
+                        "Automatically stopped due to restart",
+                        false) < 0)
+            return -1;
+    }
+    else if (!queue_is_started (q))
+        dequeue_jobs (qctx, queue_name (q));
+    return 0;
+}
+
+static int restore_named_queues (struct queue_ctx *qctx)
+{
+    zlistx_t *names;
+    const char *name;
+    struct queue *q;
+
+    if (!(names = queues_list_names (qctx->queues)))
+        return -1;
+    name = zlistx_first (names);
+    while (name) {
+        if ((q = queues_lookup (qctx->queues, name, NULL))
+            && restore_side_effects (qctx, q) < 0) {
+            zlistx_destroy (&names);
+            return -1;
+        }
+        name = zlistx_next (names);
+    }
+    zlistx_destroy (&names);
+    return 0;
+}
+
+int queue_ctx_restore (struct queue_ctx *qctx, int version, json_t *o)
+{
+    /* Apply saved state via queues_restore, which does not fire change
+     * notifications, then apply side effects for the resulting state
+     * here.
+     */
+    if (queues_restore (qctx->queues, version, o) < 0)
+        return -1;
+
+    if (version == 1) {
+        if (!queues_have_named (qctx->queues)) {
+            struct queue *q = queues_lookup (qctx->queues, NULL, NULL);
+            if (q && restore_side_effects (qctx, q) < 0)
+                return -1;
+        }
+        else if (restore_named_queues (qctx) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+int queue_submit_check (struct queue_ctx *qctx,
+                        json_t *jobspec,
+                        flux_error_t *error)
+{
+    struct queue *q;
+    json_t *o;
+    const char *name = NULL;
+
+    if ((o = jpath_get (jobspec, "attributes.system.queue")))
+        name = json_string_value (o);
+
+    if (!(q = queues_lookup (qctx->queues, name, error))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!queue_is_enabled (q)) {
+        errprintf (error, "job submission%s%s is disabled: %s",
+                   name ? " to " : "",
+                   name ? name : "",
+                   queue_disable_reason (q));
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+bool queue_started (struct queue_ctx *qctx, struct job *job)
+{
+    return queues_queue_is_started (qctx->queues, job->queue);
+}
+
 struct queue_ctx *queue_ctx_create (struct job_manager *ctx)
 {
     struct queue_ctx *qctx;
@@ -1054,8 +652,10 @@ struct queue_ctx *queue_ctx_create (struct job_manager *ctx)
     qctx->ctx = ctx;
     qctx->stop_on_restart = false;
 
-    if (!(qctx->anon = queue_create (NULL, NULL)))
+    if (!(qctx->queues = queues_create ()))
         goto error;
+    queues_set_notify (qctx->queues, on_queue_change, qctx);
+
     if (flux_msg_handler_addvec (ctx->h,
                                  htab,
                                  qctx,

--- a/src/modules/job-manager/queues.c
+++ b/src/modules/job-manager/queues.c
@@ -1,0 +1,947 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* queues.c - queues configuration and state for job-manager
+ *
+ * This module owns:
+ *   struct queues  - a collection of configured RFC 33 queues
+ *   struct queue   - a single queue's state
+ *
+ * The service layer (queue.c) delegates all queue state here and drives
+ * side effects (enqueue/dequeue, log) from the change-notification callback.
+ *
+ * See also:
+ * RFC 33/Flux Job Queues
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
+
+#include "queues.h"
+
+struct queue {
+    char *name;                 /* NULL for the anonymous queue */
+    bool is_enabled;            /* jobs may be submitted to this queue */
+    char *disable_reason;       /* reason if disabled */
+    bool is_started;            /* current queue state */
+    bool is_started_sticky;     /* tracks is_started unless --nocheckpoint */
+    char *stop_reason;          /* reason if stopped (optionally set) */
+    json_t *requires;           /* required properties array */
+    struct queues *queues;      /* back-pointer for notify */
+};
+
+struct queues {
+    struct queue *anon;         /* live when named == NULL */
+    zhashx_t *named;            /* non-NULL selects named mode */
+    bool restoring;             /* suppress notify during queues_restore */
+    queues_change_f notify_cb;
+    void *notify_arg;
+};
+
+/* Internal: fire change notification if callback is registered.
+ * Suppressed during queues_restore: restore reconstructs state that
+ * was already notified when it originally changed.
+ */
+static void notify (struct queues *queues,
+                    struct queue *q,
+                    const char *event)
+{
+    if (queues->notify_cb && !queues->restoring)
+        queues->notify_cb (queues, q, event, queues->notify_arg);
+}
+
+static void queue_free (struct queue *q)
+{
+    if (q) {
+        int saved_errno = errno;
+        json_decref (q->requires);
+        free (q->name);
+        free (q->disable_reason);
+        free (q->stop_reason);
+        free (q);
+        errno = saved_errno;
+    }
+}
+
+/* zhashx_destructor_fn signature */
+static void queue_destructor (void **item)
+{
+    if (item) {
+        queue_free (*item);
+        *item = NULL;
+    }
+}
+
+static struct queue *queue_alloc (struct queues *queues,
+                                  const char *name,
+                                  json_t *config)
+{
+    struct queue *q;
+
+    if (!(q = calloc (1, sizeof (*q))))
+        return NULL;
+    q->queues = queues;
+    if (name && !(q->name = strdup (name)))
+        goto error;
+    q->is_enabled = true;
+
+    if (config
+        && json_unpack (config, "{s?O}", "requires", &q->requires) < 0) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    /* The anonymous queue begins life started; named queues do not. */
+    if (name)
+        q->is_started_sticky = q->is_started = false;
+    else
+        q->is_started_sticky = q->is_started = true;
+    return q;
+error:
+    queue_free (q);
+    return NULL;
+}
+
+/* Collection lifecycle */
+
+struct queues *queues_create (void)
+{
+    struct queues *queues;
+
+    if (!(queues = calloc (1, sizeof (*queues))))
+        return NULL;
+    /* Start with anonymous queue: enabled + started */
+    if (!(queues->anon = queue_alloc (queues, NULL, NULL))) {
+        free (queues);
+        return NULL;
+    }
+    return queues;
+}
+
+void queues_destroy (struct queues *queues)
+{
+    if (queues) {
+        int saved_errno = errno;
+        if (queues->named)
+            zhashx_destroy (&queues->named);
+        else
+            queue_free (queues->anon);
+        free (queues);
+        errno = saved_errno;
+    }
+}
+
+/* Change notification */
+
+void queues_set_notify (struct queues *queues,
+                        queues_change_f cb,
+                        void *arg)
+{
+    queues->notify_cb = cb;
+    queues->notify_arg = arg;
+}
+
+/* Lookup */
+
+struct queue *queues_lookup (struct queues *queues,
+                             const char *name,
+                             flux_error_t *error)
+{
+    if (name) {
+        struct queue *q;
+
+        if (!queues->named
+            || !(q = zhashx_lookup (queues->named, name))) {
+            errprintf (error, "'%s' is not a valid queue", name);
+            return NULL;
+        }
+        return q;
+    }
+
+    /* Otherwise, return anon queue
+     */
+    if (queues->named) {
+        errprintf (error, "a named queue is required");
+        return NULL;
+    }
+    return queues->anon;
+}
+
+/* Cursor-based iteration over all queues without allocating.
+ *
+ * N.B. zhashx_lookup repositions the same internal cursor, so this
+ * must not be used across operations that fire change notifications
+ * or otherwise reenter this class - use queues_list_names for that.
+ */
+static struct queue *queues_first (struct queues *queues)
+{
+    if (queues->named)
+        return zhashx_first (queues->named);
+    return queues->anon;
+}
+
+static struct queue *queues_next (struct queues *queues)
+{
+    if (queues->named)
+        return zhashx_next (queues->named);
+    return NULL;
+}
+
+bool queues_have_named (struct queues *queues)
+{
+    return queues->named != NULL;
+}
+
+zlistx_t *queues_list_names (struct queues *queues)
+{
+    zlistx_t *names;
+
+    if (queues->named)
+        names = zhashx_keys (queues->named);
+    else
+        names = zlistx_new ();
+    if (!names) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return names;
+}
+
+bool queues_queue_is_started (struct queues *queues, const char *name)
+{
+    struct queue *q;
+
+    if (queues->named) {
+        if (!name || !(q = zhashx_lookup (queues->named, name)))
+            return false;
+    }
+    else {
+        if (name)
+            return false;
+        q = queues->anon;
+    }
+    return q->is_started;
+}
+
+/* First-class add/remove/update primitives */
+
+/* Remove all named queues, sending a "remove" notification for each.
+ * Establishes the anonymous queue and destroys the queues->named hash,
+ * which switches the collection back to anonymous mode.
+ *
+ * Returns -1 on failure, in which case no change has been made (named
+ * queues remain intact)
+ */
+static int remove_all_named_queues (struct queues *queues)
+{
+    zlistx_t *names;
+    const char *qname;
+    struct queue *q;
+
+    /* Establish the anon queue first. If this or creating the queues names
+     * list fails, return immediately so named queues remain intact.
+     */
+    if (!(queues->anon = queue_alloc (queues, NULL, NULL))
+        || !(names = zhashx_keys (queues->named))) {
+        queue_free (queues->anon);
+        queues->anon = NULL;
+        errno = ENOMEM;
+        return -1;
+    }
+    qname = zlistx_first (names);
+    while (qname) {
+        if ((q = zhashx_lookup (queues->named, qname)))
+            notify (queues, q, "remove");
+        qname = zlistx_next (names);
+    }
+    zlistx_destroy (&names);
+    zhashx_destroy (&queues->named);
+    return 0;
+}
+
+struct queue *queues_add (struct queues *queues,
+                          const char *name,
+                          json_t *config,
+                          flux_error_t *error)
+{
+    struct queue *q;
+    zhashx_t *named = NULL;
+
+    if (!name) {
+        if (!queues->named) {
+            /* Already anon - just return the existing anon queue:
+             */
+            return queues->anon;
+        }
+        /* Otherwise, adding the anonymous queue means switching to anon
+         * mode, since named queues and the anonymous queue cannot coexist.
+         * Any existing named queues are removed, with a "remove" notification
+         * fired for each, and a fresh anonymous queue (enabled + started) is
+         * created. This is how queues_configure() implements a reload that
+         * deletes the last [queues] table entry.
+         */
+        if (remove_all_named_queues (queues) < 0) {
+            errprintf (error, "%s", strerror (errno));
+            return NULL;
+        }
+        notify (queues, queues->anon, "add");
+        return queues->anon;
+    }
+
+    /* Otherwise, a new named queue is being added.
+     * First, check for a duplicate name:
+     */
+    if (queues->named && zhashx_lookup (queues->named, name)) {
+        errprintf (error, "queue '%s' already exists", name);
+        errno = EEXIST;
+        return NULL;
+    }
+
+    /* Build the new queue, and when transitioning from anon to named
+     * mode the new hash, before mutating any collection state. The anon
+     * queue is not torn down until the new queue is successfully in place,
+     * so an OOM failure here leaves the prior state (and its observers)
+     * intact.
+     */
+    if (!(q = queue_alloc (queues, name, config)))
+        goto error;
+    if (!queues->named) {
+        if (!(named = zhashx_new ())
+            || zhashx_insert (named, name, q) < 0) {
+            errno = ENOMEM;
+            goto error;
+        }
+        zhashx_set_destructor (named, queue_destructor);
+        notify (queues, queues->anon, "remove");
+        queue_free (queues->anon);
+        queues->anon = NULL;
+        queues->named = named;
+    }
+    else if (zhashx_insert (queues->named, name, q) < 0) {
+        errno = ENOMEM;
+        goto error;
+    }
+    notify (queues, q, "add");
+    return q;
+error:
+    errprintf (error, "%s", strerror (errno));
+    ERRNO_SAFE_WRAP (zhashx_destroy, &named);
+    queue_free (q);
+    return NULL;
+}
+
+int queues_remove (struct queues *queues, const char *name)
+{
+    struct queue *q;
+
+    if (!queues->named || !name) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(q = zhashx_lookup (queues->named, name))) {
+        errno = ENOENT;
+        return -1;
+    }
+    notify (queues, q, "remove");
+    zhashx_delete (queues->named, name);
+    return 0;
+}
+
+int queues_update (struct queues *queues,
+                   struct queue *q,
+                   json_t *config,
+                   flux_error_t *error)
+{
+    json_t *requires = NULL;
+
+    if (config && json_unpack (config, "{s?O}", "requires", &requires) < 0) {
+        errprintf (error, "invalid queue config");
+        errno = EINVAL;
+        return -1;
+    }
+    json_decref (q->requires);
+    q->requires = requires;   /* may be NULL */
+    notify (queues, q, "update");
+    return 0;
+}
+
+/* Configuration */
+
+/* Structural validation of a [queues] config object, without mutating any
+ * state: each queue's value must be a table. This is only what
+ * queues_configure() needs to reject a bad config before its destructive
+ * remove phase, keeping the reconfigure transactional. It is deliberately
+ * not a full RFC 33 schema check (known keys, 'requires' property array,
+ * 'policy' sub-table) - that is done up front by conf_policy_validate()
+ * before any config reaches this class.
+ */
+static int queues_config_validate (json_t *config, flux_error_t *error)
+{
+    const char *name;
+    json_t *value;
+
+    json_object_foreach (config, name, value) {
+        if (!json_is_object (value)) {
+            errprintf (error, "queue %s: configuration must be a table", name);
+            errno = EINVAL;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int queues_configure (struct queues *queues,
+                      json_t *config,
+                      flux_error_t *error)
+{
+    if (config && json_object_size (config) > 0) {
+        const char *name;
+        json_t *value;
+
+        /* Validate the entire config before mutating any state. The apply
+         * phase below removes queues before adding/updating, so rejecting a
+         * malformed config up front is what keeps a failed reconfigure from
+         * leaving a partially-applied configuration behind.
+         */
+        if (queues_config_validate (config, error) < 0)
+            return -1;
+
+        /* Remove queues that disappeared from config */
+        if (queues->named) {
+            zlistx_t *names;
+            if (!(names = queues_list_names (queues))) {
+                errprintf (error, "out of memory");
+                return -1;
+            }
+            name = zlistx_first (names);
+            while (name) {
+                if (!json_object_get (config, name)) {
+                    if (queues_remove (queues, name) < 0) {
+                        errprintf (error,
+                                   "remove: %s: %s",
+                                   name,
+                                   strerror (errno));
+                        zlistx_destroy (&names);
+                        return -1;
+                    }
+                }
+                name = zlistx_next (names);
+            }
+            zlistx_destroy (&names);
+        }
+
+        /* Add new queues / update existing ones */
+        json_object_foreach (config, name, value) {
+            struct queue *q;
+            if (!queues->named
+                || !(q = zhashx_lookup (queues->named, name))) {
+                if (!queues_add (queues, name, value, error))
+                    return -1;
+            }
+            else {
+                /* Existing queue: refresh config-derived state only.
+                 * Administrative state (enable/start bits, reasons,
+                 * sticky) is preserved per b362f73d7.
+                 */
+                if (queues_update (queues, q, value, error) < 0)
+                    return -1;
+            }
+        }
+    }
+    else {
+        /* No named queues configured: transition to anon mode
+         * (a no-op if already anon)
+         */
+        if (queues->named) {
+            if (!queues_add (queues, NULL, NULL, error))
+                return -1;
+        }
+    }
+    return 0;
+}
+
+/* Checkpoint */
+
+static int set_string (json_t *o, const char *key, const char *val)
+{
+    json_t *s = json_string (val);
+    if (!s || json_object_set_new (o, key, s) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+json_t *queue_status_encode (struct queue *q, bool sched_ready)
+{
+    json_t *o;
+    bool start;
+    const char *stop_reason;
+
+    if (!sched_ready) {
+        start = false;
+        stop_reason = "Scheduler is offline";
+    }
+    else {
+        start = q->is_started;
+        stop_reason = q->stop_reason;
+    }
+    if (!(o = json_pack ("{s:b s:b}",
+                         "enable", q->is_enabled,
+                         "start", start)))
+        goto error;
+    if (!q->is_enabled && q->disable_reason) {
+        if (set_string (o, "disable_reason", q->disable_reason) < 0)
+            goto error;
+    }
+    if (!start && stop_reason) {
+        if (set_string (o, "stop_reason", stop_reason) < 0)
+            goto error;
+    }
+    return o;
+error:
+    errno = ENOMEM;
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return NULL;
+}
+
+json_t *queues_list_encode (struct queues *queues)
+{
+    json_t *a;
+
+    if (!(a = json_array ()))
+        goto error;
+    if (queues->named) {
+        struct queue *q = zhashx_first (queues->named);
+        while (q) {
+            json_t *o;
+            if (!(o = json_string (q->name))
+                || json_array_append_new (a, o) < 0) {
+                /* jansson decrefs the new object on failure */
+                goto error;
+            }
+            q = zhashx_next (queues->named);
+        }
+    }
+    return a;
+error:
+    errno = ENOMEM;
+    ERRNO_SAFE_WRAP (json_decref, a);
+    return NULL;
+}
+
+static int save_one (json_t *a, struct queue *q)
+{
+    json_t *entry;
+
+    if (!(entry = json_pack ("{s:b s:b}",
+                             "enable", q->is_enabled,
+                             "start", q->is_started_sticky)))
+        goto error;
+    if (q->name) {
+        if (set_string (entry, "name", q->name) < 0)
+            goto error;
+    }
+    if (!q->is_enabled) {
+        if (set_string (entry, "disable_reason", q->disable_reason) < 0)
+            goto error;
+    }
+    if (!q->is_started_sticky && q->stop_reason) {
+        if (set_string (entry, "stop_reason", q->stop_reason) < 0)
+            goto error;
+    }
+    if (json_array_append_new (a, entry) < 0) {
+        /* jansson decrefs entry on failure */
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+error:
+    errno = ENOMEM;
+    ERRNO_SAFE_WRAP (json_decref, entry);
+    return -1;
+}
+
+json_t *queues_save (struct queues *queues)
+{
+    json_t *a;
+    struct queue *q;
+
+    if (!(a = json_array ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    q = queues_first (queues);
+    while (q) {
+        if (save_one (a, q) < 0)
+            goto error;
+        q = queues_next (queues);
+    }
+    return a;
+error:
+    ERRNO_SAFE_WRAP (json_decref, a);
+    return NULL;
+}
+
+static int restore_v0 (struct queues *queues, json_t *entry)
+{
+    const char *name = NULL;
+    const char *reason = NULL;
+    const char *disable_reason = NULL;
+    int enable;
+    struct queue *q = NULL;
+
+    if (json_unpack (entry,
+                     "{s?s s:b s?s s?s}",
+                     "name", &name,
+                     "enable", &enable,
+                     "reason", &reason,
+                     "disable_reason", &disable_reason) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /* "reason" is backwards compatible field name for "disable_reason" */
+    if (!disable_reason && reason)
+        disable_reason = reason;
+
+    if ((q = queues_lookup (queues, name, NULL))) {
+        if (enable) {
+            if (queue_enable (q) < 0)
+                return -1;
+        }
+        else {
+            if (queue_disable (q, disable_reason) < 0)
+                return -1;
+        }
+    }
+    return 0;
+}
+
+static int restore_v1 (struct queues *queues, json_t *entry)
+{
+    const char *name = NULL;
+    const char *disable_reason = NULL;
+    const char *stop_reason = NULL;
+    int enable;
+    int start;
+    struct queue *q = NULL;
+
+    if (json_unpack (entry,
+                     "{s?s s:b s?s s:b s?s}",
+                     "name", &name,
+                     "enable", &enable,
+                     "disable_reason", &disable_reason,
+                     "start", &start,
+                     "stop_reason", &stop_reason) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    /* Find the queue, silently ignoring unknown queue names */
+    if ((q = queues_lookup (queues, name, NULL))) {
+        if (enable) {
+            if (queue_enable (q) < 0)
+                return -1;
+        }
+        else {
+            if (queue_disable (q, disable_reason) < 0)
+                return -1;
+        }
+        if (start) {
+            if (queue_start (q, false) < 0)
+                return -1;
+        }
+        else {
+            if (queue_stop (q, stop_reason, false) < 0)
+                return -1;
+        }
+    }
+    return 0;
+}
+
+int queues_restore (struct queues *queues, int version, json_t *o)
+{
+    size_t index;
+    json_t *entry;
+    int rc = -1;
+
+    if ((version != 0 && version != 1)
+        || !o
+        || !json_is_array (o)) {
+        errno = EINVAL;
+        return -1;
+    }
+    queues->restoring = true;
+    json_array_foreach (o, index, entry) {
+        if (version == 0) {
+            if (restore_v0 (queues, entry) < 0)
+                goto done;
+        }
+        else {
+            if (restore_v1 (queues, entry) < 0)
+                goto done;
+        }
+    }
+    rc = 0;
+done:
+    queues->restoring = false;
+    return rc;
+}
+
+/* Per-queue accessors */
+
+const char *queue_name (struct queue *q)
+{
+    return q->name;
+}
+
+json_t *queue_requires (struct queue *q)
+{
+    return q->requires;
+}
+
+bool queue_is_enabled (struct queue *q)
+{
+    return q->is_enabled;
+}
+
+const char *queue_disable_reason (struct queue *q)
+{
+    return q->disable_reason;
+}
+
+bool queue_is_started (struct queue *q)
+{
+    return q->is_started;
+}
+
+const char *queue_stop_reason (struct queue *q)
+{
+    return q->stop_reason;
+}
+
+/* Per-queue mutators (fire notify) */
+
+int queue_enable (struct queue *q)
+{
+    q->is_enabled = true;
+    free (q->disable_reason);
+    q->disable_reason = NULL;
+    notify (q->queues, q, "enable");
+    return 0;
+}
+
+int queue_disable (struct queue *q, const char *reason)
+{
+    char *cpy = NULL;
+    if (reason && !(cpy = strdup (reason)))
+        return -1;
+    free (q->disable_reason);
+    q->disable_reason = cpy;
+    q->is_enabled = false;
+    notify (q->queues, q, "disable");
+    return 0;
+}
+
+int queue_start (struct queue *q, bool nocheckpoint)
+{
+    q->is_started = true;
+    if (!nocheckpoint)
+        q->is_started_sticky = q->is_started;
+    free (q->stop_reason);
+    q->stop_reason = NULL;
+    notify (q->queues, q, "start");
+    return 0;
+}
+
+int queue_stop (struct queue *q, const char *reason, bool nocheckpoint)
+{
+    char *cpy = NULL;
+    if (reason) {
+        if (!(cpy = strdup (reason)))
+            return -1;
+    }
+    free (q->stop_reason);
+    q->stop_reason = cpy;
+    q->is_started = false;
+    if (!nocheckpoint)
+        q->is_started_sticky = q->is_started;
+    notify (q->queues, q, "stop");
+    return 0;
+}
+
+/* Administrative operations by queue name */
+
+static int foreach_named_queue (struct queues *queues,
+                                int (*cb) (struct queue *, void *),
+                                void *arg)
+{
+    int rc = -1;
+    struct queue *q;
+    zlistx_t *values;
+
+    /* Callback may trigger notify, which may do a queue lookup or other
+     * operation that perturbs zhashx cursor, so do not iterate zhashx
+     * directly here. Use a values list instead:
+     */
+    if (!(values = zhashx_values (queues->named))) {
+        errno = ENOMEM;
+        return -1;
+    }
+    zlistx_set_destructor (values, NULL);
+    q = zlistx_first (values);
+    while (q) {
+        if ((*cb) (q, arg) < 0)
+            goto out;
+        q = zlistx_next (values);
+    }
+    rc = 0;
+out:
+    ERRNO_SAFE_WRAP (zlistx_destroy, &values);
+    return rc;
+}
+
+static int enable_cb (struct queue *q, void *arg)
+{
+    return queue_enable (q);
+}
+
+int queues_enable_queue (struct queues *queues,
+                         const char *name,
+                         flux_error_t *error)
+{
+    struct queue *q;
+
+    if (!name && queues->named) {
+        if (foreach_named_queue (queues, &enable_cb, NULL) < 0)
+            return errprintf (error,
+                              "failed to enable queues: %s",
+                              strerror (errno));
+        return 0;
+    }
+    if (!(q = queues_lookup (queues, name, error)))
+        return -1;
+    if (queue_enable (q) < 0)
+        return errprintf (error,
+                          "failed to enable queue: %s",
+                          strerror (errno));
+    return 0;
+}
+
+static int disable_cb (struct queue *q, void *arg)
+{
+    const char *reason = arg;
+    return queue_disable (q, reason);
+}
+
+int queues_disable_queue (struct queues *queues,
+                          const char *name,
+                          const char *reason,
+                          flux_error_t *error)
+{
+    struct queue *q;
+
+    if (!reason) {
+        errprintf (error, "reason is required for disable");
+        errno = EINVAL;
+        return -1;
+    }
+    if (!name && queues->named) {
+        if (foreach_named_queue (queues, &disable_cb, (void *) reason) < 0)
+            return errprintf (error,
+                              "failed to disable queues: %s",
+                              strerror (errno));
+        return 0;
+    }
+    if (!(q = queues_lookup (queues, name, error)))
+        return -1;
+    if (queue_disable (q, reason) < 0)
+        return errprintf (error,
+                          "failed to disable queue: %s",
+                          strerror (errno));
+    return 0;
+}
+
+static int start_cb (struct queue *q, void *arg)
+{
+    bool nocheckpoint = *((bool *)arg);
+    return queue_start (q, nocheckpoint);
+}
+
+int queues_start_queue (struct queues *queues,
+                        const char *name,
+                        bool nocheckpoint,
+                        flux_error_t *error)
+{
+    struct queue *q;
+
+    if (!name && queues->named) {
+        if (foreach_named_queue (queues, &start_cb, &nocheckpoint) < 0)
+            return errprintf (error,
+                              "failed to start queues: %s",
+                              strerror (errno));
+        return 0;
+    }
+    if (!(q = queues_lookup (queues, name, error)))
+        return -1;
+    return queue_start (q, nocheckpoint);
+}
+
+struct stop_arg {
+    bool nocheckpoint;
+    const char *reason;
+};
+
+static int stop_cb (struct queue *q, void *arg)
+{
+    struct stop_arg *s_arg = arg;
+    return queue_stop (q, s_arg->reason, s_arg->nocheckpoint);
+}
+
+int queues_stop_queue (struct queues *queues,
+                       const char *name,
+                       const char *reason,
+                       bool nocheckpoint,
+                       flux_error_t *error)
+{
+    struct queue *q;
+
+    if (!name && queues->named) {
+        struct stop_arg arg = {
+            .reason = reason,
+            .nocheckpoint = nocheckpoint
+        };
+        if (foreach_named_queue (queues, &stop_cb, &arg) < 0)
+            return errprintf (error,
+                              "failed to stop queues: %s",
+                              strerror (errno));
+        return 0;
+    }
+    if (!(q = queues_lookup (queues, name, error)))
+        return -1;
+    if (queue_stop (q, reason, nocheckpoint) < 0)
+        return errprintf (error,
+                          "failed to stop queue: %s",
+                          strerror (errno));
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/queues.h
+++ b/src/modules/job-manager/queues.h
@@ -1,0 +1,158 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_QUEUES_H
+#define _FLUX_JOB_MANAGER_QUEUES_H
+
+#include <stdbool.h>
+#include <jansson.h>
+#include <flux/core.h>  /* flux_error_t */
+
+#include "src/common/libczmqcontainers/czmq_containers.h"  /* zlistx_t */
+
+struct queues;
+struct queue;
+
+/* Collection lifecycle */
+struct queues *queues_create (void);
+void queues_destroy (struct queues *queues);
+
+/* Configure queues from a JSON `[queues]` table or NULL in `config`.
+ *
+ * `queues_configure()` diffs provided config against the current table
+ * and applies add/remove/update queue primitives. Initial load is the same
+ * diff against a (nearly) empty table. Going from a set of configured queues
+ * to an empty [queues] table forces configuration back to the anon queue,
+ * removing all current named queues.
+ *
+ * Added named queues are enabled but stopped.
+ * Anon queue is always enabled + started.
+ */
+int queues_configure (struct queues *queues,
+                      json_t *config,
+                      flux_error_t *error);
+
+/* First-class add/remove/update (used by configure)
+ */
+struct queue *queues_add (struct queues *queues,
+                          const char *name,
+                          json_t *config,
+                          flux_error_t *error);
+int queues_remove (struct queues *queues, const char *name);
+
+/* Refresh config-derived fields (requires, ...) of an existing queue;
+ * administrative state (enable/start bits, reasons, sticky) is preserved.
+ * Called by configure for queues present in both old and new config.
+ *
+ * Returns -1 on error with error->text set to a readable error string.
+ */
+int queues_update (struct queues *queues,
+                   struct queue *q,
+                   json_t *config,
+                   flux_error_t *error);
+
+/* Lookup a named queue. If name == NULL, returns the anon queue
+ */
+struct queue *queues_lookup (struct queues *queues,
+                             const char *name,
+                             flux_error_t *error);
+
+/* Return true if there are named queues in the current configuration,
+ * false otherwise.
+ */
+bool queues_have_named (struct queues *queues);
+
+/* Return a snapshot list of current queue names (empty in anon mode),
+ * or NULL with errno set on error. Caller must destroy the list. Safe to
+ * iterate while queues are mutated or looked up.
+ */
+zlistx_t *queues_list_names (struct queues *queues);
+
+/* Test whether the queue named 'name' (NULL = anon) is started.
+ * Returns false if name does not resolve to a queue.
+ */
+bool queues_queue_is_started (struct queues *queues, const char *name);
+
+/* Queue change notification: single stream for all mutations.
+ *
+ * Events: "add", "remove", "update", "enable", "disable", "start", "stop".
+ * Fired per affected queue, including during configure and aggregate
+ * operations. Never fired during queues_restore(): restore reconstructs
+ * state that was already notified when it originally changed, so consumers
+ * that persist or forward changes do not see them replayed.
+ *
+ * The callback keeps the queue table free of side effects: consumers attach
+ * behavior (e.g. the job manager cancels a stopped queue's alloc requests)
+ * without the table knowing about it. All mutations are reported uniformly
+ * so that future consumers (e.g. announcing queue changes to the scheduler,
+ * or persisting runtime-created queues) can attach to the same stream.
+ */
+typedef void (*queues_change_f) (struct queues *queues,
+                                 struct queue *q,
+                                 const char *event,
+                                 void *arg);
+void queues_set_notify (struct queues *queues,
+                        queues_change_f cb,
+                        void *arg);
+
+/* Serialize/de-serialize queue state for checkpoint/restore:
+ */
+json_t *queues_save (struct queues *queues);
+int queues_restore (struct queues *queues, int version, json_t *o);
+
+/* RPC response payload encoders. Pass 'sched_ready=true' if scheduler
+ * is loaded: when false, status presents the queue as stopped with a
+ * synthesized reason.
+ */
+json_t *queue_status_encode (struct queue *q, bool sched_ready);
+json_t *queues_list_encode (struct queues *queues);
+
+/* Per-queue accessors
+ * If q == NULL, assume anonymous queue.
+ */
+const char *queue_name (struct queue *q);
+json_t *queue_requires (struct queue *q);
+bool queue_is_enabled (struct queue *q);
+const char *queue_disable_reason (struct queue *q);
+bool queue_is_started (struct queue *q);
+const char *queue_stop_reason (struct queue *q);
+
+/* Per-queue mutators
+ * These methods fire notification.
+ */
+int queue_enable (struct queue *q);
+int queue_disable (struct queue *q, const char *reason);
+int queue_start (struct queue *q, bool nocheckpoint);
+int queue_stop (struct queue *q, const char *reason, bool nocheckpoint);
+
+/* Administrative operations by queue name. A NULL name applies the
+ * operation to all queues. A reason is required to disable a queue
+ * and optional to stop one. Each affected queue fires notify.
+ */
+int queues_enable_queue (struct queues *queues,
+                         const char *name,
+                         flux_error_t *error);
+int queues_disable_queue (struct queues *queues,
+                          const char *name,
+                          const char *reason,
+                          flux_error_t *error);
+int queues_start_queue (struct queues *queues,
+                        const char *name,
+                        bool nocheckpoint,
+                        flux_error_t *error);
+int queues_stop_queue (struct queues *queues,
+                       const char *name,
+                       const char *reason,
+                       bool nocheckpoint,
+                       flux_error_t *error);
+
+#endif /* ! _FLUX_JOB_MANAGER_QUEUES_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/test/queues.c
+++ b/src/modules/job-manager/test/queues.c
@@ -1,0 +1,1571 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* test/queues.c - unit tests for queues.[ch]
+ *
+ * Modeled on test/restart.c pattern.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <errno.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
+#include "src/modules/job-manager/queues.h"
+
+/* ---------- notify tracking helpers ----------------------------------- */
+
+struct notify_record {
+    char name[64];      /* queue name or "" for anon */
+    char event[32];
+};
+
+#define MAX_NOTIFY 64
+static struct notify_record notify_log[MAX_NOTIFY];
+static int notify_count;
+
+static void notify_reset (void)
+{
+    notify_count = 0;
+}
+
+static void notify_cb (struct queues *queues,
+                       struct queue *q,
+                       const char *event,
+                       void *arg)
+{
+    if (notify_count < MAX_NOTIFY) {
+        const char *n = queue_name (q);
+        snprintf (notify_log[notify_count].name,
+                  sizeof (notify_log[0].name),
+                  "%s", n ? n : "");
+        snprintf (notify_log[notify_count].event,
+                  sizeof (notify_log[0].event),
+                  "%s", event);
+        notify_count++;
+    }
+}
+
+
+/* ---------- tests ----------------------------------------------------- */
+
+static void test_create_destroy (void)
+{
+    struct queues *qs;
+    struct queue *q;
+
+    qs = queues_create ();
+    ok (qs != NULL, "queues_create works");
+
+    /* Default state: anonymous queue, enabled + started */
+    ok (!queues_have_named (qs),
+        "queues_have_named returns false after create");
+
+    q = queues_lookup (qs, NULL, NULL);
+    ok (q != NULL, "queues_lookup NULL returns anon queue");
+
+    ok (queue_name (q) == NULL,
+        "anon queue has NULL name");
+    ok (queue_is_enabled (q),
+        "anon queue is enabled by default");
+    ok (queue_is_started (q),
+        "anon queue is started by default");
+    ok (queue_disable_reason (q) == NULL,
+        "anon queue disable_reason is NULL");
+    ok (queue_stop_reason (q) == NULL,
+        "anon queue stop_reason is NULL");
+    ok (queue_requires (q) == NULL,
+        "anon queue requires is NULL");
+
+    queues_destroy (qs);
+    pass ("queues_destroy on anon queue doesn't crash");
+
+    queues_destroy (NULL);
+    pass ("queues_destroy on NULL doesn't crash");
+}
+
+static void test_configure_named (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* Configure two named queues */
+    config = json_pack ("{s:{} s:{}}",
+                        "batch", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+
+    ok (queues_configure (qs, config, &error) == 0,
+        "queues_configure with named queues works");
+    ok (queues_have_named (qs),
+        "queues_have_named returns true after configure");
+
+    /* Named queues default to enabled + stopped */
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "queues_lookup finds 'batch'");
+    ok (queue_is_enabled (q), "batch queue is enabled");
+    ok (!queue_is_started (q), "batch queue is stopped");
+
+    q = queues_lookup (qs, "debug", &error);
+    ok (q != NULL, "queues_lookup finds 'debug'");
+    ok (queue_is_enabled (q), "debug queue is enabled");
+    ok (!queue_is_started (q), "debug queue is stopped");
+
+    json_decref (config);
+    queues_destroy (qs);
+}
+
+static void test_configure_empty_is_anon (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* Configure with NULL (empty config): stays anon */
+    ok (queues_configure (qs, NULL, &error) == 0,
+        "queues_configure with NULL config works");
+    ok (!queues_have_named (qs),
+        "queues_have_named still false after NULL configure");
+    q = queues_lookup (qs, NULL, NULL);
+    ok (q != NULL && queue_name (q) == NULL,
+        "anon queue present after NULL configure");
+
+    /* Configure with empty object: stays anon */
+    json_t *empty = json_object ();
+    ok (queues_configure (qs, empty, &error) == 0,
+        "queues_configure with empty object works");
+    ok (!queues_have_named (qs),
+        "queues_have_named still false after empty configure");
+    json_decref (empty);
+
+    queues_destroy (qs);
+}
+
+static void test_anon_to_named_and_back (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    queues_set_notify (qs, notify_cb, NULL);
+    notify_reset ();
+
+    /* Anon -> named */
+    config = json_pack ("{s:{}}", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+
+    ok (queues_configure (qs, config, &error) == 0,
+        "anon->named configure works");
+    ok (queues_have_named (qs),
+        "now have named queues");
+    json_decref (config);
+
+    /* named -> anon */
+    ok (queues_configure (qs, NULL, &error) == 0,
+        "named->anon configure works");
+    ok (!queues_have_named (qs),
+        "back to anon");
+    q = queues_lookup (qs, NULL, NULL);
+    ok (q != NULL && queue_name (q) == NULL,
+        "anon queue present");
+    ok (queue_is_enabled (q) && queue_is_started (q),
+        "new anon queue is enabled+started");
+
+    queues_destroy (qs);
+}
+
+static void test_reload_diff (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* Initial configure: batch, debug */
+    config = json_pack ("{s:{} s:{}}", "batch", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "initial configure: batch+debug");
+    json_decref (config);
+
+    /* Mark batch queue with some state to test preservation */
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "found batch queue");
+    ok (queue_start (q, false) == 0, "start batch queue");
+    ok (queue_disable (q, "maintenance") == 0, "disable batch queue");
+
+    /* Reload: batch stays, debug gone, new 'gpu' added */
+    config = json_pack ("{s:{} s:{}}", "batch", "gpu");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "reload configure: batch+gpu");
+    json_decref (config);
+
+    /* batch should still exist with preserved state */
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "batch survives reload");
+    ok (!queue_is_enabled (q), "batch disable state preserved");
+    ok (queue_is_started (q), "batch started state preserved");
+    is (queue_disable_reason (q), "maintenance",
+        "batch disable_reason preserved");
+
+    /* debug should be gone */
+    q = queues_lookup (qs, "debug", &error);
+    ok (q == NULL, "debug removed on reload");
+
+    /* gpu should exist, default state */
+    q = queues_lookup (qs, "gpu", &error);
+    ok (q != NULL, "gpu added on reload");
+    ok (queue_is_enabled (q) && !queue_is_started (q),
+        "gpu default state: enabled+stopped");
+
+    queues_destroy (qs);
+}
+
+static void test_update_preserves_state (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+    json_t *req1, *req2;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* Configure with requires */
+    req1 = json_pack ("[s]", "partition:batch");
+    if (!req1)
+        BAIL_OUT ("json_pack failed");
+    config = json_pack ("{s:{s:O}}", "batch", "requires", req1);
+    json_decref (req1);
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure batch with requires");
+    json_decref (config);
+
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "found batch queue");
+    ok (queue_requires (q) != NULL, "batch has requires");
+
+    /* Set some admin state */
+    ok (queue_disable (q, "down for maintenance") == 0,
+        "disable batch queue");
+    ok (queue_start (q, false) == 0, "start batch queue");
+
+    /* Now reload with different requires */
+    req2 = json_pack ("[s]", "partition:new-batch");
+    if (!req2)
+        BAIL_OUT ("json_pack failed");
+    config = json_pack ("{s:{s:O}}", "batch", "requires", req2);
+    json_decref (req2);
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "reload with updated requires");
+    json_decref (config);
+
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "batch still exists after reload");
+
+    /* Requires should be updated */
+    json_t *reqs = queue_requires (q);
+    ok (reqs != NULL, "requires still set after update");
+    ok (json_array_size (reqs) == 1, "requires has one element");
+    const char *s = json_string_value (json_array_get (reqs, 0));
+    is (s, "partition:new-batch",
+        "requires updated to new value");
+
+    /* Admin state preserved */
+    ok (!queue_is_enabled (q), "disable state preserved");
+    ok (queue_is_started (q), "start state preserved");
+    is (queue_disable_reason (q), "down for maintenance",
+        "disable_reason preserved");
+
+    /* Reload with requires omitted: requires is cleared, admin state kept */
+    config = json_pack ("{s:{}}", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "reload with requires omitted");
+    json_decref (config);
+
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "batch still exists after reload");
+    ok (queue_requires (q) == NULL,
+        "requires cleared when omitted from config");
+    ok (!queue_is_enabled (q) && queue_is_started (q),
+        "admin state preserved across requires clear");
+    is (queue_disable_reason (q), "down for maintenance",
+        "disable_reason preserved across requires clear");
+
+    queues_destroy (qs);
+}
+
+static void test_lookup (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* Anon: lookup NULL succeeds */
+    q = queues_lookup (qs, NULL, &error);
+    ok (q != NULL, "lookup NULL in anon mode succeeds");
+
+    /* Anon: lookup named fails */
+    q = queues_lookup (qs, "batch", &error);
+    ok (q == NULL, "lookup named in anon mode fails");
+    ok (strlen (error.text) > 0, "error.text set");
+
+    /* Named mode */
+    config = json_pack ("{s:{}}", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure named queues");
+    json_decref (config);
+
+    /* Named: lookup by name succeeds */
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "lookup 'batch' in named mode succeeds");
+
+    /* Named: lookup NULL fails with "a named queue is required" */
+    q = queues_lookup (qs, NULL, &error);
+    ok (q == NULL, "lookup NULL in named mode fails");
+    ok (strstr (error.text, "named queue") != NULL,
+        "error says 'named queue'");
+
+    /* Named: lookup unknown name fails */
+    q = queues_lookup (qs, "nosuchqueue", &error);
+    ok (q == NULL, "lookup unknown queue fails");
+    ok (strlen (error.text) > 0, "error.text set");
+
+    queues_destroy (qs);
+}
+
+static void test_enable_disable (void)
+{
+    struct queues *qs;
+    struct queue *q;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    queues_set_notify (qs, notify_cb, NULL);
+
+    q = queues_lookup (qs, NULL, NULL);
+    ok (q != NULL, "got anon queue");
+
+    notify_reset ();
+    ok (queue_disable (q, "testing") == 0, "queue_disable works");
+    ok (!queue_is_enabled (q), "queue now disabled");
+    is (queue_disable_reason (q), "testing",
+        "disable reason set");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "disable"),
+        "disable event fired");
+
+    notify_reset ();
+    ok (queue_enable (q) == 0, "queue_enable works");
+    ok (queue_is_enabled (q), "queue now enabled");
+    ok (queue_disable_reason (q) == NULL, "disable reason cleared");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "enable"),
+        "enable event fired");
+
+    /* A NULL reason must not crash (strdup(NULL)); the queue is
+     * disabled with no reason string.  Reachable via a checkpoint
+     * entry that has enable=false with no disable_reason.
+     */
+    ok (queue_disable (q, NULL) == 0, "queue_disable with NULL reason works");
+    ok (!queue_is_enabled (q), "queue disabled with NULL reason");
+    ok (queue_disable_reason (q) == NULL, "disable reason is NULL");
+
+    queues_destroy (qs);
+}
+
+static void test_start_stop (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    queues_set_notify (qs, notify_cb, NULL);
+
+    /* Use named queue (starts stopped) */
+    config = json_pack ("{s:{}}", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    queues_configure (qs, config, &error);
+    json_decref (config);
+
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL && !queue_is_started (q),
+        "batch queue starts stopped");
+
+    /* Stop with reason, no nocheckpoint */
+    notify_reset ();
+    ok (queue_stop (q, "down", false) == 0, "queue_stop works");
+    ok (!queue_is_started (q), "queue stopped");
+    is (queue_stop_reason (q), "down",
+        "stop reason set");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "stop"),
+        "stop event fired");
+
+    /* Start */
+    notify_reset ();
+    ok (queue_start (q, false) == 0, "queue_start works");
+    ok (queue_is_started (q), "queue started");
+    ok (queue_stop_reason (q) == NULL, "stop reason cleared");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "start"),
+        "start event fired");
+
+    /* Nocheckpoint: stop without updating sticky */
+    ok (queue_stop (q, "transient", true) == 0,
+        "queue_stop with nocheckpoint works");
+    ok (!queue_is_started (q), "queue stopped");
+
+    /* Save should reflect sticky=true (was started before nocheckpoint stop) */
+    json_t *saved = queues_save (qs);
+    ok (saved != NULL, "queues_save works");
+    int start_val = 0;
+    ok (json_array_size (saved) == 1, "saved has one entry");
+    ok (json_unpack (json_array_get (saved, 0), "{s:b}", "start", &start_val) == 0
+        && start_val == 1,
+        "nocheckpoint stop: sticky bit is still 'started'");
+    json_decref (saved);
+
+    queues_destroy (qs);
+}
+
+static void test_save_restore_v1 (void)
+{
+    struct queues *qs_save;
+    struct queues *qs_restore;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+    json_t *saved;
+
+    /* Create queues and set state */
+    qs_save = queues_create ();
+    if (!qs_save)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{} s:{}}", "batch", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs_save, config, &error) == 0,
+        "configure batch+debug for save");
+    json_decref (config);
+
+    q = queues_lookup (qs_save, "batch", &error);
+    ok (q != NULL, "batch lookup ok");
+    ok (queue_disable (q, "maint") == 0, "disable batch");
+    ok (queue_start (q, false) == 0, "start batch");
+
+    q = queues_lookup (qs_save, "debug", &error);
+    ok (q != NULL, "debug lookup ok");
+    /* debug: enabled, stopped (default), with reason */
+    ok (queue_stop (q, "offline", false) == 0, "stop debug");
+
+    saved = queues_save (qs_save);
+    ok (saved != NULL, "queues_save works");
+    ok (json_is_array (saved), "saved is array");
+    ok (json_array_size (saved) == 2, "saved has 2 entries");
+    queues_destroy (qs_save);
+
+    /* Restore into fresh queues with same config */
+    qs_restore = queues_create ();
+    if (!qs_restore)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{} s:{}}", "batch", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs_restore, config, &error) == 0,
+        "configure batch+debug for restore");
+    json_decref (config);
+
+    ok (queues_restore (qs_restore, 1, saved) == 0,
+        "queues_restore v1 works");
+    json_decref (saved);
+
+    q = queues_lookup (qs_restore, "batch", &error);
+    ok (q != NULL, "batch found after restore");
+    ok (!queue_is_enabled (q), "batch disabled after restore");
+    is (queue_disable_reason (q), "maint",
+        "batch disable_reason restored");
+    ok (queue_is_started (q), "batch started after restore");
+
+    q = queues_lookup (qs_restore, "debug", &error);
+    ok (q != NULL, "debug found after restore");
+    ok (queue_is_enabled (q), "debug enabled after restore");
+    ok (!queue_is_started (q), "debug stopped after restore");
+    is (queue_stop_reason (q), "offline",
+        "debug stop_reason restored");
+
+    queues_destroy (qs_restore);
+}
+
+static void test_restore_v0 (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+    json_t *saved;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{}}", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure batch for v0 restore");
+    json_decref (config);
+
+    /* v0 only has enable/name/reason fields */
+    saved = json_pack ("[{s:s s:b s:s}]",
+                       "name", "batch",
+                       "enable", 0,
+                       "reason", "old-style-reason");
+    if (!saved)
+        BAIL_OUT ("json_pack for v0 data failed");
+
+    ok (queues_restore (qs, 0, saved) == 0,
+        "queues_restore v0 works");
+    json_decref (saved);
+
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "batch found after v0 restore");
+    ok (!queue_is_enabled (q), "batch disabled after v0 restore");
+    is (queue_disable_reason (q), "old-style-reason",
+        "v0 'reason' key used as disable_reason");
+
+    queues_destroy (qs);
+}
+
+static void test_restore_unknown_queue_ignored (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+    json_t *saved;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{}}", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure batch only");
+    json_decref (config);
+
+    /* v1 restore with unknown queue entry */
+    saved = json_pack ("[{s:s s:b s:b}]",
+                       "name", "nosuchqueue",
+                       "enable", 1,
+                       "start", 0);
+    if (!saved)
+        BAIL_OUT ("json_pack failed");
+
+    ok (queues_restore (qs, 1, saved) == 0,
+        "queues_restore ignores unknown queue entry");
+    json_decref (saved);
+
+    queues_destroy (qs);
+}
+
+static void test_notify_configure (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    queues_set_notify (qs, notify_cb, NULL);
+    notify_reset ();
+
+    /* Configure named queues: should fire "add" for each */
+    config = json_pack ("{s:{} s:{}}", "batch", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure fires add events");
+    json_decref (config);
+
+    /* anon->named transition fires "remove" for anon plus one "add"
+     * per named queue */
+    ok (notify_count == 3, "three events fired");
+    bool saw_anon_remove = false;
+    bool saw_batch_add = false, saw_debug_add = false;
+    for (int i = 0; i < notify_count; i++) {
+        if (streq (notify_log[i].name, "")
+            && streq (notify_log[i].event, "remove"))
+            saw_anon_remove = true;
+        if (streq (notify_log[i].name, "batch")
+            && streq (notify_log[i].event, "add"))
+            saw_batch_add = true;
+        if (streq (notify_log[i].name, "debug")
+            && streq (notify_log[i].event, "add"))
+            saw_debug_add = true;
+    }
+    ok (saw_anon_remove, "anon remove event fired");
+    ok (saw_batch_add, "batch add event fired");
+    ok (saw_debug_add, "debug add event fired");
+
+    /* Reload removing debug: should fire "remove" for debug,
+     * "update" for batch */
+    notify_reset ();
+    config = json_pack ("{s:{}}", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "reload fires remove+update events");
+    json_decref (config);
+
+    bool saw_debug_remove = false, saw_batch_update = false;
+    for (int i = 0; i < notify_count; i++) {
+        if (streq (notify_log[i].name, "debug")
+            && streq (notify_log[i].event, "remove"))
+            saw_debug_remove = true;
+        if (streq (notify_log[i].name, "batch")
+            && streq (notify_log[i].event, "update"))
+            saw_batch_update = true;
+    }
+    ok (saw_debug_remove, "debug remove event fired on reload");
+    ok (saw_batch_update, "batch update event fired on reload");
+
+    queues_destroy (qs);
+}
+
+static void test_notify_restore (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+    json_t *saved;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{}}", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure batch");
+    json_decref (config);
+
+    /* Disable + stop with reason */
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "batch found");
+    queue_disable (q, "maint");
+    queue_stop (q, "down", false);
+
+    saved = queues_save (qs);
+    ok (saved != NULL, "save ok");
+    queues_destroy (qs);
+
+    /* New queues, register notify, then restore */
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    config = json_pack ("{s:{}}", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    queues_configure (qs, config, &error);
+    json_decref (config);
+
+    queues_set_notify (qs, notify_cb, NULL);
+    notify_reset ();
+
+    ok (queues_restore (qs, 1, saved) == 0,
+        "queues_restore works");
+    json_decref (saved);
+
+    /* Restore reconstructs previously-notified state: no events */
+    ok (notify_count == 0,
+        "no notify events fired during restore");
+
+    /* State was nonetheless applied */
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL
+        && !queue_is_enabled (q)
+        && !queue_is_started (q),
+        "restored state applied without notifications");
+
+    queues_destroy (qs);
+}
+
+static void test_requires_accessor (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+    json_t *req;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    req = json_pack ("[s s]", "partition:batch", "infiniband");
+    if (!req)
+        BAIL_OUT ("json_pack failed");
+    config = json_pack ("{s:{s:O}}", "batch", "requires", req);
+    json_decref (req);
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure batch with requires array");
+    json_decref (config);
+
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "batch found");
+
+    json_t *r = queue_requires (q);
+    ok (r != NULL, "queue_requires returns non-NULL");
+    ok (json_is_array (r), "queue_requires returns array");
+    ok (json_array_size (r) == 2, "requires has 2 elements");
+    ok (streq (json_string_value (json_array_get (r, 0)),
+                "partition:batch"),
+        "first requires element correct");
+    ok (streq (json_string_value (json_array_get (r, 1)),
+                "infiniband"),
+        "second requires element correct");
+
+    queues_destroy (qs);
+}
+
+static void test_restore_bad_args (void)
+{
+    struct queues *qs;
+    json_t *a;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    a = json_array ();
+    if (!a)
+        BAIL_OUT ("json_array failed");
+
+    errno = 0;
+    ok (queues_restore (qs, 2, a) < 0 && errno == EINVAL,
+        "queues_restore with invalid version fails");
+    errno = 0;
+    ok (queues_restore (qs, 1, NULL) < 0 && errno == EINVAL,
+        "queues_restore with NULL data fails");
+    errno = 0;
+    ok (queues_restore (qs, 1, json_null ()) < 0 && errno == EINVAL,
+        "queues_restore with non-array fails");
+
+    json_decref (a);
+    queues_destroy (qs);
+}
+
+static void test_anon_restore_v1 (void)
+{
+    struct queues *qs_save, *qs_restore;
+    struct queue *q;
+    json_t *saved;
+
+    /* Save anon queue state */
+    qs_save = queues_create ();
+    if (!qs_save)
+        BAIL_OUT ("queues_create failed");
+    q = queues_lookup (qs_save, NULL, NULL);
+    ok (q != NULL, "got anon queue");
+    ok (queue_disable (q, "anon-maint") == 0, "disable anon queue");
+    ok (queue_stop (q, "anon-down", false) == 0, "stop anon queue");
+
+    saved = queues_save (qs_save);
+    ok (saved != NULL, "save anon queue state");
+    ok (json_array_size (saved) == 1, "one entry saved");
+    queues_destroy (qs_save);
+
+    /* Restore */
+    qs_restore = queues_create ();
+    if (!qs_restore)
+        BAIL_OUT ("queues_create failed");
+
+    ok (queues_restore (qs_restore, 1, saved) == 0,
+        "restore anon queue state v1");
+    json_decref (saved);
+
+    q = queues_lookup (qs_restore, NULL, NULL);
+    ok (q != NULL && queue_name (q) == NULL,
+        "anon queue present after restore");
+    ok (!queue_is_enabled (q), "anon disabled after restore");
+    is (queue_disable_reason (q), "anon-maint",
+        "anon disable_reason restored");
+    ok (!queue_is_started (q), "anon stopped after restore");
+    is (queue_stop_reason (q), "anon-down",
+        "anon stop_reason restored");
+
+    queues_destroy (qs_restore);
+}
+
+static void test_admin_ops (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    config = json_pack ("{s:{} s:{}}", "batch", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed");
+    json_decref (config);
+    queues_set_notify (qs, notify_cb, NULL);
+
+    /* start one queue by name */
+    notify_reset ();
+    ok (queues_start_queue (qs, "batch", false, &error) == 0,
+        "queues_start_queue by name works");
+    q = queues_lookup (qs, "batch", &error);
+    ok (q && queue_is_started (q),
+        "batch is started");
+    q = queues_lookup (qs, "debug", &error);
+    ok (q && !queue_is_started (q),
+        "debug remains stopped");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "start")
+        && streq (notify_log[0].name, "batch"),
+        "one start event fired for batch");
+
+    /* stop one queue by name with a reason */
+    notify_reset ();
+    ok (queues_stop_queue (qs, "batch", "wedged", false, &error) == 0,
+        "queues_stop_queue by name works");
+    q = queues_lookup (qs, "batch", &error);
+    ok (q
+        && !queue_is_started (q)
+        && streq (queue_stop_reason (q), "wedged"),
+        "batch stopped by name with reason");
+    q = queues_lookup (qs, "debug", &error);
+    ok (q && !queue_is_started (q), "debug remains stopped");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "stop")
+        && streq (notify_log[0].name, "batch"),
+        "one stop event fired for batch");
+
+    /* stop all queues (NULL name) with reason */
+    notify_reset ();
+    ok (queues_stop_queue (qs, NULL, "maint", false, &error) == 0,
+        "queues_stop_queue with NULL name works");
+    q = queues_lookup (qs, "batch", &error);
+    ok (q
+        && !queue_is_started (q)
+        && streq (queue_stop_reason (q), "maint"),
+        "batch is stopped with reason");
+    ok (notify_count == 2,
+        "stop events fired for both queues");
+
+    /* unknown name fails */
+    ok (queues_start_queue (qs, "noexist", false, &error) < 0,
+        "queues_start_queue unknown name fails");
+
+    /* disable requires a reason */
+    errno = 0;
+    ok (queues_disable_queue (qs, "batch", NULL, &error) < 0
+        && errno == EINVAL,
+        "queues_disable_queue without reason fails with EINVAL");
+
+    /* disable by name, then enable all */
+    ok (queues_disable_queue (qs, "batch", "broken", &error) == 0,
+        "queues_disable_queue works");
+    q = queues_lookup (qs, "batch", &error);
+    ok (q
+        && !queue_is_enabled (q)
+        && streq (queue_disable_reason (q), "broken"),
+        "batch is disabled with reason");
+    ok (queues_enable_queue (qs, NULL, &error) == 0,
+        "queues_enable_queue with NULL name works");
+    ok (q && queue_is_enabled (q),
+        "batch is enabled again");
+
+    queues_destroy (qs);
+}
+
+/* Notify callback that reenters the class with a lookup, as the job
+ * manager's callback does (its enqueue/dequeue side effects match jobs
+ * by queue name).  zhashx_lookup repositions the hash cursor, so
+ * aggregate operations must not iterate with queues_first/next while
+ * notifications fire - this callback turns that mistake into an
+ * infinite loop.  Regression test for a bug caught in testing.
+ */
+static void reenter_cb (struct queues *queues,
+                        struct queue *q,
+                        const char *event,
+                        void *arg)
+{
+    int *count = arg;
+
+    (void)queues_lookup (queues, queue_name (q), NULL);
+    (*count)++;
+}
+
+static void test_admin_ops_reenter (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+    int count = 0;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    config = json_pack ("{s:{} s:{} s:{}}", "batch", "debug", "gpu");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed");
+    json_decref (config);
+    queues_set_notify (qs, reenter_cb, &count);
+
+    count = 0;
+    ok (queues_start_queue (qs, NULL, false, &error) == 0,
+        "queues_start_queue all with reentrant callback works");
+    ok (count == 3,
+        "start fired exactly one notification per queue");
+    q = queues_lookup (qs, "batch", &error);
+    ok (q && queue_is_started (q),
+        "batch is started");
+    q = queues_lookup (qs, "gpu", &error);
+    ok (q && queue_is_started (q),
+        "gpu is started");
+
+    count = 0;
+    ok (queues_stop_queue (qs, NULL, "maint", false, &error) == 0,
+        "queues_stop_queue all with reentrant callback works");
+    ok (count == 3,
+        "stop fired exactly one notification per queue");
+
+    count = 0;
+    ok (queues_disable_queue (qs, NULL, "maint", &error) == 0
+        && queues_enable_queue (qs, NULL, &error) == 0,
+        "disable/enable all with reentrant callback works");
+    ok (count == 6,
+        "disable+enable fired exactly one notification per queue each");
+
+    queues_destroy (qs);
+}
+
+static void test_list_names (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+    zlistx_t *names;
+    const char *name;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* anon mode: empty list */
+    names = queues_list_names (qs);
+    ok (names != NULL && zlistx_size (names) == 0,
+        "queues_list_names returns empty list in anon mode");
+    zlistx_destroy (&names);
+
+    config = json_pack ("{s:{} s:{}}", "batch", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed");
+    json_decref (config);
+
+    names = queues_list_names (qs);
+    ok (names != NULL && zlistx_size (names) == 2,
+        "queues_list_names returns both queue names");
+    bool saw_batch = false, saw_debug = false;
+    name = zlistx_first (names);
+    while (name) {
+        if (streq (name, "batch"))
+            saw_batch = true;
+        if (streq (name, "debug"))
+            saw_debug = true;
+        name = zlistx_next (names);
+    }
+    ok (saw_batch && saw_debug,
+        "list contains batch and debug");
+
+    /* snapshot survives queue removal mid-iteration */
+    name = zlistx_first (names);
+    ok (queues_remove (qs, "batch") == 0,
+        "queues_remove during snapshot iteration works");
+    ok (queues_lookup (qs, "batch", NULL) == NULL,
+        "removed name no longer resolves");
+    ok (zlistx_size (names) == 2,
+        "snapshot list is unaffected by removal");
+    zlistx_destroy (&names);
+
+    queues_destroy (qs);
+}
+
+static void test_add_remove_primitives (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    struct queue *q2;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    queues_set_notify (qs, notify_cb, NULL);
+
+    /* add named queue from anon mode */
+    notify_reset ();
+    config = json_pack ("{s:[s]}", "requires", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    q = queues_add (qs, "batch", config, &error);
+    json_decref (config);
+    ok (q != NULL, "queues_add batch from anon mode works");
+    ok (queues_have_named (qs), "queues_have_named is true after add");
+    ok (notify_count == 2
+        && streq (notify_log[0].event, "remove")
+        && streq (notify_log[0].name, "")
+        && streq (notify_log[1].event, "add")
+        && streq (notify_log[1].name, "batch"),
+        "add from anon mode fires anon remove then batch add");
+    ok (queue_is_enabled (q) && !queue_is_started (q),
+        "added named queue is enabled + stopped");
+    ok (queue_requires (q) != NULL
+        && json_array_size (queue_requires (q)) == 1,
+        "added queue has requires from config");
+
+    /* duplicate add is an error */
+    notify_reset ();
+    errno = 0;
+    q2 = queues_add (qs, "batch", NULL, &error);
+    ok (q2 == NULL && errno == EEXIST,
+        "queues_add duplicate name fails with EEXIST");
+    ok (notify_count == 0, "failed add fires no events");
+
+    /* add a second queue in named mode: no mode transition */
+    notify_reset ();
+    q2 = queues_add (qs, "debug", NULL, &error);
+    ok (q2 != NULL, "queues_add debug in named mode works");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "add")
+        && streq (notify_log[0].name, "debug"),
+        "add in named mode fires a single add event");
+
+    /* remove error cases */
+    errno = 0;
+    ok (queues_remove (qs, "noexist") < 0 && errno == ENOENT,
+        "queues_remove unknown name fails with ENOENT");
+    errno = 0;
+    ok (queues_remove (qs, NULL) < 0 && errno == EINVAL,
+        "queues_remove NULL name fails with EINVAL");
+
+    /* remove one queue */
+    notify_reset ();
+    ok (queues_remove (qs, "debug") == 0,
+        "queues_remove debug works");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "remove")
+        && streq (notify_log[0].name, "debug"),
+        "remove fires a single remove event");
+    ok (queues_lookup (qs, "debug", NULL) == NULL,
+        "removed queue is no longer found");
+
+    /* add NULL from named mode: back to anon */
+    notify_reset ();
+    q = queues_add (qs, NULL, NULL, &error);
+    ok (q != NULL, "queues_add NULL from named mode works");
+    ok (!queues_have_named (qs), "queues_have_named is false again");
+    ok (queue_is_enabled (q) && queue_is_started (q),
+        "anon queue is enabled + started");
+    ok (notify_count == 2
+        && streq (notify_log[0].event, "remove")
+        && streq (notify_log[0].name, "batch")
+        && streq (notify_log[1].event, "add")
+        && streq (notify_log[1].name, ""),
+        "add NULL fires remove per named queue then anon add");
+
+    /* add NULL when already anon: idempotent, no events */
+    notify_reset ();
+    q2 = queues_add (qs, NULL, NULL, &error);
+    ok (q2 == q, "queues_add NULL when already anon returns same queue");
+    ok (notify_count == 0, "idempotent anon add fires no events");
+
+    /* remove in anon mode is an error */
+    errno = 0;
+    ok (queues_remove (qs, "batch") < 0 && errno == EINVAL,
+        "queues_remove in anon mode fails with EINVAL");
+
+    queues_destroy (qs);
+}
+
+/* queues_add (NULL) with multiple named queues: all named queues are
+ * removed (one "remove" notification each, in any order) and replaced
+ * by a fresh anonymous queue, regardless of the named queues'
+ * administrative state.
+ */
+static void test_add_anon_removes_all (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    config = json_pack ("{s:{} s:{} s:{}}", "batch", "debug", "gpu");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed");
+    json_decref (config);
+
+    /* Give the queues distinct administrative state */
+    q = queues_lookup (qs, "batch", &error);
+    if (!q || queue_start (q, false) < 0)
+        BAIL_OUT ("could not start batch");
+    q = queues_lookup (qs, "debug", &error);
+    if (!q || queue_disable (q, "maint") < 0)
+        BAIL_OUT ("could not disable debug");
+
+    queues_set_notify (qs, notify_cb, NULL);
+    notify_reset ();
+
+    q = queues_add (qs, NULL, NULL, &error);
+    ok (q != NULL,
+        "queues_add NULL with multiple named queues works");
+    ok (!queues_have_named (qs),
+        "table is in anon mode");
+    ok (queue_is_enabled (q) && queue_is_started (q),
+        "anon queue is enabled + started regardless of prior state");
+
+    /* One remove per named queue (hash order unspecified), then the
+     * anon add */
+    int removes = 0;
+    bool saw_batch = false, saw_debug = false, saw_gpu = false;
+    for (int i = 0; i < notify_count; i++) {
+        if (streq (notify_log[i].event, "remove")) {
+            removes++;
+            if (streq (notify_log[i].name, "batch"))
+                saw_batch = true;
+            if (streq (notify_log[i].name, "debug"))
+                saw_debug = true;
+            if (streq (notify_log[i].name, "gpu"))
+                saw_gpu = true;
+        }
+    }
+    ok (removes == 3 && saw_batch && saw_debug && saw_gpu,
+        "remove fired once for each named queue");
+    ok (notify_count == 4
+        && streq (notify_log[3].event, "add")
+        && streq (notify_log[3].name, ""),
+        "anon add fired last");
+
+    ok (queues_lookup (qs, "batch", NULL) == NULL
+        && queues_lookup (qs, "debug", NULL) == NULL
+        && queues_lookup (qs, "gpu", NULL) == NULL,
+        "named queues are no longer found");
+    {
+        zlistx_t *names = queues_list_names (qs);
+        ok (names != NULL && zlistx_size (names) == 0
+            && queues_lookup (qs, NULL, NULL) == q,
+            "table contains exactly the anonymous queue");
+        zlistx_destroy (&names);
+    }
+
+    queues_destroy (qs);
+}
+
+/* A new queue whose config value is not an object (so the "requires"
+ * unpack fails) is rejected with EINVAL, and the prior anon state is
+ * left intact.
+ */
+static void test_add_invalid_config (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    queues_set_notify (qs, notify_cb, NULL);
+    notify_reset ();
+
+    /* config value is an integer, not an object */
+    config = json_integer (5);
+    if (!config)
+        BAIL_OUT ("json_integer failed");
+    errno = 0;
+    q = queues_add (qs, "batch", config, &error);
+    json_decref (config);
+    ok (q == NULL && errno == EINVAL,
+        "queues_add with non-object config fails with EINVAL");
+    ok (strlen (error.text) > 0, "error.text set");
+    ok (notify_count == 0, "failed add fires no events");
+    ok (!queues_have_named (qs), "still in anon mode after failed add");
+
+    queues_destroy (qs);
+}
+
+/* Reconfiguring an existing queue with an invalid (non-object) config
+ * value takes the queues_update() path and fails with EINVAL. The prior
+ * queue and its administrative state must be left intact.
+ */
+static void test_update_invalid_config (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+    json_t *bad;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{s:[s]}}", "batch", "requires", "gpu");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure batch with requires");
+    json_decref (config);
+
+    /* Give batch administrative state to verify it survives the failure */
+    q = queues_lookup (qs, "batch", &error);
+    if (!q || queue_disable (q, "maint") < 0)
+        BAIL_OUT ("could not disable batch");
+
+    /* reconfigure existing "batch" with a non-object value */
+    bad = json_pack ("{s:i}", "batch", 5);
+    if (!bad)
+        BAIL_OUT ("json_pack failed");
+    errno = 0;
+    ok (queues_configure (qs, bad, &error) < 0 && errno == EINVAL,
+        "reconfigure existing queue with non-object value fails EINVAL");
+    ok (strlen (error.text) > 0, "error.text set");
+    json_decref (bad);
+
+    /* Old configuration must be intact after the failed reconfigure */
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "batch still present after failed reconfigure");
+    ok (!queue_is_enabled (q), "batch still disabled after failure");
+    is (queue_disable_reason (q), "maint",
+        "batch disable_reason preserved after failure");
+    ok (queue_requires (q) != NULL
+        && json_array_size (queue_requires (q)) == 1,
+        "batch requires preserved after failure");
+
+    queues_destroy (qs);
+}
+
+/* A failed queues_configure() must not partially apply: a config that
+ * drops one queue and adds an invalid one is rejected whole, leaving the
+ * dropped queue in place with no notifications fired. Regression test for
+ * the non-transactional remove-before-add ordering.
+ */
+static void test_configure_partial_failure (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+    json_t *bad;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{} s:{}}", "batch", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed");
+    json_decref (config);
+
+    queues_set_notify (qs, notify_cb, NULL);
+    notify_reset ();
+
+    /* New config drops "debug" and adds invalid "gpu" (non-object). The
+     * whole reconfigure must be rejected before "debug" is removed.
+     */
+    bad = json_pack ("{s:{} s:i}", "batch", "gpu", 5);
+    if (!bad)
+        BAIL_OUT ("json_pack failed");
+    errno = 0;
+    ok (queues_configure (qs, bad, &error) < 0 && errno == EINVAL,
+        "configure with an invalid new queue fails with EINVAL");
+    json_decref (bad);
+
+    ok (notify_count == 0, "no notifications fired on failed configure");
+    ok (queues_lookup (qs, "debug", NULL) != NULL,
+        "dropped queue still present after failed configure");
+    ok (queues_lookup (qs, "batch", NULL) != NULL,
+        "existing queue still present after failed configure");
+    ok (queues_lookup (qs, "gpu", NULL) == NULL,
+        "invalid queue was not added");
+
+    queues_destroy (qs);
+}
+
+/* A malformed entry inside the restore array (missing a required field)
+ * fails with EINVAL. Covers the per-entry unpack error in restore_v1
+ * and restore_v0.
+ */
+static void test_restore_bad_entry (void)
+{
+    struct queues *qs;
+    json_t *saved;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* v1 entry missing the required "start" field */
+    saved = json_pack ("[{s:s s:b}]",
+                       "name", "batch",
+                       "enable", 1);
+    if (!saved)
+        BAIL_OUT ("json_pack failed");
+    errno = 0;
+    ok (queues_restore (qs, 1, saved) < 0 && errno == EINVAL,
+        "queues_restore v1 with malformed entry fails with EINVAL");
+    json_decref (saved);
+
+    /* v0 entry missing the required "enable" field */
+    saved = json_pack ("[{s:s}]", "name", "batch");
+    if (!saved)
+        BAIL_OUT ("json_pack failed");
+    errno = 0;
+    ok (queues_restore (qs, 0, saved) < 0 && errno == EINVAL,
+        "queues_restore v0 with malformed entry fails with EINVAL");
+    json_decref (saved);
+
+    queues_destroy (qs);
+}
+
+static void test_status_encode (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+    json_t *o;
+    int enable;
+    int start;
+    const char *reason;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    config = json_pack ("{s:{}}", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed");
+    json_decref (config);
+    q = queues_lookup (qs, "batch", &error);
+    if (!q)
+        BAIL_OUT ("queues_lookup failed");
+
+    /* enabled + stopped (default), scheduler ready, no stop reason */
+    o = queue_status_encode (q, true);
+    ok (o != NULL, "queue_status_encode works");
+    ok (json_unpack (o, "{s:b s:b !}", "enable", &enable,
+                     "start", &start) == 0
+        && enable && !start,
+        "default status: enabled + stopped, no reasons");
+    json_decref (o);
+
+    /* stopped with reason */
+    queue_stop (q, "maintenance", false);
+    o = queue_status_encode (q, true);
+    ok (o && json_unpack (o, "{s:b s:b s:s !}", "enable", &enable,
+                          "start", &start, "stop_reason", &reason) == 0
+        && enable && !start && streq (reason, "maintenance"),
+        "stopped status includes stop_reason");
+    json_decref (o);
+
+    /* started, scheduler ready */
+    queue_start (q, false);
+    o = queue_status_encode (q, true);
+    ok (o && json_unpack (o, "{s:b s:b !}", "enable", &enable,
+                          "start", &start) == 0
+        && enable && start,
+        "started status: start true, no stop_reason");
+    json_decref (o);
+
+    /* started but scheduler offline: presented stopped + synthesized
+     * reason (own state untouched) */
+    o = queue_status_encode (q, false);
+    ok (o && json_unpack (o, "{s:b s:b s:s !}", "enable", &enable,
+                          "start", &start, "stop_reason", &reason) == 0
+        && enable && !start && streq (reason, "Scheduler is offline"),
+        "sched offline: presented stopped with synthesized reason");
+    ok (queue_is_started (q),
+        "sched offline does not modify queue state");
+    json_decref (o);
+
+    /* disabled: disable_reason included */
+    queue_disable (q, "no submit");
+    o = queue_status_encode (q, true);
+    ok (o && json_unpack (o, "{s:b s:b s:s !}", "enable", &enable,
+                          "start", &start, "disable_reason", &reason) == 0
+        && !enable && start && streq (reason, "no submit"),
+        "disabled status includes disable_reason");
+    json_decref (o);
+
+    queues_destroy (qs);
+}
+
+static void test_list_encode (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+    json_t *a;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* anon mode: empty array */
+    a = queues_list_encode (qs);
+    ok (a != NULL && json_is_array (a) && json_array_size (a) == 0,
+        "list_encode in anon mode returns empty array");
+    json_decref (a);
+
+    /* named mode: array of names */
+    config = json_pack ("{s:{} s:{}}", "batch", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed");
+    json_decref (config);
+
+    a = queues_list_encode (qs);
+    ok (a != NULL && json_array_size (a) == 2,
+        "list_encode returns both queue names");
+    bool saw_batch = false, saw_debug = false;
+    size_t i;
+    json_t *v;
+    json_array_foreach (a, i, v) {
+        const char *s = json_string_value (v);
+        if (s && streq (s, "batch"))
+            saw_batch = true;
+        if (s && streq (s, "debug"))
+            saw_debug = true;
+    }
+    ok (saw_batch && saw_debug, "list contains batch and debug");
+    json_decref (a);
+
+    queues_destroy (qs);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_create_destroy ();
+    test_configure_named ();
+    test_configure_empty_is_anon ();
+    test_anon_to_named_and_back ();
+    test_reload_diff ();
+    test_update_preserves_state ();
+    test_lookup ();
+    test_enable_disable ();
+    test_start_stop ();
+    test_save_restore_v1 ();
+    test_restore_v0 ();
+    test_restore_unknown_queue_ignored ();
+    test_notify_configure ();
+    test_notify_restore ();
+    test_requires_accessor ();
+    test_restore_bad_args ();
+    test_anon_restore_v1 ();
+    test_add_remove_primitives ();
+    test_add_anon_removes_all ();
+    test_add_invalid_config ();
+    test_update_invalid_config ();
+    test_configure_partial_failure ();
+    test_restore_bad_entry ();
+    test_admin_ops ();
+    test_admin_ops_reenter ();
+    test_list_names ();
+    test_status_encode ();
+    test_list_encode ();
+
+    done_testing ();
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -586,5 +586,20 @@ test_expect_success 'flux-queue disable fails on unknown queue' '
 test_expect_success 'flux-queue status fails on unknown queue' '
 	test_must_fail flux queue status notaqueue
 '
+test_expect_success 'config load with bad job-manager table fails' '
+	test_must_fail flux config load 2>badconf.err <<-EOT &&
+	[job-manager]
+	stop-queues-on-restart = "notabool"
+	[queues.batch]
+	[queues.debug]
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+	grep "error updating job-manager" badconf.err
+'
+test_expect_success 'configured queues survive a failed config load' '
+	flux queue list -n >queues_after_badconf.out &&
+	test $(wc -l < queues_after_badconf.out) -eq 2
+'
 
 test_done


### PR DESCRIPTION
This PR refactors the job-manager's queue handling, splitting the queue configuration and state logic out of the `queue.c` service layer into a standalone `queues` class (`queues.c`/`queues.h`).

The new class is pure state management with no broker/RPC dependencies: `queue.c` remains the service layer and drives side effects (enqueue/dequeue, logging) via a single change-notification callback, while the class owns the `struct queues` collection and per-queue `struct queue` state. This allows the queue configuration and state logic to be covered by a standalone unit test (`test/queues.c`).

The queues interface is designed to easily support future work on vqueues and runtime queues, but there should be no significant user visible changes yet.