### PR TITLE
job-exec: refactor to allow backends to share code

### DIFF
--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -23,6 +23,8 @@ libjob_exec_la_SOURCES = \
 	namespace.c \
 	exec_config.h \
 	exec_config.c \
+	exec_cmd.h \
+	exec_cmd.c \
 	barrier.h \
 	barrier.c \
 	rset.c \

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -23,6 +23,8 @@ libjob_exec_la_SOURCES = \
 	namespace.c \
 	exec_config.h \
 	exec_config.c \
+	barrier.h \
+	barrier.c \
 	rset.c \
 	rset.h \
 	testexec.c \

--- a/src/modules/job-exec/barrier.c
+++ b/src/modules/job-exec/barrier.c
@@ -1,0 +1,235 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* barrier.c - shell barrier
+ */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <flux/core.h>
+#include <flux/idset.h>
+
+#include "src/common/libjob/idf58.h"
+#include "src/common/libutil/errprintf.h"
+
+#include "job-exec.h"
+#include "barrier.h"
+
+struct barrier {
+    struct jobinfo *job;
+    struct idset *pending_ranks;
+    int enter_count;
+    int exit_count;
+    int total;
+    struct flux_msglist *requests;
+    flux_watcher_t *timer;
+};
+
+static void barrier_release (struct barrier *b, int errnum)
+{
+    const flux_msg_t *msg;
+    struct jobinfo *job = b->job;
+
+    if (!b->requests)
+        return;
+    while ((msg = flux_msglist_first (b->requests))) {
+        int rc;
+        if (errnum == 0)
+            rc = shell_barrier_respond (job->h, msg, NULL);
+        else
+            rc = shell_barrier_respond_error (job->h, msg, errnum, NULL);
+        if (rc < 0)
+            flux_log_error (job->h, "shell-barrier: error responding to shell");
+        flux_msglist_delete (b->requests);
+    }
+}
+
+static void barrier_timer_cb (flux_reactor_t *r,
+                              flux_watcher_t *w,
+                              int revents,
+                              void *arg)
+{
+    struct barrier *b = arg;
+    struct jobinfo *job = b->job;
+    char *ranks;
+
+    if (!(ranks = idset_encode (b->pending_ranks, IDSET_FLAG_RANGE))) {
+        flux_log_error (job->h,
+                        "failed to encode barrier pending ranks for job %s",
+                        idf58 (job->id));
+        return;
+    }
+
+    /*  User-facing drain reason and exception message - don't change. */
+    (void) jobinfo_drain_ranks (job,
+                                ranks,
+                                "job %s start timeout: %s",
+                                idf58 (job->id),
+                                "possible node hang");
+
+    jobinfo_fatal_error (job,
+                         0,
+                         "%s waiting for %zu/%d nodes (rank%s %s)",
+                         "start barrier timeout",
+                         idset_count (b->pending_ranks),
+                         b->total,
+                         idset_count (b->pending_ranks) > 1 ?"s":"",
+                         ranks);
+    free (ranks);
+}
+
+int barrier_enter (struct barrier *b, const flux_msg_t *msg)
+{
+    struct jobinfo *job = b->job;
+    int rank;
+
+    if (flux_msg_unpack (msg, "{s:i}", "rank", &rank) < 0)
+        return BARRIER_ERROR;
+    /*  Reject a request whose rank is out of range or not pending
+     *  to avoid corrupting barrier accounting.
+     */
+    if (rank < 0 || !idset_test (b->pending_ranks, rank)) {
+        flux_error_t error;
+        errprintf (&error, "rank %d is not pending in barrier", rank);
+        if (shell_barrier_respond_error (job->h,
+                                         msg,
+                                         EINVAL,
+                                         error.text) < 0)
+            flux_log_error (job->h, "shell-barrier: error responding");
+        return BARRIER_PENDING;
+    }
+    (void) idset_clear (b->pending_ranks, rank);
+    b->enter_count++;
+
+    /*
+     *  Terminate barrier with error immediately when a shell enters after
+     *   one or more shells have already exited. The case where a shell exits
+     *   while a barrier is already in progress is handled in exit_cb().
+     */
+    if (b->exit_count > 0) {
+        if (shell_barrier_respond_error (job->h, msg, EIO, NULL) < 0)
+            flux_log_error (job->h, "shell-barrier: error responding");
+        return BARRIER_PENDING;
+    }
+
+    if (flux_msglist_append (b->requests, msg) < 0)
+        return BARRIER_ERROR;
+
+    if (b->enter_count == b->total) {
+        barrier_release (b, 0);
+        flux_watcher_stop (b->timer);
+        return BARRIER_COMPLETE;
+    }
+    /*  When the first shell enters the barrier, start a timer after
+     *   which the job will be terminated if all shells have not reached
+     *   the barrier.
+     */
+    if (b->enter_count == 1)
+        flux_watcher_start (b->timer);
+
+    return BARRIER_PENDING;
+}
+
+void barrier_notify_shell_exit (struct barrier *b)
+{
+    b->exit_count++;
+
+    /*  Terminate any barrier in progress with error, releasing shells
+     *   currently waiting so they exit immediately rather than being killed
+     *   by the exec system.  Shells that enter the barrier later are
+     *   rejected by barrier_enter() since exit_count is now nonzero.
+     */
+    barrier_release (b, EIO);
+}
+
+int barrier_drain_pending (struct barrier *b, const struct idset *ranks)
+{
+    struct idset *drain_ranks;
+    char *drain_ids = NULL;
+    int rc = -1;
+
+    if (!(drain_ranks = idset_intersect (ranks, b->pending_ranks))
+        || !(drain_ids = idset_encode (drain_ranks, IDSET_FLAG_RANGE)))
+        goto fail;
+
+    /*  User-facing drain reason - don't change. */
+    if (idset_count (drain_ranks) > 0
+        && jobinfo_drain_ranks (b->job,
+                                drain_ids,
+                                "%s terminated before first barrier",
+                                idf58 (b->job->id)) < 0)
+        goto fail;
+
+    rc = 0;
+
+fail:
+    idset_destroy (drain_ranks);
+    free (drain_ids);
+    return rc;
+}
+
+void barrier_destroy (struct barrier *b)
+{
+    if (b) {
+        int saved_errno = errno;
+        /*  Respond with an error to any requests still parked in the
+         *  barrier so those shells exit rather than blocking until killed.
+         */
+        barrier_release (b, EIO);
+        flux_msglist_destroy (b->requests);
+        idset_destroy (b->pending_ranks);
+        flux_watcher_destroy (b->timer);
+        free (b);
+        errno = saved_errno;
+    }
+}
+
+struct barrier *barrier_create (struct jobinfo *job,
+                                const struct idset *ranks,
+                                double timeout,
+                                flux_error_t *errp)
+{
+    struct barrier *b = NULL;
+    flux_reactor_t *r;
+
+    if (!(r = flux_get_reactor (job->h))
+        || !(b = calloc (1, sizeof (*b)))
+        || !(b->requests = flux_msglist_create ())
+        || !(b->pending_ranks = idset_copy (ranks))) {
+        errprintf (errp, "%s", strerror (errno));
+        goto error;
+    }
+    b->job = job;
+    b->total = idset_count (ranks);
+
+    if (timeout > 0.) {
+        b->timer = flux_timer_watcher_create (r,
+                                              timeout,
+                                              0.,
+                                              barrier_timer_cb,
+                                              b);
+        if (!b->timer) {
+            errprintf (errp,
+                       "%s: failed to create barrier timer",
+                       idf58 (job->id));
+            goto error;
+        }
+    }
+    return b;
+error:
+    barrier_destroy (b);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-exec/barrier.h
+++ b/src/modules/job-exec/barrier.h
@@ -1,0 +1,80 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_JOB_EXEC_BARRIER_H
+#define HAVE_JOB_EXEC_BARRIER_H 1
+
+#include <flux/core.h>
+#include <flux/idset.h>
+
+struct jobinfo;
+
+/*  A shell barrier: a one-shot, all-ranks rendezvous.
+ *
+ *  Job shells enter a barrier at points during startup (after
+ *  initialization, and again after tasks are started).  The barrier
+ *  completes when all shells have entered, at which point they are released
+ *  together.  A timer (optional) terminates the job if not all shells enter
+ *  within the configured timeout, since that likely indicates a hung node.
+ *
+ *  This is a self-contained unit: it is a single rendezvous over a fixed
+ *  rank set and knows nothing of the sequence of barriers a job performs.
+ *  The caller creates one per barrier (destroying the previous one on
+ *  completion), so the "first barrier is timed" policy lives in the caller,
+ *  not here.  It is driven entirely by plain values so it does not depend on
+ *  a particular exec backend.
+ */
+
+struct barrier;
+
+enum barrier_status {
+    BARRIER_ERROR    = -1,  /* internal failure; errno set */
+    BARRIER_PENDING  =  0,  /* not all entered, or request rejected */
+    BARRIER_COMPLETE =  1,  /* all ranks entered and were released */
+};
+
+/*  Create a barrier over the shell ranks in `ranks`.  `timeout` is the
+ *  barrier timeout in seconds; if <= 0 no timer is armed.
+ */
+struct barrier *barrier_create (struct jobinfo *job,
+                                const struct idset *ranks,
+                                double timeout,
+                                flux_error_t *errp);
+
+/*  Destroy the barrier, responding EIO to any still-parked requests so that
+ *  waiting shells exit rather than blocking until killed.
+ */
+void barrier_destroy (struct barrier *b);
+
+/*  Handle a shell's barrier-enter request.  Rejects a request whose rank is
+ *  out of range or not pending.  Returns BARRIER_COMPLETE when this request
+ *  is the last to enter (all parked requests have been released),
+ *  BARRIER_PENDING when more ranks are still expected (including the
+ *  rejected-request case, which is reported to the shell), or BARRIER_ERROR
+ *  with errno set on internal failure.
+ */
+int barrier_enter (struct barrier *b, const flux_msg_t *msg);
+
+/*  Notify the barrier that one or more shells have exited.  Terminates the
+ *  in-progress barrier with EIO (releasing waiting shells so they exit) and
+ *  causes subsequent barrier-enter requests to be rejected.
+ */
+void barrier_notify_shell_exit (struct barrier *b);
+
+/*  Drain the subset of `ranks` that are still pending in the barrier.
+ *  Returns 0 on success, -1 with errno set on failure.
+ */
+int barrier_drain_pending (struct barrier *b, const struct idset *ranks);
+
+#endif /* !HAVE_JOB_EXEC_BARRIER_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -46,10 +46,9 @@
 
 #include "job-exec.h"
 #include "exec_config.h"
+#include "exec_cmd.h"
 #include "rset.h"
 #include "barrier.h"
-
-extern char **environ;
 
 struct exec_ctx {
     struct jobinfo *job;
@@ -559,77 +558,8 @@ static int exec_init (struct jobinfo *job)
         flux_log_error (job->h, "exec_init: bulk_exec_aux_set");
         goto err;
     }
-    if (!(cmd = flux_cmd_create (0, NULL, environ))) {
-        flux_log_error (job->h, "exec_init: flux_cmd_create");
+    if (!(cmd = job_shell_cmd_create (job, service)))
         goto err;
-    }
-    /* Set any configured exec.sdexec-properties.
-     */
-    json_t *props;
-    if (streq (service, "sdexec")
-        && (props = config_get_sdexec_properties ())) {
-        const char *k;
-        json_t *v;
-        json_object_foreach (props, k, v) {
-            char name[128];
-            snprintf (name, sizeof (name), "SDEXEC_PROP_%s", k);
-            if (flux_cmd_setopt (cmd, name, json_string_value (v)) < 0) {
-                flux_log_error (job->h, "Unable to set sdexec options");
-                return -1;
-            }
-        }
-    }
-    if (flux_cmd_setenvf (cmd, 1, "FLUX_KVS_NAMESPACE", "%s", job->ns) < 0) {
-        flux_log_error (job->h, "exec_init: flux_cmd_setenvf");
-        goto err;
-    }
-    if (job->multiuser) {
-        if (flux_cmd_setenvf (cmd,
-                              1,
-                              "FLUX_IMP_EXEC_HELPER",
-                              "flux imp_exec_helper %ju",
-                              (uintmax_t) job->id) < 0) {
-            flux_log_error (job->h, "exec_init: flux_cmd_setenvf");
-            goto err;
-        }
-        /* The systemd user instance running as user flux is not privileged
-         * to signal guest processes, therefore:
-         * - Set the KillMode=process so only the IMP is signaled
-         * - Use Type=notify in conjunction with IMP calling sd_notify(3) so
-         *   the unit transitions to deactivating when the shell exits.
-         * - Set TimeoutStopUsec=infinity to disable systemd's stop timeout.
-         * - Enable sdexec's stop timeout which is armed at deactivating,
-         *   delivers SIGUSR1 (proxy for SIGKILL) after 30s, then abandons
-         *   the unit and terminates the exec RPC after another 30s.
-         */
-        if (streq (service, "sdexec")) {
-            if (flux_cmd_setopt (cmd, "SDEXEC_PROP_KillMode", "process") < 0
-                || flux_cmd_setopt (cmd, "SDEXEC_PROP_Type", "notify") < 0
-                || flux_cmd_setopt (cmd,
-                                    "SDEXEC_PROP_TimeoutStopUSec",
-                                    "infinity") < 0
-                || flux_cmd_setopt (cmd,
-                                    "SDEXEC_STOP_TIMER_SIGNAL",
-                                    config_get_sdexec_stop_timer_signal ()) < 0
-                || flux_cmd_setopt (cmd,
-                                    "SDEXEC_STOP_TIMER_SEC",
-                                    config_get_sdexec_stop_timer_sec ()) < 0) {
-                flux_log_error (job->h,
-                                "Unable to set multiuser sdexec options");
-                return -1;
-            }
-        }
-        if (flux_cmd_argv_append (cmd, config_get_imp_path ()) < 0
-            || flux_cmd_argv_append (cmd, "exec") < 0) {
-            flux_log_error (job->h, "exec_init: flux_cmd_argv_append");
-            goto err;
-        }
-    }
-    if (flux_cmd_argv_append (cmd, config_get_job_shell (job)) < 0
-        || flux_cmd_argv_appendf (cmd, "%ju", (uintmax_t) job->id) < 0) {
-        flux_log_error (job->h, "exec_init: flux_cmd_argv_append");
-        goto err;
-    }
     /* When per-rank sdexec options are needed, push one cmd per rank so
      * each transient unit can be configured for its own allocation.
      * Otherwise push a single command covering all ranks (the common case).

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -48,6 +48,7 @@
 #include "job-exec.h"
 #include "exec_config.h"
 #include "rset.h"
+#include "barrier.h"
 
 /*  Numeric severity used for a non-fatal, critical job exception:
  *  (e.g. node failure)
@@ -61,10 +62,15 @@ struct exec_ctx {
 
     const char * mock_exception;   /* fake exception */
     const char *sdexec_test_expected_cpus; /* override for post-start check */
-    struct idset *barrier_pending_ranks;
-    int barrier_enter_count;
-    int barrier_completion_count;
-    struct flux_msglist *barrier_requests;
+
+    /*  Shells enter a sequence of barriers during startup.  Only the first
+     *  is timed; on completion the current barrier is destroyed and a fresh
+     *  untimed one is created for the next.  first_barrier_done records that
+     *  the first barrier has completed.
+     */
+    struct barrier *barrier;
+    double barrier_timeout;
+    bool first_barrier_done;
 
     /*  terminated_before_barrier will be set to true if one shell terminates
      *  before the first barrier *and* the first exception. This allows other
@@ -72,80 +78,14 @@ struct exec_ctx {
      */
     bool terminated_before_barrier;
 
-    int exit_count;
-
     bool shell_exit_posted; /* true after shell-exit event is posted */
-
-    flux_watcher_t *shell_barrier_timer;
 };
-
-static void barrier_release (struct exec_ctx *ctx, int errnum)
-{
-    const flux_msg_t *msg;
-    struct jobinfo *job = ctx->job;
-
-    if (!ctx->barrier_requests)
-        return;
-    while ((msg = flux_msglist_first (ctx->barrier_requests))) {
-        int rc;
-        if (errnum == 0)
-            rc = shell_barrier_respond (job->h, msg, NULL);
-        else
-            rc = shell_barrier_respond_error (job->h, msg, errnum, NULL);
-        if (rc < 0)
-            flux_log_error (job->h, "shell-barrier: error responding to shell");
-        flux_msglist_delete (ctx->barrier_requests);
-    }
-}
-
-static void barrier_timer_cb (flux_reactor_t *r,
-                              flux_watcher_t *w,
-                              int revents,
-                              void *arg)
-{
-    struct exec_ctx *ctx = arg;
-    struct jobinfo *job = ctx->job;
-    struct bulk_exec *exec = ctx->job->data;
-    char *ranks;
-
-    if (!(ranks = idset_encode (ctx->barrier_pending_ranks,
-                                IDSET_FLAG_RANGE))) {
-        flux_log_error (job->h,
-                        "failed to encode barrier pending ranks for job %s",
-                        idf58 (job->id));
-        return;
-    }
-
-    (void) jobinfo_drain_ranks (job,
-                                ranks,
-                                "job %s start timeout: %s",
-                                idf58 (job->id),
-                                "possible node hang");
-
-    jobinfo_fatal_error (job,
-                         0,
-                         "%s waiting for %zu/%d nodes (rank%s %s)",
-                         "start barrier timeout",
-                         idset_count (ctx->barrier_pending_ranks),
-                         bulk_exec_total (exec),
-                         idset_count (ctx->barrier_pending_ranks) > 1 ?"s":"",
-                         ranks);
-    free (ranks);
-}
-
 
 static void exec_ctx_destroy (struct exec_ctx *tc)
 {
     if (tc) {
         int saved_errno = errno;
-        /*  Respond with an error to any requests still parked in the
-         *  barrier so those shells exit rather than blocking until killed.
-         */
-        if (tc->job)
-            barrier_release (tc, EIO);
-        flux_msglist_destroy (tc->barrier_requests);
-        idset_destroy (tc->barrier_pending_ranks);
-        flux_watcher_destroy (tc->shell_barrier_timer);
+        barrier_destroy (tc->barrier);
         free (tc);
         errno = saved_errno;
     }
@@ -157,19 +97,15 @@ static struct exec_ctx *exec_ctx_create (struct jobinfo *job,
 {
     json_error_t error;
     const char *service;
-    flux_reactor_t *r;
     struct exec_ctx *ctx = NULL;
-    double barrier_timeout = config_get_default_barrier_timeout ();
 
-    if (!(r = flux_get_reactor (job->h))
-        || !(ctx = calloc (1, sizeof (*ctx)))
-        || !(ctx->barrier_requests = flux_msglist_create ())
-        || !(ctx->barrier_pending_ranks = idset_copy (ranks))) {
+    if (!(ctx = calloc (1, sizeof (*ctx)))) {
         errprintf (errp, "%s", strerror (errno));
         goto error;
     }
 
     ctx->job = job;
+    ctx->barrier_timeout = config_get_default_barrier_timeout ();
 
     /* Note: service unpacked below but unused to allow use of strict (!)
      * unpacking.
@@ -186,7 +122,7 @@ static struct exec_ctx *exec_ctx_create (struct jobinfo *job,
                                 "mock_exception", &ctx->mock_exception,
                                 "sdexec-test-expected-cpus",
                                     &ctx->sdexec_test_expected_cpus,
-                                "barrier-timeout", &barrier_timeout) < 0) {
+                                "barrier-timeout", &ctx->barrier_timeout) < 0) {
         errprintf (errp,
                    "failed to unpack system.exec.bulkexec for %s: %s",
                     idf58 (job->id),
@@ -194,19 +130,11 @@ static struct exec_ctx *exec_ctx_create (struct jobinfo *job,
         goto error;
     }
 
-    if (barrier_timeout > 0.) {
-        ctx->shell_barrier_timer = flux_timer_watcher_create (r,
-                                                              barrier_timeout,
-                                                              0.,
-                                                              barrier_timer_cb,
-                                                              ctx);
-        if (!ctx->shell_barrier_timer) {
-            errprintf (errp,
-                       "%s: failed to create barrier timer",
-                       idf58 (ctx->job->id));
-            goto error;
-        }
-    }
+    if (!(ctx->barrier = barrier_create (job,
+                                         ranks,
+                                         ctx->barrier_timeout,
+                                         errp)))
+        goto error;
 
     return ctx;
 error:
@@ -234,84 +162,6 @@ static void complete_cb (struct bulk_exec *exec, void *arg)
     jobinfo_tasks_complete (job,
                             resource_set_ranks (job->R),
                             bulk_exec_rc (exec));
-}
-
-static void barrier_timer_stop (struct exec_ctx *ctx)
-{
-    flux_watcher_stop (ctx->shell_barrier_timer);
-}
-
-static void barrier_timer_start (struct exec_ctx *ctx)
-{
-    /* Only ever create one barrier timer (for the first shell barrier)
-     */
-    if (ctx->barrier_completion_count == 0)
-        flux_watcher_start (ctx->shell_barrier_timer);
-}
-
-
-static int exec_barrier_enter (struct bulk_exec *exec, const flux_msg_t *msg)
-{
-    struct exec_ctx *ctx = bulk_exec_aux_get (exec, "ctx");
-    int rank;
-
-    if (!ctx)
-        return -1;
-
-    if (flux_msg_unpack (msg, "{s:i}", "rank", &rank) < 0)
-        return -1;
-    /*  Reject a request whose rank is out of range or not pending
-     *  to avoid corrupting barrier accounting.
-     */
-    if (rank < 0 || !idset_test (ctx->barrier_pending_ranks, rank)) {
-        flux_error_t error;
-        errprintf (&error, "rank %d is not pending in barrier", rank);
-        if (shell_barrier_respond_error (ctx->job->h,
-                                         msg,
-                                         EINVAL,
-                                         error.text) < 0)
-            flux_log_error (ctx->job->h, "shell-barrier: error responding");
-        return 0;
-    }
-    (void) idset_clear (ctx->barrier_pending_ranks, rank);
-    ctx->barrier_enter_count++;
-
-    /*
-     *  Terminate barrier with error immediately when a shell enters after
-     *   one or more shells have already exited. The case where a shell exits
-     *   while a barrier is already in progress is handled in exit_cb().
-     */
-    if (ctx->exit_count > 0) {
-        if (shell_barrier_respond_error (ctx->job->h, msg, EIO, NULL) < 0)
-            flux_log_error (ctx->job->h, "shell-barrier: error responding");
-        return 0;
-    }
-
-    if (flux_msglist_append (ctx->barrier_requests, msg) < 0)
-        return -1;
-
-    if (ctx->barrier_enter_count == bulk_exec_total (exec)) {
-        barrier_release (ctx, 0);
-        ctx->barrier_enter_count = 0;
-        ctx->barrier_completion_count++;
-        barrier_timer_stop (ctx);
-        /*  Reset pending ranks for next barrier.  Failure is unlikely
-         *  since the set universe won't expand here.
-         */
-        if (idset_add (ctx->barrier_pending_ranks,
-                       resource_set_ranks (ctx->job->R)) < 0) {
-            flux_log_error (ctx->job->h,
-                            "shell-barrier: failed to reset pending ranks");
-        }
-    }
-    /*  When the first shell enters the barrier, start a timer after
-     *   which the job will be terminated if all shells have not reached
-     *   the barrier.
-     */
-    else if (ctx->barrier_enter_count == 1)
-        barrier_timer_start (ctx);
-
-    return 0;
 }
 
 static void output_cb (struct bulk_exec *exec,
@@ -514,34 +364,6 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
                              rank);
 }
 
-static int drain_barrier_pending_ranks (struct jobinfo *job,
-                                        struct exec_ctx *ctx,
-                                        const struct idset *ranks)
-{
-    struct idset *drain_ranks;
-    char *drain_ids = NULL;
-    int rc = -1;
-
-    if (!(drain_ranks = idset_intersect (ranks, ctx->barrier_pending_ranks))
-        || !(drain_ids = idset_encode (drain_ranks, IDSET_FLAG_RANGE)))
-        goto fail;
-
-
-    if (idset_count (drain_ranks) > 0
-        && jobinfo_drain_ranks (job,
-                                drain_ids,
-                                "%s terminated before first barrier",
-                                idf58 (job->id)) < 0)
-        goto fail;
-
-    rc = 0;
-
-fail:
-    idset_destroy (drain_ranks);
-    free (drain_ids);
-    return rc;
-}
-
 static void shell_exit_timer_cb (flux_reactor_t *r,
                                  flux_watcher_t *w,
                                  int revents,
@@ -689,13 +511,11 @@ static void exit_cb (struct bulk_exec *exec,
         || !(ctx = bulk_exec_aux_get (exec, "ctx")))
         return;
 
-    ctx->exit_count++;
-
     /*  Check if a shell is exiting before the first barrier, in which
      *   case we raise a job exception because the shell or IMP may not
      *   have had a chance to do so.
      */
-    if (ctx->barrier_completion_count == 0
+    if (!ctx->first_barrier_done
         && (!job->exception_in_progress || ctx->terminated_before_barrier)) {
         char *ids = idset_encode (ranks, IDSET_FLAG_RANGE);
         char *hosts = flux_hostmap_lookup (job->h, ids, NULL);
@@ -717,7 +537,7 @@ static void exit_cb (struct bulk_exec *exec,
          * or incorrect MUNGE key)
          */
         if (job->multiuser
-            && drain_barrier_pending_ranks (job, ctx, ranks) < 0)
+            && barrier_drain_pending (ctx->barrier, ranks) < 0)
             flux_log_error (job->h,
                             "failed to drain %s (rank%s %s) for job %s",
                             hosts ? hosts : "(unknown)",
@@ -728,12 +548,12 @@ static void exit_cb (struct bulk_exec *exec,
         free (hosts);
     }
 
-    /*  Terminate any barrier in progress with error, releasing shells
-     *   currently waiting so they exit immediately rather than being killed
-     *   by the exec system.  Shells that enter the barrier later are
-     *   rejected by exec_barrier_enter() since exit_count is now nonzero.
+    /*  Notify the barrier that shells have exited: terminates any barrier in
+     *   progress with error (releasing waiting shells so they exit rather
+     *   than being killed) and causes later barrier-enter requests to be
+     *   rejected.
      */
-    barrier_release (ctx, EIO);
+    barrier_notify_shell_exit (ctx->barrier);
 
     /*  If a shell exits due to signal report the shell as lost to
      *  the leader shell. This avoids potential hangs in the leader
@@ -1188,7 +1008,29 @@ static struct idset *active_ranks (struct jobinfo *job)
 
 static int exec_barrier_enter_op (struct jobinfo *job, const flux_msg_t *msg)
 {
-    return exec_barrier_enter ((struct bulk_exec *) job->data, msg);
+    struct bulk_exec *exec = job->data;
+    struct exec_ctx *ctx = bulk_exec_aux_get (exec, "ctx");
+    flux_error_t error;
+    int rc;
+
+    if (!ctx || !ctx->barrier)
+        return -1;
+    if ((rc = barrier_enter (ctx->barrier, msg)) != BARRIER_COMPLETE)
+        return rc == BARRIER_ERROR ? -1 : 0;
+
+    /*  This barrier is done and its shells have been released.  Replace it
+     *  with a fresh untimed barrier for the next one in the sequence: only
+     *  the first barrier is timed (a hung node at initialization), and this
+     *  keeps barrier.c ignorant of the barrier sequence.
+     */
+    barrier_destroy (ctx->barrier);
+    ctx->first_barrier_done = true;
+    if (!(ctx->barrier = barrier_create (job,
+                                         resource_set_ranks (job->R),
+                                         0.,
+                                         &error)))
+        jobinfo_fatal_error (job, errno, "barrier: %s", error.text);
+    return 0;
 }
 
 struct exec_implementation bulkexec = {

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -49,11 +49,6 @@
 #include "rset.h"
 #include "barrier.h"
 
-/*  Numeric severity used for a non-fatal, critical job exception:
- *  (e.g. node failure)
- */
-#define FLUX_JOB_EXCEPTION_CRIT 2
-
 extern char **environ;
 
 struct exec_ctx {
@@ -179,68 +174,6 @@ static void output_cb (struct bulk_exec *exec,
                         len);
 }
 
-static int lost_shell (struct jobinfo *job,
-                       bool critical,
-                       int shell_rank,
-                       const char *fmt,
-                       ...)
-{
-    flux_future_t *f;
-    char msgbuf[160];
-    int msglen = sizeof (msgbuf);
-    char *msg = msgbuf;
-    va_list ap;
-    int severity = critical ? 0 : FLUX_JOB_EXCEPTION_CRIT;
-
-    if (fmt) {
-        va_start (ap, fmt);
-        if (vsnprintf (msg, msglen, fmt, ap) >= msglen)
-            (void) snprintf (msg, msglen, "%s", "lost contact with job shell");
-        va_end (ap);
-    }
-
-    if (!critical) {
-        /* Raise a non-fatal job exception if the lost shell was not critical.
-         * The job exec service will raise a fatal exception later for
-         * critical shells.
-         */
-        jobinfo_raise (job,
-                       "node-failure",
-                       FLUX_JOB_EXCEPTION_CRIT,
-                       "%s",
-                       msg);
-        /* If an exception was raised, do not duplicate the message
-         * to the shell exception service since the message will already
-         * be displayed as part of the exception note:
-         */
-        msg = "";
-    }
-
-    /* Also notify job shell rank 0 of exception
-     */
-    if (!(f = jobinfo_shell_rpc_pack (job,
-                                      "exception",
-                                      "{s:s s:i s:i s:s}",
-                                      "type", "lost-shell",
-                                      "severity", severity,
-                                      "shell_rank", shell_rank,
-                                      "message", msg)))
-            return -1;
-    /*  Do not wait for response. If a shell is lost because the job
-     *  is terminating, then the rank 0 shell may also have exited by the
-     *  time this message is sent, so a response may never come. This
-     *  could leak the future (and the job reference taken by
-     *  jobinfo_shell_rpc_pack())
-     */
-    flux_future_destroy (f);
-    return 0;
-}
-
-static bool is_critical_rank (struct jobinfo *job, int shell_rank)
-{
-    return idset_test (job->critical_ranks, shell_rank);
-}
-
 static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
 {
     struct jobinfo *job = arg;
@@ -267,17 +200,17 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
                                         "sdexec reports %s for job %s",
                                         flux_subprocess_fail_error (p),
                                         idf58 (job->id));
-            bool critical = is_critical_rank (job, shell_rank);
+            bool critical = jobinfo_is_critical_rank (job, shell_rank);
 
             /*  Always notify rank 0 shell of a lost shell.
              */
-            lost_shell (job,
-                        critical,
-                        shell_rank,
-                        "shell exited with unkillable processes"
-                        " on %s (shell rank %d)",
-                        hostname,
-                        shell_rank);
+            jobinfo_lost_shell (job,
+                                critical,
+                                shell_rank,
+                                "shell exited with unkillable processes"
+                                " on %s (shell rank %d)",
+                                hostname,
+                                shell_rank);
 
             /*  Raise a fatal error and terminate job immediately if
              *  the lost shell was critical.
@@ -291,16 +224,16 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
                                      rank);
         }
         else if (errnum == EHOSTUNREACH) {
-            bool critical = is_critical_rank (job, shell_rank);
+            bool critical = jobinfo_is_critical_rank (job, shell_rank);
 
             /*  Always notify rank 0 shell of a lost shell.
              */
-            lost_shell (job,
-                        critical,
-                        shell_rank,
-                        "node failure on %s (shell rank %d)",
-                        hostname,
-                        shell_rank);
+            jobinfo_lost_shell (job,
+                                critical,
+                                shell_rank,
+                                "node failure on %s (shell rank %d)",
+                                hostname,
+                                shell_rank);
 
             /*  Raise a fatal error and terminate job immediately if
              *  the lost shell was critical.
@@ -445,13 +378,13 @@ static void exit_cb (struct bulk_exec *exec,
         int shell_rank = resource_set_rank_index (job->R, rank);
         if (p && signo > 0) {
             if (shell_rank != 0)
-                lost_shell (job,
-                            is_critical_rank (job, shell_rank),
-                            shell_rank,
-                            "shell rank %d (on %s): %s",
-                            shell_rank,
-                            flux_get_hostbyrank (job->h, rank),
-                            strsignal (signo));
+                jobinfo_lost_shell (job,
+                                    jobinfo_is_critical_rank (job, shell_rank),
+                                    shell_rank,
+                                    "shell rank %d (on %s): %s",
+                                    shell_rank,
+                                    flux_get_hostbyrank (job->h, rank),
+                                    strsignal (signo));
             else {
                 /*  Job can't continue without the leader shell, which has
                  *  terminated unexpectedly. Cancel the job now to avoid

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -42,7 +42,6 @@
 #include "src/common/libutil/basename.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
-#include "src/common/libutil/fsd.h"
 #include "src/common/libsubprocess/bulk-exec.h"
 
 #include "job-exec.h"
@@ -77,8 +76,6 @@ struct exec_ctx {
      *  ranks to be drained when they exit too.
      */
     bool terminated_before_barrier;
-
-    bool shell_exit_posted; /* true after shell-exit event is posted */
 };
 
 static void exec_ctx_destroy (struct exec_ctx *tc)
@@ -364,144 +361,25 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
                              rank);
 }
 
-static void shell_exit_timer_cb (flux_reactor_t *r,
-                                 flux_watcher_t *w,
-                                 int revents,
-                                 void *arg)
-{
-    struct jobinfo *job = arg;
-    struct bulk_exec *exec = job->data;
-    struct idset *active = bulk_exec_active_ranks (exec);
-    char *ids = NULL;
-    char *hosts = NULL;
-    char fsd_buf[64];
-    double timeout = config_get_shell_exit_timeout ();
-
-    flux_watcher_stop (w);
-
-    if (!active)
-        return;
-
-    ids = idset_encode (active, IDSET_FLAG_RANGE);
-    hosts = flux_hostmap_lookup (job->h, ids, NULL);
-    (void) fsd_format_duration (fsd_buf, sizeof (fsd_buf), timeout);
-
-    jobinfo_fatal_error (job,
-                         0,
-                         "job shells still active on %s"
-                         " (rank%s %s) %s after leader shell exit",
-                         hosts ? hosts : "(unknown)",
-                         idset_count (active) > 1 ? "s" : "",
-                         ids ? ids : "(unknown)",
-                         fsd_buf);
-    free (ids);
-    free (hosts);
-    idset_destroy (active);
-}
-
-/*  Post the shell-exit event when the leader shell (shell rank 0) exits.
- *  Also arm the shell_exit_timer if configured and shells remain active.
- *  Called at most once per job (guarded by ctx->shell_exit_posted).
- */
-static void post_shell_exit_event (struct bulk_exec *exec,
-                                   struct jobinfo *job,
-                                   struct exec_ctx *ctx,
-                                   unsigned int leader_rank)
-{
-    flux_subprocess_t *p;
-    int rc;
-    struct idset *active = NULL;
-    char *active_ids = NULL;
-    int wait_status = 0;
-    double timeout;
-
-    if (ctx->shell_exit_posted)
-        return;
-    ctx->shell_exit_posted = true;
-
-    p = bulk_exec_get_subprocess (exec, leader_rank);
-    if (p)
-        wait_status = flux_subprocess_status (p);
-
-    /*  The shell-exit event is informational only (to notify eventlog
-     *  consumers that rank 0 shell services are unavailable). If encoding
-     *  or posting fails, log but continue - the timer below is the critical
-     *  safety mechanism to prevent hanging jobs.
-     */
-    if ((active = bulk_exec_active_ranks (exec))
-        && idset_count (active) > 0
-        && !(active_ids = idset_encode (active, IDSET_FLAG_RANGE)))
-        flux_log_error (job->h,
-                        "%s: failed to encode %zu active_ranks for %s",
-                        "shell-exit",
-                        idset_count (active),
-                        idf58 (job->id));
-
-    if (active_ids) {
-        rc = jobinfo_emit_event_pack_nowait (job,
-                                             "shell-exit",
-                                             "{s:i s:i s:s}",
-                                             "rank", (int) leader_rank,
-                                             "wait_status", wait_status,
-                                             "active_ranks", active_ids);
-    }
-    else {
-        rc = jobinfo_emit_event_pack_nowait (job,
-                                             "shell-exit",
-                                             "{s:i s:i}",
-                                             "rank", (int) leader_rank,
-                                             "wait_status", wait_status);
-    }
-    if (rc < 0)
-        flux_log_error (job->h,
-                        "failed to post shell-exit event for job %s",
-                        idf58 (job->id));
-
-    timeout = config_get_shell_exit_timeout ();
-    if (timeout > 0.
-        && active
-        && idset_count (active) > 0
-        && !job->exception_in_progress) {
-        flux_reactor_t *reactor = flux_get_reactor (job->h);
-        job->shell_exit_timer =
-            flux_timer_watcher_create (reactor,
-                                       timeout,
-                                       0.,
-                                       shell_exit_timer_cb,
-                                       job);
-        if (job->shell_exit_timer)
-            flux_watcher_start (job->shell_exit_timer);
-        else {
-            /*  Without the timer the job could hang indefinitely waiting
-             *  for the remaining shells, so raise an exception now rather
-             *  than just logging the error.
-             */
-            jobinfo_fatal_error (job,
-                                 errno,
-                                 "failed to create shell exit timer");
-        }
-    }
-
-    free (active_ids);
-    idset_destroy (active);
-}
-
 static void exit_cb (struct bulk_exec *exec,
                      void *arg,
                      const struct idset *ranks)
 {
     struct jobinfo *job = arg;
-    struct exec_ctx *ctx = bulk_exec_aux_get (exec, "ctx");
+    struct exec_ctx *ctx;
 
     /*  Post shell-exit event if the leader shell (shell rank 0) is in the
      *  set of exiting ranks.  This must be done before the single-shell
      *  early-return so the event is posted for single-shell jobs too.
-     *  ctx may be NULL in highly unlikely error scenarios; skip if so.
+     *  jobinfo_post_shell_exit() is a no-op after the first call.
      */
-    if (ctx) {
+    {
         unsigned int leader_rank = resource_set_nth_rank (job->R, 0);
-        if (idset_test (ranks, leader_rank))
-            post_shell_exit_event (exec, job, ctx, leader_rank);
+        if (idset_test (ranks, leader_rank)) {
+            flux_subprocess_t *p = bulk_exec_get_subprocess (exec, leader_rank);
+            int wait_status = p ? flux_subprocess_status (p) : 0;
+            jobinfo_post_shell_exit (job, leader_rank, wait_status);
+        }
     }
 
     /*  Nothing more to do here if the job consists of only one shell.

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -450,40 +450,6 @@ static struct bulk_exec_ops exec_ops = {
     .on_error =     error_cb
 };
 
-/* Set per-rank sdexec options on `cmd` for rank `r`.
- * Returns 0 on success, -1 on error.
- */
-static int sdexec_cmd_set_rank_opts (struct exec_ctx *ctx,
-                                     flux_cmd_t *cmd,
-                                     unsigned int r)
-{
-    if (config_get_sdexec_constrain_resources ()) {
-        char *R_str = resource_set_R_local (ctx->job->R, r);
-        if (!R_str)
-            return -1;
-        int rc = flux_cmd_setopt (cmd, "SDEXEC_R_LOCAL", R_str);
-        free (R_str);
-        if (rc < 0)
-            return -1;
-    }
-    if (ctx->sdexec_test_expected_cpus) {
-        if (flux_cmd_setopt (cmd,
-                             "SDEXEC_TEST_EXPECTED_CPUS",
-                             ctx->sdexec_test_expected_cpus) < 0)
-            return -1;
-    }
-    return 0;
-}
-
-/* Return true if per-rank sdexec commands are needed.
- * When true, exec_init() pushes one cmd per rank instead of one for all.
- */
-static bool sdexec_needs_per_rank_cmds (struct exec_ctx *ctx)
-{
-    return config_get_sdexec_constrain_resources ()
-        || ctx->sdexec_test_expected_cpus != NULL;
-}
-
 /* Push one bulk_exec cmd per rank, each with rank-specific sdexec options.
  * Returns 0 on success, -1 on error.
  */
@@ -501,7 +467,11 @@ static int sdexec_push_per_rank_cmds (struct bulk_exec *exec,
         if (!(rcmd = flux_cmd_copy (cmd))
             || !(rset = idset_create (0, IDSET_FLAG_AUTOGROW))
             || idset_set (rset, r) < 0
-            || sdexec_cmd_set_rank_opts (ctx, rcmd, r) < 0) {
+            || job_shell_cmd_set_rank_opts (ctx->job,
+                                            rcmd,
+                                            r,
+                                            ctx->sdexec_test_expected_cpus)
+               < 0) {
             flux_cmd_destroy (rcmd);
             idset_destroy (rset);
             return -1;
@@ -564,7 +534,8 @@ static int exec_init (struct jobinfo *job)
      * each transient unit can be configured for its own allocation.
      * Otherwise push a single command covering all ranks (the common case).
      */
-    if (streq (service, "sdexec") && sdexec_needs_per_rank_cmds (ctx)) {
+    if (streq (service, "sdexec")
+        && job_shell_needs_per_rank_cmds (ctx->sdexec_test_expected_cpus)) {
         if (sdexec_push_per_rank_cmds (exec, ranks, cmd) < 0) {
             flux_log_error (job->h, "exec_init: sdexec per-rank cmd setup");
             goto err;

--- a/src/modules/job-exec/exec_cmd.c
+++ b/src/modules/job-exec/exec_cmd.c
@@ -26,6 +26,7 @@
 #include "job-exec.h"
 #include "exec_config.h"
 #include "exec_cmd.h"
+#include "rset.h"
 
 extern char **environ;
 
@@ -108,6 +109,35 @@ flux_cmd_t *job_shell_cmd_create (struct jobinfo *job, const char *service)
 err:
     flux_cmd_destroy (cmd);
     return NULL;
+}
+
+bool job_shell_needs_per_rank_cmds (const char *test_expected_cpus)
+{
+    return config_get_sdexec_constrain_resources ()
+        || test_expected_cpus != NULL;
+}
+
+int job_shell_cmd_set_rank_opts (struct jobinfo *job,
+                                 flux_cmd_t *cmd,
+                                 unsigned int r,
+                                 const char *test_expected_cpus)
+{
+    if (config_get_sdexec_constrain_resources ()) {
+        char *R_str = resource_set_R_local (job->R, r);
+        if (!R_str)
+            return -1;
+        int rc = flux_cmd_setopt (cmd, "SDEXEC_R_LOCAL", R_str);
+        free (R_str);
+        if (rc < 0)
+            return -1;
+    }
+    if (test_expected_cpus) {
+        if (flux_cmd_setopt (cmd,
+                             "SDEXEC_TEST_EXPECTED_CPUS",
+                             test_expected_cpus) < 0)
+            return -1;
+    }
+    return 0;
 }
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/exec_cmd.c
+++ b/src/modules/job-exec/exec_cmd.c
@@ -1,0 +1,114 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* exec_cmd.c - build the base job-shell command
+ *
+ * Shared by the exec implementations that launch real job shells (bulk-exec
+ * and bgexec).  The per-rank sdexec push machinery remains private to each
+ * implementation since it is coupled to the implementation's push interface.
+ */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <flux/core.h>
+
+#include "ccan/str/str.h"
+
+#include "job-exec.h"
+#include "exec_config.h"
+#include "exec_cmd.h"
+
+extern char **environ;
+
+flux_cmd_t *job_shell_cmd_create (struct jobinfo *job, const char *service)
+{
+    flux_cmd_t *cmd;
+
+    if (!(cmd = flux_cmd_create (0, NULL, environ))) {
+        flux_log_error (job->h, "exec_init: flux_cmd_create");
+        return NULL;
+    }
+    /* Set any configured exec.sdexec-properties.
+     */
+    json_t *props;
+    if (streq (service, "sdexec")
+        && (props = config_get_sdexec_properties ())) {
+        const char *k;
+        json_t *v;
+        json_object_foreach (props, k, v) {
+            char name[128];
+            snprintf (name, sizeof (name), "SDEXEC_PROP_%s", k);
+            if (flux_cmd_setopt (cmd, name, json_string_value (v)) < 0) {
+                flux_log_error (job->h, "Unable to set sdexec options");
+                goto err;
+            }
+        }
+    }
+    if (flux_cmd_setenvf (cmd, 1, "FLUX_KVS_NAMESPACE", "%s", job->ns) < 0) {
+        flux_log_error (job->h, "exec_init: flux_cmd_setenvf");
+        goto err;
+    }
+    if (job->multiuser) {
+        if (flux_cmd_setenvf (cmd,
+                              1,
+                              "FLUX_IMP_EXEC_HELPER",
+                              "flux imp_exec_helper %ju",
+                              (uintmax_t) job->id) < 0) {
+            flux_log_error (job->h, "exec_init: flux_cmd_setenvf");
+            goto err;
+        }
+        /* The systemd user instance running as user flux is not privileged
+         * to signal guest processes, therefore:
+         * - Set the KillMode=process so only the IMP is signaled
+         * - Use Type=notify in conjunction with IMP calling sd_notify(3) so
+         *   the unit transitions to deactivating when the shell exits.
+         * - Set TimeoutStopUsec=infinity to disable systemd's stop timeout.
+         * - Enable sdexec's stop timeout which is armed at deactivating,
+         *   delivers SIGUSR1 (proxy for SIGKILL) after 30s, then abandons
+         *   the unit and terminates the exec RPC after another 30s.
+         */
+        if (streq (service, "sdexec")) {
+            if (flux_cmd_setopt (cmd, "SDEXEC_PROP_KillMode", "process") < 0
+                || flux_cmd_setopt (cmd, "SDEXEC_PROP_Type", "notify") < 0
+                || flux_cmd_setopt (cmd,
+                                    "SDEXEC_PROP_TimeoutStopUSec",
+                                    "infinity") < 0
+                || flux_cmd_setopt (cmd,
+                                    "SDEXEC_STOP_TIMER_SIGNAL",
+                                    config_get_sdexec_stop_timer_signal ()) < 0
+                || flux_cmd_setopt (cmd,
+                                    "SDEXEC_STOP_TIMER_SEC",
+                                    config_get_sdexec_stop_timer_sec ()) < 0) {
+                flux_log_error (job->h,
+                                "Unable to set multiuser sdexec options");
+                goto err;
+            }
+        }
+        if (flux_cmd_argv_append (cmd, config_get_imp_path ()) < 0
+            || flux_cmd_argv_append (cmd, "exec") < 0) {
+            flux_log_error (job->h, "exec_init: flux_cmd_argv_append");
+            goto err;
+        }
+    }
+    if (flux_cmd_argv_append (cmd, config_get_job_shell (job)) < 0
+        || flux_cmd_argv_appendf (cmd, "%ju", (uintmax_t) job->id) < 0) {
+        flux_log_error (job->h, "exec_init: flux_cmd_argv_append");
+        goto err;
+    }
+    return cmd;
+err:
+    flux_cmd_destroy (cmd);
+    return NULL;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/exec_cmd.h
+++ b/src/modules/job-exec/exec_cmd.h
@@ -27,6 +27,23 @@
  */
 flux_cmd_t *job_shell_cmd_create (struct jobinfo *job, const char *service);
 
+/*  Return true if per-rank job-shell commands are needed for sdexec, in which
+ *  case each rank must be launched with a command carrying its own sdexec
+ *  options rather than a single command covering all ranks.  This is the case
+ *  when resource constraints are configured or `test_expected_cpus` (the
+ *  jobspec sdexec-test-expected-cpus override) is set.
+ */
+bool job_shell_needs_per_rank_cmds (const char *test_expected_cpus);
+
+/*  Set per-rank sdexec options on `cmd` for rank `r`: the local resource set
+ *  (when constraints are configured) and `test_expected_cpus` (when set).
+ *  Returns 0 on success, -1 on error.
+ */
+int job_shell_cmd_set_rank_opts (struct jobinfo *job,
+                                 flux_cmd_t *cmd,
+                                 unsigned int r,
+                                 const char *test_expected_cpus);
+
 #endif /* !HAVE_JOB_EXEC_CMD_H */
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/exec_cmd.h
+++ b/src/modules/job-exec/exec_cmd.h
@@ -1,0 +1,33 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_JOB_EXEC_CMD_H
+#define HAVE_JOB_EXEC_CMD_H 1
+
+#include <flux/core.h>
+
+#include "job-exec.h"
+
+/*  Build the base job-shell command for `job` to be launched via `service`
+ *  ("rexec" or "sdexec").  The returned command covers the common case where
+ *  a single command is pushed for all ranks: it carries the guest KVS
+ *  namespace, any configured sdexec properties, the IMP wrapper for multiuser
+ *  jobs, and the shell argv (shell path + jobid).  Per-rank sdexec options
+ *  (resource constraints) are applied separately by the caller.
+ *
+ *  Returns a new flux_cmd_t on success (caller destroys it), or NULL on
+ *  failure with an error logged to job->h.
+ */
+flux_cmd_t *job_shell_cmd_create (struct jobinfo *job, const char *service);
+
+#endif /* !HAVE_JOB_EXEC_CMD_H */
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -389,6 +389,123 @@ static int jobinfo_respond (flux_t *h,
                               "data");
 }
 
+static struct idset *jobinfo_active_ranks (struct jobinfo *job)
+{
+    if (job->impl->active_ranks)
+        return (*job->impl->active_ranks) (job);
+    return NULL;
+}
+
+static void shell_exit_timer_cb (flux_reactor_t *r,
+                                 flux_watcher_t *w,
+                                 int revents,
+                                 void *arg)
+{
+    struct jobinfo *job = arg;
+    struct idset *active = jobinfo_active_ranks (job);
+    char *ids = NULL;
+    char *hosts = NULL;
+    char fsd_buf[64];
+    double timeout = config_get_shell_exit_timeout ();
+
+    flux_watcher_stop (w);
+
+    if (!active)
+        return;
+
+    ids = idset_encode (active, IDSET_FLAG_RANGE);
+    hosts = flux_hostmap_lookup (job->h, ids, NULL);
+    (void) fsd_format_duration (fsd_buf, sizeof (fsd_buf), timeout);
+
+    jobinfo_fatal_error (job,
+                         0,
+                         "job shells still active on %s"
+                         " (rank%s %s) %s after leader shell exit",
+                         hosts ? hosts : "(unknown)",
+                         idset_count (active) > 1 ? "s" : "",
+                         ids ? ids : "(unknown)",
+                         fsd_buf);
+    free (ids);
+    free (hosts);
+    idset_destroy (active);
+}
+
+void jobinfo_post_shell_exit (struct jobinfo *job,
+                              unsigned int leader_rank,
+                              int wait_status)
+{
+    int rc;
+    struct idset *active = NULL;
+    char *active_ids = NULL;
+    double timeout;
+
+    if (job->shell_exit_posted)
+        return;
+    job->shell_exit_posted = 1;
+
+    /*  The shell-exit event is informational only (to notify eventlog
+     *  consumers that rank 0 shell services are unavailable). If encoding
+     *  or posting fails, log but continue - the timer below is the critical
+     *  safety mechanism to prevent hanging jobs.
+     */
+    if ((active = jobinfo_active_ranks (job))
+        && idset_count (active) > 0
+        && !(active_ids = idset_encode (active, IDSET_FLAG_RANGE)))
+        flux_log_error (job->h,
+                        "%s: failed to encode %zu active_ranks for %s",
+                        "shell-exit",
+                        idset_count (active),
+                        idf58 (job->id));
+
+    if (active_ids) {
+        rc = jobinfo_emit_event_pack_nowait (job,
+                                             "shell-exit",
+                                             "{s:i s:i s:s}",
+                                             "rank", (int) leader_rank,
+                                             "wait_status", wait_status,
+                                             "active_ranks", active_ids);
+    }
+    else {
+        rc = jobinfo_emit_event_pack_nowait (job,
+                                             "shell-exit",
+                                             "{s:i s:i}",
+                                             "rank", (int) leader_rank,
+                                             "wait_status", wait_status);
+    }
+    if (rc < 0)
+        flux_log_error (job->h,
+                        "failed to post shell-exit event for job %s",
+                        idf58 (job->id));
+
+    timeout = config_get_shell_exit_timeout ();
+    if (timeout > 0.
+        && active
+        && idset_count (active) > 0
+        && !job->exception_in_progress) {
+        flux_reactor_t *reactor = flux_get_reactor (job->h);
+        job->shell_exit_timer =
+            flux_timer_watcher_create (reactor,
+                                       timeout,
+                                       0.,
+                                       shell_exit_timer_cb,
+                                       job);
+        if (job->shell_exit_timer)
+            flux_watcher_start (job->shell_exit_timer);
+        else {
+            /*  Without the timer the job could hang indefinitely waiting
+             *  for the remaining shells, so raise an exception now rather
+             *  than just logging the error.
+             */
+            jobinfo_fatal_error (job,
+                                 errno,
+                                 "failed to create shell exit timer");
+        }
+    }
+
+    free (active_ids);
+    idset_destroy (active);
+}
+
 static void jobinfo_complete (struct jobinfo *job, const struct idset *ranks)
 {
     flux_t *h = job->ctx->h;

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1000,6 +1000,68 @@ void jobinfo_raise (struct jobinfo *job,
     va_end (ap);
 }
 
+bool jobinfo_is_critical_rank (struct jobinfo *job, int shell_rank)
+{
+    return idset_test (job->critical_ranks, shell_rank);
+}
+
+int jobinfo_lost_shell (struct jobinfo *job,
+                        bool critical,
+                        int shell_rank,
+                        const char *fmt,
+                        ...)
+{
+    flux_future_t *f;
+    char msgbuf[160];
+    int msglen = sizeof (msgbuf);
+    char *msg = msgbuf;
+    va_list ap;
+    int severity = critical ? 0 : FLUX_JOB_EXCEPTION_CRIT;
+
+    if (fmt) {
+        va_start (ap, fmt);
+        if (vsnprintf (msg, msglen, fmt, ap) >= msglen)
+            (void) snprintf (msg, msglen, "%s", "lost contact with job shell");
+        va_end (ap);
+    }
+
+    if (!critical) {
+        /* Raise a non-fatal job exception if the lost shell was not critical.
+         * The job exec service will raise a fatal exception later for
+         * critical shells.
+         */
+        jobinfo_raise (job,
+                       "node-failure",
+                       FLUX_JOB_EXCEPTION_CRIT,
+                       "%s",
+                       msg);
+        /* If an exception was raised, do not duplicate the message
+         * to the shell exception service since the message will already
+         * be displayed as part of the exception note:
+         */
+        msg = "";
+    }
+
+    /* Also notify job shell rank 0 of exception
+     */
+    if (!(f = jobinfo_shell_rpc_pack (job,
+                                      "exception",
+                                      "{s:s s:i s:i s:s}",
+                                      "type", "lost-shell",
+                                      "severity", severity,
+                                      "shell_rank", shell_rank,
+                                      "message", msg)))
+            return -1;
+    /*  Do not wait for response. If a shell is lost because the job
+     *  is terminating, then the rank 0 shell may also have exited by the
+     *  time this message is sent, so a response may never come. This
+     *  could leak the future (and the job reference taken by
+     *  jobinfo_shell_rpc_pack())
+     */
+    flux_future_destroy (f);
+    return 0;
+}
+
 void jobinfo_log_output (struct jobinfo *job,
                          int rank,
                          const char *component,

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -113,6 +113,7 @@ struct jobinfo {
     uint8_t               multiuser:1;
     uint8_t               has_namespace:1;
     uint8_t               exception_in_progress:1;
+    uint8_t               shell_exit_posted:1; /* shell-exit event was posted */
 
     uint8_t               started:1;     /* some or all shells are starting */
     uint8_t               running:1;     /* all shells are running */
@@ -188,6 +189,16 @@ int jobinfo_drain_ranks (struct jobinfo *job,
                          const char *ranks,
                          const char *fmt,
                          ...);
+
+/* Post the "shell-exit" event for the exiting leader shell (shell rank 0),
+ * then arm a timer that raises a fatal exception if other shells remain
+ * active longer than the configured shell-exit timeout.  `wait_status` is
+ * the leader shell's raw wait status (supplied by the exec implementation,
+ * which holds the exited shell).  Posts at most once per job.
+ */
+void jobinfo_post_shell_exit (struct jobinfo *job,
+                              unsigned int leader_rank,
+                              int wait_status);
 
 /* Append a log output message to exec.eventlog for job
  */

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -11,6 +11,7 @@
 #ifndef HAVE_JOB_EXEC_H
 #define HAVE_JOB_EXEC_H 1
 
+#include <stdbool.h>
 #include <jansson.h>
 #include <flux/core.h>
 #include <flux/idset.h>
@@ -180,10 +181,33 @@ void jobinfo_tasks_complete (struct jobinfo *job,
 void jobinfo_fatal_error (struct jobinfo *job, int errnum,
                           const char *fmt, ...);
 
+/*  Numeric severity used for a non-fatal, critical job exception:
+ *  (e.g. node failure)
+ */
+#define FLUX_JOB_EXCEPTION_CRIT 2
+
 void jobinfo_raise (struct jobinfo *job,
                     const char *type,
                     int severity,
                     const char *fmt, ...);
+
+/*  Return true if shell rank `shell_rank` is a critical rank, i.e. one whose
+ *  loss requires a fatal job exception rather than a non-fatal one.
+ */
+bool jobinfo_is_critical_rank (struct jobinfo *job, int shell_rank);
+
+/*  Report shell rank `shell_rank` as lost: raise a non-fatal "node-failure"
+ *  exception if the rank is not critical (the caller raises a fatal error
+ *  separately for critical ranks), and always notify shell rank 0 via a
+ *  "lost-shell" exception RPC so the leader shell does not hang awaiting a
+ *  peer that will never respond.  `fmt` supplies the human-readable reason.
+ *  Returns 0 on success, -1 on error.
+ */
+int jobinfo_lost_shell (struct jobinfo *job,
+                        bool critical,
+                        int shell_rank,
+                        const char *fmt,
+                        ...);
 
 int jobinfo_drain_ranks (struct jobinfo *job,
                          const char *ranks,


### PR DESCRIPTION
This just moves some code out of the bulk-exec `job-exec` internal implementation so that it can be shared by another upcoming implementation.  There are some small functional changes, primarily on error paths, related to making functions generally usable but nothing that should be concerning.