### PR TITLE
ci: enhance coccinelle test to catch more double-free cases with `json_*_new()` calls

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -678,7 +678,6 @@ static json_t *exec_config_stats (void)
     return o;
 error:
     ERRNO_SAFE_WRAP (json_decref, o);
-    ERRNO_SAFE_WRAP (json_decref, conf);
     return NULL;
 }
 

--- a/t/cocci/json_set_new_decref.cocci
+++ b/t/cocci/json_set_new_decref.cocci
@@ -5,113 +5,106 @@
 // All jansson json_*_new() functions steal the reference to the value
 // argument whether they succeed or fail — on failure, jansson calls
 // json_decref() on the value internally.  Calling json_decref() on the
-// same value in the caller's error path is therefore a double-free.
+// same value afterward is therefore wrong: a double-free on the failure
+// path, or a premature free of a now-container-owned reference on the
+// success path.  Either way, once the value has been passed to a
+// json_*_new() function, the caller must not decref it again unless it
+// is first reassigned (or re-increfed).
 //
-// Covers both forms:
+// These rules match on data flow rather than on if/block structure, so
+// they catch the decref no matter how control reaches it:
 //
-//   Simple:
-//     if (json_object_set_new(obj, key, val) < 0) { json_decref(val); }
+//   Direct:
+//     if (json_object_set_new(obj, key, val) < 0)
+//         json_decref(val);
 //
-//   Compound (double-free when the _new call is reached and fails):
-//     if (E || json_object_set_new(obj, key, val) < 0) { json_decref(val); }
+//   Via goto to a shared error label:
+//     if (json_object_set_new(obj, key, val) < 0)
+//         goto error;
+//     ...
+//   error:
+//     json_decref(val);
 //
+//   Via the ERRNO_SAFE_WRAP() macro at such a label:
+//   error:
+//     ERRNO_SAFE_WRAP (json_decref, val);
+//
+// The "when != " constraints suppress the match when the value is
+// reassigned or re-increfed between the steal and the decref, since in
+// those cases the later decref refers to a reference the caller does
+// own.
 
 // ---- json_object_set_new ----
 
 @@
-expression obj, key, val;
-@@
-* if (json_object_set_new(obj, key, val) < 0) {
-  ...
-* json_decref(val);
-  ...
-  }
-
-@@
 expression obj, key, val, E;
+identifier decref = json_decref;
 @@
-* if (E || json_object_set_new(obj, key, val) < 0) {
-  ...
-* json_decref(val);
-  ...
-  }
+  json_object_set_new(obj, key, val)
+  ... when != val = E
+      when != json_incref(val)
+(
+* decref(val)
+|
+* ERRNO_SAFE_WRAP(decref, val)
+)
 
 // ---- json_array_append_new ----
 
 @@
-expression arr, val;
-@@
-* if (json_array_append_new(arr, val) < 0) {
-  ...
-* json_decref(val);
-  ...
-  }
-
-@@
 expression arr, val, E;
+identifier decref = json_decref;
 @@
-* if (E || json_array_append_new(arr, val) < 0) {
-  ...
-* json_decref(val);
-  ...
-  }
+  json_array_append_new(arr, val)
+  ... when != val = E
+      when != json_incref(val)
+(
+* decref(val)
+|
+* ERRNO_SAFE_WRAP(decref, val)
+)
 
 // ---- json_array_set_new ----
 
 @@
-expression arr, idx, val;
-@@
-* if (json_array_set_new(arr, idx, val) < 0) {
-  ...
-* json_decref(val);
-  ...
-  }
-
-@@
 expression arr, idx, val, E;
+identifier decref = json_decref;
 @@
-* if (E || json_array_set_new(arr, idx, val) < 0) {
-  ...
-* json_decref(val);
-  ...
-  }
+  json_array_set_new(arr, idx, val)
+  ... when != val = E
+      when != json_incref(val)
+(
+* decref(val)
+|
+* ERRNO_SAFE_WRAP(decref, val)
+)
 
 // ---- json_array_insert_new ----
 
 @@
-expression arr, idx, val;
-@@
-* if (json_array_insert_new(arr, idx, val) < 0) {
-  ...
-* json_decref(val);
-  ...
-  }
-
-@@
 expression arr, idx, val, E;
+identifier decref = json_decref;
 @@
-* if (E || json_array_insert_new(arr, idx, val) < 0) {
-  ...
-* json_decref(val);
-  ...
-  }
+  json_array_insert_new(arr, idx, val)
+  ... when != val = E
+      when != json_incref(val)
+(
+* decref(val)
+|
+* ERRNO_SAFE_WRAP(decref, val)
+)
 
 // ---- json_object_iter_set_new ----
 
 @@
-expression obj, iter, val;
-@@
-* if (json_object_iter_set_new(obj, iter, val) < 0) {
-  ...
-* json_decref(val);
-  ...
-  }
-
-@@
 expression obj, iter, val, E;
+identifier decref = json_decref;
 @@
-* if (E || json_object_iter_set_new(obj, iter, val) < 0) {
-  ...
-* json_decref(val);
-  ...
-  }
+  json_object_iter_set_new(obj, iter, val)
+  ... when != val = E
+      when != json_incref(val)
+(
+* decref(val)
+|
+* ERRNO_SAFE_WRAP(decref, val)
+)


### PR DESCRIPTION
Problem: The existing cocinelle `json_*_new()` check only catches double-free if the associated `json_decref()` falls within the same conditional as the original new() call. This misses cases where the target object is freed after a `goto` or when using `ERRNO_SAFE_WRAP()`.

Rewrite each rule to match on data flow instead of block structure: match the `json_*_new()` call, then any later decref of the value reachable without an intervening reassignment or `json_incref()`. This catches the goto-to-shared-label and `ERRNO_SAFE_WRAP()` forms while still catching the original simple and compound-conditional forms.

Fix one instance of this new pattern in job-exec. (Another instance was fixed as part of the refactor in #7749)