### PR TITLE
add core support for RFC 33 virtual queues

### DIFF
--- a/doc/guide/admin_config.rst
+++ b/doc/guide/admin_config.rst
@@ -575,6 +575,17 @@ define a default queue.
 Finally, queues can override the ``[policy]`` table on a per queue basis.
 This is useful for setting queue-specific limits.
 
+A queue may also be configured as a *virtual queue* by setting ``parent``
+to the name of another queue. A virtual queue is an alternate submission
+name for the parent queue's resources with different policy: it inherits the
+parent's policy and overrides only the keys it sets. For example, a virtual
+queue that raises the parent's limits can allow a subset of users to submit
+jobs that bypass those limits. Note that Flux does not yet enforce per-queue
+access control, so restricting who may use a virtual queue currently requires
+an external mechanism such as the flux-accounting multi-factor priority
+plugin. A virtual queue may also be started, stopped, enabled, or disabled
+independently of its parent. See :man5:`flux-config-queues` for details.
+
 Here is an example that puts these concepts together:
 
 .. code-block:: toml
@@ -630,8 +641,12 @@ is rejected.
   ``nnodes`` *and* ``ncores`` limits when configuring job size policy limits.
 
 Limits are global when set in the top level ``[policy]`` table.  Global limits
-may be overridden by a ``policy`` table within a ``[queues]`` entry.  Here is
-an example which implements duration and job size limits for two queues:
+may be overridden by a ``policy`` table within a ``[queues]`` entry. A virtual
+queue's ``policy`` table overrides its parent queue's limits on a per-key
+basis, so a virtual queue that overrides only the duration limit still
+inherits the parent's job size limits. Here is an example which implements
+duration and job size limits for two queues, and adds a virtual queue for
+smaller jobs with a longer duration limit in the batch queue.
 
 .. code-block:: toml
 
@@ -651,6 +666,12 @@ an example which implements duration and job size limits for two queues:
  policy.limits.duration = "8h"
  policy.limits.job-size.max.nnodes = 16
  policy.limits.job-size.max.ncores = 128
+
+ [queues.small]
+ parent = "batch"
+ policy.limits.duration = "24h"
+ policy.limits.job-size.max.nnodes = 2
+ policy.limits.job-size.max.ncores = 16
 
 See also: :man5:`flux-config-policy`.
 

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -56,6 +56,10 @@ OPTIONS
 
    List jobs in a specific queue or queues. Multiple queues may be separated
    by a comma or by using the :option:`-q, --queue` option multiple times.
+   If a named queue has virtual queues configured (RFC 33), then jobs
+   submitted to any of its virtual queues are also listed, since they are
+   scheduled as part of the named queue. Naming a virtual queue directly
+   lists only the jobs submitted to that virtual queue.
 
 .. option:: -i, --include=HOSTS|RANKS
 

--- a/doc/man1/flux-queue.rst
+++ b/doc/man1/flux-queue.rst
@@ -32,6 +32,15 @@ The :program:`flux queue` command operates on Flux job queue(s).
 By default, Flux has one anonymous queue.  Multiple named queues may be
 configured - see :man5:`flux-config-queues`.
 
+A named queue may be a virtual queue, as described in RFC 33: an alternate
+submission name for a parent queue's resources with different policy,
+such as raised limits for a subset of users. Jobs submitted to a virtual
+queue are scheduled as part of the parent queue. The :program:`flux queue`
+administrative commands below operate on a virtual queue's own state
+without affecting its parent or sibling queues, but note that a virtual
+queue's jobs are only eligible for scheduling when both the virtual queue
+and its parent are started.
+
 COMMANDS
 ========
 
@@ -42,7 +51,9 @@ list
 
 .. program:: flux queue list
 
-List queue status, defaults, and limits.
+List queue status, defaults, and limits. When one or more virtual
+queues are configured, a ``PARENT`` column is also shown, listing each
+virtual queue's parent queue (blank for a non-virtual queue).
 
 .. option:: -q, --queue=QUEUE,...
 
@@ -223,23 +234,35 @@ The following field names can be specified:
 **queuem**
    queue name, but default queue is marked up with an asterisk
 
+**parent**
+   parent queue name if this is a virtual queue (RFC 33), otherwise empty.
+   This field is only shown by default if at least one configured queue
+   has a parent.
+
 **submission**
    Description of queue submission status: ``enabled`` or ``disabled``
 
 **scheduling**
-   Description of queue scheduling status: ``started`` or ``stopped``
+   Description of queue scheduling status: ``started``, ``stopped``, or,
+   for a virtual queue whose own state is started but whose parent queue
+   is stopped, ``stopped (parent)``.
 
 **enabled**
    Single character submission status: ``✔`` if enabled, ``✗`` if disabled.
 
 **started**
    Single character scheduling status: ``✔`` if started, ``✗`` if stopped.
+   A virtual queue whose own state is started but whose parent queue is
+   stopped shows ``⏸`` instead: scheduling will resume automatically once
+   the parent is started.
 
 **enabled.ascii**
    Single character submission status: ``y`` if enabled, ``n`` if disabled.
 
 **started.ascii**
-   Single character scheduling status: ``y`` if started, ``n`` if stopped.
+   Single character scheduling status: ``y`` if started, ``n`` if stopped,
+   or ``p`` if started but paused because its parent is stopped (see
+   **started** above).
 
 **defaults.timelimit**
    default timelimit for jobs submitted to the queue

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -493,7 +493,9 @@ The following field names can be specified for the **list** subcommand:
 
 **queue**
    Queue(s) associated with resources. When ``-q, --queue`` is used,
-   only the specified queues are shown.
+   only the specified queues are shown. Virtual queues (RFC 33) do not
+   appear in this field, since they share their parent queue's resources
+   rather than being associated with any resources of their own.
 
 **properties**
    Properties associated with resources.

--- a/doc/man5/flux-config-policy.rst
+++ b/doc/man5/flux-config-policy.rst
@@ -12,7 +12,10 @@ and limits, as described in RFC 33.
 Each queue defined in the ``queues`` table described in
 :man5:`flux-config-queues` may have a ``policy`` sub-table that follows the
 same rules as the main table.  The per-queue table overrides the general table
-for jobs submitted to that queue.
+for jobs submitted to that queue. A virtual queue (RFC 33) adds a further
+level: its own ``policy`` table, where set, overrides its parent queue's
+effective policy on a per-key basis, which in turn overrides the general
+table.
 
 DEFAULTS
 ========

--- a/doc/man5/flux-config-queues.rst
+++ b/doc/man5/flux-config-queues.rst
@@ -25,9 +25,42 @@ policy (table)
    A policy table as described in :man5:`flux-config-policy` that overrides
    the general system policy for jobs submitted to this queue.
 
+parent (string)
+   Declares this queue to be a virtual queue, as described in RFC 33. The
+   value names another queue in the ``[queues]`` table from which this
+   queue inherits its resource subset and policy. A virtual queue MUST
+   NOT set ``requires`` or ``policy.scheduler``: it always shares its
+   parent's resources, and thus its parent's scheduler configuration.
+   The named parent must not itself be a virtual queue. A virtual queue
+   may be configured as the default queue.
+
 A default queue name may be configured by setting
 ``policy.jobspec.defaults.system.queue`` as described in
 :man5:`flux-config-policy`.
+
+
+VIRTUAL QUEUES
+==============
+
+A virtual queue is an alternate name under which jobs may be submitted to
+a parent queue's resources, with different policy applied at job
+ingest. A job submitted to a virtual queue keeps the virtual queue's name
+for listing, accounting, and per-queue policy purposes, but is scheduled
+as part of its parent queue: it competes for the parent's resources in the
+same priority order as jobs submitted directly to the parent.
+
+A virtual queue inherits every policy key from its parent, and any key it
+sets itself overrides only that key. For example, a virtual queue that
+sets ``policy.limits.duration`` but not ``policy.limits.job-size`` still
+inherits the parent's job-size limits. Job defaults
+(``policy.jobspec.defaults.system``) are inherited the same way.
+
+A virtual queue may be enabled/disabled and started/stopped
+independently of its parent. However, because a virtual queue's jobs are
+scheduled as part of its parent, they are only eligible for scheduling
+when both the virtual queue and its parent are started. Starting a
+virtual queue whose parent is stopped does not release its jobs; they
+become eligible only once the parent is also started.
 
 
 EXAMPLE
@@ -51,7 +84,12 @@ EXAMPLE
 
    [queues.batch]
    policy.limits.duration = "8h"
+   policy.limits.job-size.max.nnodes = 16
    requires = [ "batch" ]
+
+   [queues.expedite]
+   parent = "batch"
+   policy.limits.duration = "1h"
 
    [policy.jobspec.defaults.system]
    queue = "batch"
@@ -62,6 +100,11 @@ EXAMPLE
    [sched-fluxion-resource]
    match-policy = "lonodex"
    match-format = "rv1_nosched"
+
+In this configuration, ``expedite`` is a virtual queue of ``batch``: jobs
+submitted with ``--queue=expedite`` run on ``batch``'s resources, subject
+to a shorter 1 hour duration limit, but still inherit ``batch``'s
+16 node job-size limit since ``expedite`` does not override it.
 
 
 CAVEATS

--- a/src/bindings/python/flux/job/frobnicator/plugins/constraints.py
+++ b/src/bindings/python/flux/job/frobnicator/plugins/constraints.py
@@ -25,9 +25,25 @@ class QueueConfig:
 
     def queue_properties(self, name):
         try:
-            return self.queues[name]["requires"]
+            entry = self.queues[name]
         except KeyError:
             return None
+        # A virtual queue (RFC 33) has no 'requires' of its own -
+        # inject the parent's instead, since that is what makes the
+        # job schedule as part of the parent's job list. Inheritance
+        # is one level (validated by conf_policy.c), so no chain to
+        # walk. An unresolvable parent is a fatal error (fail closed):
+        # silently dropping the parent's constraint would place the
+        # job outside the parent's resource slice.
+        parent = entry.get("parent")
+        if parent is not None:
+            try:
+                entry = self.queues[parent]
+            except KeyError:
+                raise ValueError(
+                    f"queue '{name}': parent queue '{parent}' is not configured"
+                )
+        return entry.get("requires")
 
     def apply_constraints(self, jobspec):
         """Apply queue-specific constraints to jobspec"""

--- a/src/bindings/python/flux/job/frobnicator/plugins/defaults.py
+++ b/src/bindings/python/flux/job/frobnicator/plugins/defaults.py
@@ -49,18 +49,42 @@ class DefaultsConfig:
             self.queue_defaults(queue)
 
     def queue_defaults(self, name):
-        """Create a copy of self.defaults updated with queue-specific values"""
+        """Create a copy of self.defaults updated with queue-specific values
+
+        Effective defaults are layered: global defaults, then (if 'name'
+        is a virtual queue, RFC 33) the parent queue's own defaults,
+        then this queue's own defaults - each layer overlaid per-key
+        over the last. Inheritance is one level (validated by
+        conf_policy.c), so there is no chain to walk beyond the parent.
+        """
+
+        def queue_system_defaults(qconf):
+            try:
+                return qconf["policy"]["jobspec"]["defaults"]["system"]
+            except KeyError:
+                return None
+
         defaults = copy.deepcopy(self.defaults)
         if name and self.queues:
             if name not in self.queues:
                 raise ValueError(f"Invalid queue '{name}' specified")
             qconf = self.queues[name]
-            try:
-                qdefaults = qconf["policy"]["jobspec"]["defaults"]["system"]
+            # A virtual queue (RFC 33) inherits the parent's defaults
+            # beneath its own. An unresolvable parent is a fatal error
+            # (fail closed): silently skipping the parent layer would
+            # give the vqueue the wrong effective defaults.
+            parent = qconf.get("parent")
+            if parent is not None:
+                if parent not in self.queues:
+                    raise ValueError(
+                        f"queue '{name}': parent queue '{parent}' is not configured"
+                    )
+                pdefaults = queue_system_defaults(self.queues[parent])
+                if pdefaults is not None:
+                    defaults.update(pdefaults)
+            qdefaults = queue_system_defaults(qconf)
+            if qdefaults is not None:
                 defaults.update(qdefaults)
-                return defaults
-            except KeyError:
-                return defaults
         return defaults
 
     def setattr_default(self, jobspec, attr, value):

--- a/src/bindings/python/flux/queue.py
+++ b/src/bindings/python/flux/queue.py
@@ -60,6 +60,7 @@ attributes are also documented for each corresponding class in this module::
   queue.is_default (bool)
   queue.enabled (bool)
   queue.started (bool)
+  queue.parent (str) (empty string unless this is an RFC 33 virtual queue)
   queue.defaults.duration (float)
   queue.limits.min.{nnodes,ncores,ngpus} (int)
   queue.limits.max.{nnodes,ncores,ngpus} (int)
@@ -147,16 +148,27 @@ class QueueResources:
             allocated to jobs
     """
 
-    def __init__(self, name, resources, config):
-        if (
-            name
-            and "queues" in config
-            and name in config["queues"]
-            and "requires" in config["queues"][name]
-        ):
-            self._resource_list = resources.copy_constraint(
-                {"properties": config["queues"][name]["requires"]}
-            )
+    def __init__(self, name, resources, config, parent=""):
+        # A virtual queue (RFC 33) has no "requires" of its own (enforced
+        # at config validation), so it takes its parent's resource slice
+        # instead of the full instance resource set. 'parent' comes from
+        # the queue-status RPC while 'config' comes from a separate
+        # config.get RPC, so a config reload can race the two: a parent
+        # that is no longer in config is an error (fail closed), since
+        # falling through would silently report the vqueue as covering
+        # the full instance resource set.
+        requires = None
+        queues = config.get("queues", {})
+        if name and name in queues:
+            requires = queues[name].get("requires")
+        if requires is None and parent:
+            if parent not in queues:
+                raise ValueError(
+                    f"queue '{name}': parent queue '{parent}' is not configured"
+                )
+            requires = queues[parent].get("requires")
+        if requires is not None:
+            self._resource_list = resources.copy_constraint({"properties": requires})
         else:
             self._resource_list = resources
 
@@ -172,19 +184,43 @@ class QueueInfo:
         name (str): The queue name (empty string for anonymous queue)
         is_default (bool): True if this is the default queue
         enabled (bool): True if this queue is enabled
-        started (bool): True if this queue is started
+        started (bool): True if this queue is started (effective state,
+            i.e. own AND parent for an RFC 33 virtual queue)
+        blocked (str): Reason keyword (RFC 33) if this queue's own started
+            bit is set but it is effectively stopped by an external
+            condition: "scheduler" (scheduler offline) or "parent" (a
+            virtual queue's parent is stopped). None otherwise. An
+            unrecognized keyword is treated as a generic blocked condition.
+        parent (str): Name of the parent queue if this is an RFC 33
+            virtual queue, otherwise an empty string
         resources (:obj:`QueueResources`): resources currently in this queue
         defaults (:obj:`QueueDefaults`): defaults that apply to this queue
         limits (:obj:`QueueLimits`): policy limits that apply to this queue
     """
 
-    def __init__(self, name, config, resources, enabled, started, default):
+    def __init__(
+        self,
+        name,
+        config,
+        resources,
+        enabled,
+        started,
+        default,
+        parent="",
+        blocked=None,
+    ):
         self.name = name or ""
         self.config = config
         self.is_default = default
         self.enabled = enabled
         self.started = started
-        self.resources = QueueResources(name, resources, config)
+        # RFC 33 virtual queues: parent is sourced from the queue-status
+        # RPC response rather than config, since that is the job-manager's
+        # authoritative view of the resolved parent (config is also in
+        # hand here, but a single source avoids the two ever disagreeing).
+        self.parent = parent or ""
+        self.blocked = blocked
+        self.resources = QueueResources(name, resources, config, self.parent)
         self.defaults = QueueDefaults(
             duration=parse_fsd(self._policy_default("duration"))
         )
@@ -202,42 +238,57 @@ class QueueInfo:
             duration=parse_fsd(self._policy_system_limit("duration")),
         )
 
+    def _config_entries(self):
+        """
+        Yield config entries to search for a policy/limit/default key, in
+        RFC 33 virtual queue inheritance order: this queue's own config
+        entry, its parent's config entry (if this is a virtual queue),
+        then the global config. Each key is looked up independently in
+        this order (per-key inheritance), so a vqueue setting only one
+        key still inherits its parent's other keys. A parent missing
+        from config (a config reload racing the queue-status RPC, see
+        QueueResources) is an error: silently skipping the parent layer
+        would report the wrong effective limits and defaults.
+        """
+        queues = self.config.get("queues", {})
+        if self.name in queues:
+            yield queues[self.name]
+        if self.parent:
+            if self.parent not in queues:
+                raise ValueError(
+                    f"queue '{self.name}': parent queue '{self.parent}'"
+                    " is not configured"
+                )
+            yield queues[self.parent]
+        yield self.config
+
     def _size_limit(self, key, maximum=True):
         limit = maximum and "max" or "min"
-        try:
-            val = self.config["queues"][self.name]["policy"]["limits"]["job-size"][
-                limit
-            ][key]
-        except KeyError:
+        for entry in self._config_entries():
             try:
-                val = self.config["policy"]["limits"]["job-size"][limit][key]
+                val = entry["policy"]["limits"]["job-size"][limit][key]
             except KeyError:
-                val = math.inf if maximum else 0
+                continue
             if val < 0:
                 val = math.inf
-        return val
+            return val
+        return math.inf if maximum else 0
 
     def _policy_default(self, key, default="inf"):
-        try:
-            result = self.config["queues"][self.name]["policy"]["jobspec"]["defaults"][
-                "system"
-            ][key]
-        except KeyError:
+        for entry in self._config_entries():
             try:
-                result = self.config["policy"]["jobspec"]["defaults"]["system"][key]
+                return entry["policy"]["jobspec"]["defaults"]["system"][key]
             except KeyError:
-                result = default
-        return result
+                continue
+        return default
 
     def _policy_system_limit(self, key, default="inf"):
-        try:
-            result = self.config["queues"][self.name]["policy"]["limits"][key]
-        except KeyError:
+        for entry in self._config_entries():
             try:
-                result = self.config["policy"]["limits"][key]
+                return entry["policy"]["limits"][key]
             except KeyError:
-                result = default
-        return result
+                continue
+        return default
 
 
 class QueueList:
@@ -268,7 +319,14 @@ class QueueList:
         if not queue_config:
             # single anonymous queue:
             self.__queue = QueueInfo(
-                None, config, resources, status["enable"], status["start"], True
+                None,
+                config,
+                resources,
+                status["enable"],
+                status["start"],
+                True,
+                status.get("parent", ""),
+                status.get("blocked"),
             )
             self.__queues = {"": self.__queue}
         else:
@@ -281,6 +339,8 @@ class QueueList:
                     status[x]["enable"],
                     status[x]["start"],
                     x == self.default_queue,
+                    status[x].get("parent", ""),
+                    status[x].get("blocked"),
                 )
                 for x in queue_config.keys()
             }

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -112,6 +112,7 @@ class FluxQueueConfig(UtilConfig):
             "description": "Default flux-queue list format string",
             "format": (
                 "?:{queuem:<8.8} "
+                "?:{parent:<8.8} "
                 "{color_enabled}{enabled:>2}{color_off} "
                 "{color_started}{started:>2}{color_off} "
                 "{defaults.timelimit!F:>8} "
@@ -125,6 +126,7 @@ class FluxQueueConfig(UtilConfig):
             "description": "flux-queue list with policy limits only",
             "format": (
                 "?:{queuem:<8.8} "
+                "?:{parent:<8.8} "
                 "{color_enabled}{enabled:>2}{color_off} "
                 "{color_started}{started:>2}{color_off} "
                 "{defaults.timelimit!F:>8} "
@@ -138,6 +140,7 @@ class FluxQueueConfig(UtilConfig):
             "description": "Show queue status plus all/up/allocated/free nodes",
             "format": (
                 "?:{queuem:<8.8} "
+                "?:{parent:<8.8} "
                 "{color_enabled}{enabled:>2}{color_off} "
                 "{color_started}{started:>2}{color_off} "
                 "{resources.all.nnodes:>6} "
@@ -231,6 +234,7 @@ class QueueInfoWrapper:
         self.__qinfo = queue_info
         self.is_started = queue_info.started
         self.is_enabled = queue_info.enabled
+        self.blocked_reason = queue_info.blocked
         self.limits = QueueLimitsWrapper(queue_info)
 
     def __getattr__(self, attr):
@@ -240,8 +244,25 @@ class QueueInfoWrapper:
             raise AttributeError("invalid QueueInfo attribute '{}'".format(attr))
 
     @property
+    def is_paused(self):
+        # An RFC 33 virtual queue whose own start bit is set but which is
+        # effectively stopped because its parent queue is stopped
+        # (blocked reason "parent"). This is the only blocked condition
+        # that gets a distinct display (SCHED "stopped (parent)", yellow
+        # paused glyph): it is new with virtual queues, so no prior
+        # expectation is perturbed, and it clears on its own once the
+        # parent starts. Other blocked conditions (e.g. "scheduler", the
+        # scheduler being offline) are pre-existing and remain rendered
+        # as a plain red "stopped", unchanged from prior behavior.
+        return self.blocked_reason == "parent"
+
+    @property
     def scheduling(self):
-        return "started" if self.is_started else "stopped"
+        if self.is_started:
+            return "started"
+        if self.is_paused:
+            return "stopped (parent)"
+        return "stopped"
 
     @property
     def submission(self):
@@ -271,11 +292,24 @@ class QueueInfoWrapper:
 
     @property
     def color_started(self):
-        return "\033[01;32m" if self.is_started else "\033[01;31m"
+        if self.is_started:
+            return "\033[01;32m"
+        # Yellow for a vqueue paused by a stopped parent, between the
+        # green "started" and red "stopped". See is_paused.
+        if self.is_paused:
+            return "\033[01;33m"
+        return "\033[01;31m"
 
     @property
     def started(self):
-        return AltField("✔", "y") if self.is_started else AltField("✗", "n")
+        if self.is_started:
+            return AltField("✔", "y")
+        # A vqueue paused by a stopped parent gets a distinct "paused"
+        # glyph rather than the plain "stopped" ✗, since it resumes
+        # scheduling on its own once the parent starts. See is_paused.
+        if self.is_paused:
+            return AltField("⏸", "p")
+        return AltField("✗", "n")
 
 
 def generate_resource_headings():
@@ -293,6 +327,7 @@ def list(args):
     headings = {
         "queue": "QUEUE",
         "queuem": "QUEUE",
+        "parent": "PARENT",
         "submission": "SUBMIT",
         "scheduling": "SCHED",
         "enabled": "EN",

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -196,6 +196,29 @@ def undrain(args):
     RPC(flux.Flux(), "resource.undrain", payload, nodeid=0).get()
 
 
+def queue_effective_entry(queues, name):
+    """
+    Return the effective [queues] config entry for queue ``name``: its own
+    entry, or its parent's entry if it is an RFC 33 virtual queue.
+
+    A virtual queue has no "requires" of its own, so resolving to the
+    parent's entry is what maps it to the parent's resource slice rather
+    than wrongly matching every node as an unconstrained queue would. An
+    unresolvable parent raises ValueError (defense in depth: config
+    validation rejects it in a live instance, but --config-file and
+    --from-stdin input is not validated).
+    """
+    entry = queues[name]
+    if "parent" in entry:
+        parent = entry["parent"]
+        if parent not in queues:
+            raise ValueError(
+                f"queue '{name}': parent queue '{parent}' is not configured"
+            )
+        entry = queues[parent]
+    return entry
+
+
 class QueueResources:
     """
     Convenience class to map queues to resource sets
@@ -206,10 +229,9 @@ class QueueResources:
         if "queues" not in config:
             return
         for queue in config["queues"]:
-            if "requires" in config["queues"][queue]:
-                result = resource_set.copy_constraint(
-                    {"properties": config["queues"][queue]["requires"]}
-                )
+            entry = queue_effective_entry(config["queues"], queue)
+            if "requires" in entry:
+                result = resource_set.copy_constraint({"properties": entry["requires"]})
             else:
                 result = resource_set.copy()
             self._queues[queue] = result
@@ -561,7 +583,14 @@ class ResourceSetExtra(ResourceSet):
                         continue
                 elif key in self._hidden_queues:
                     continue
-                if "requires" not in value or set(value["requires"]).issubset(
+                # RFC 33 virtual queues: only emit a vqueue name when it
+                # was explicitly requested via -q (i.e. is in the filter),
+                # otherwise it would match every node in the default QUEUE
+                # column via its resolved parent's requires:
+                if "parent" in value and not self._queue_filter:
+                    continue
+                entry = queue_effective_entry(self.flux_config["queues"], key)
+                if "requires" not in entry or set(entry["requires"]).issubset(
                     set(properties)
                 ):
                     queues = queues + "," + key if queues else key
@@ -633,11 +662,20 @@ def resources_uniq_lines(
     #  Get a list of configured queues if a specific list of queues
     #  was not supplied by the caller. Hidden queues are excluded from the
     #  default list but are still visible when explicitly requested via -q.
+    #  RFC 33 virtual queues are excluded from this default list, since
+    #  they share their parent's resources and would otherwise duplicate
+    #  the parent's rows. When requested explicitly via -q they are kept
+    #  (queues == args.queue is truthy, so this branch is skipped) and
+    #  resolve to their parent's slice in ResourceSetExtra.queue.
     #  If no queues are configured then one "anonymous" queue is simulated
     #  with [None].
     if not queues:
         if config and "queues" in config:
-            queues = [q for q in config["queues"] if q not in hidden_queues]
+            queues = [
+                q
+                for q, entry in config["queues"].items()
+                if q not in hidden_queues and "parent" not in entry
+            ]
             if not queues:
                 queues = [None]
         else:

--- a/src/common/libfluxutil/conf_policy.c
+++ b/src/common/libfluxutil/conf_policy.c
@@ -19,6 +19,7 @@
 
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/fsd.h"
+#include "ccan/str/str.h"
 
 #include "conf_policy.h"
 
@@ -243,6 +244,7 @@ inval:
 static int validate_policy_json (json_t *policy,
                                  const char *key,
                                  const char **default_queue,
+                                 json_t **schedulerp,
                                  flux_error_t *error)
 {
     json_error_t jerror;
@@ -285,6 +287,8 @@ static int validate_policy_json (json_t *policy,
     }
     if (default_queue)
         *default_queue = defqueue;
+    if (schedulerp)
+        *schedulerp = scheduler;
     return 0;
 }
 
@@ -304,12 +308,30 @@ static int validate_policy_config (const flux_conf_t *conf,
         return -1;
     }
     if (policy) {
-        if (validate_policy_json (policy, "policy", &defqueue, error) < 0)
+        if (validate_policy_json (policy, "policy", &defqueue, NULL, error)
+            < 0)
             return -1;
     }
     if (default_queue)
         *default_queue = defqueue;
     return 0;
+}
+
+/* Returns true if 'entry' (a queues.NAME config table) declares a 'parent'
+ * key, i.e. is a virtual queue. '*parentp' is set to the parent name
+ * string (unvalidated) when non-NULL and a parent key is present.
+ */
+static bool queue_entry_is_virtual (json_t *entry, const char **parentp)
+{
+    json_t *parent;
+
+    if ((parent = json_object_get (entry, "parent"))
+        && json_is_string (parent)) {
+        if (parentp)
+            *parentp = json_string_value (parent);
+        return true;
+    }
+    return false;
 }
 
 static int validate_queues_config (const flux_conf_t *conf,
@@ -336,17 +358,21 @@ static int validate_queues_config (const flux_conf_t *conf,
                        " not a table");
             goto inval;
         }
+        /* Pass 1: per-entry syntax validation
+         */
         json_object_foreach (queues, name, entry) {
             json_error_t jerror;
             json_t *policy = NULL;
             json_t *requires = NULL;
+            const char *parent = NULL;
 
             if (json_unpack_ex (entry,
                                 &jerror,
                                 0,
-                                "{s?o s?o !}",
+                                "{s?o s?o s?s !}",
                                 "policy", &policy,
-                                "requires", &requires) < 0) {
+                                "requires", &requires,
+                                "parent", &parent) < 0) {
                 errprintf (error,
                            "error parsing [queues.%s] config table: %s",
                            name,
@@ -356,8 +382,13 @@ static int validate_queues_config (const flux_conf_t *conf,
             if (policy) {
                 char key[1024];
                 const char *defqueue;
+                json_t *scheduler = NULL;
                 snprintf (key, sizeof (key), "queues.%s.policy", name);
-                if (validate_policy_json (policy, key, &defqueue, error) < 0)
+                if (validate_policy_json (policy,
+                                          key,
+                                          &defqueue,
+                                          &scheduler,
+                                          error) < 0)
                     return -1;
                 if (defqueue) {
                     errprintf (error,
@@ -366,8 +397,23 @@ static int validate_queues_config (const flux_conf_t *conf,
                                name);
                     goto inval;
                 }
+                if (parent && scheduler) {
+                    errprintf (error,
+                               "error parsing [queues.%s] config table:"
+                               " a virtual queue must not set"
+                               " 'policy.scheduler'",
+                               name);
+                    goto inval;
+                }
             }
             if (requires) {
+                if (parent) {
+                    errprintf (error,
+                               "error parsing [queues.%s] config table:"
+                               " a virtual queue must not set 'requires'",
+                               name);
+                    goto inval;
+                }
                 const char *banned_property_chars = " \t!&'\"`'|()";
                 if (!is_string_array (requires, banned_property_chars)) {
                     errprintf (error,
@@ -379,8 +425,49 @@ static int validate_queues_config (const flux_conf_t *conf,
                 }
             }
         }
+        /* Pass 2: cross-queue virtual queue relationships. This requires
+         * all entries to have already passed syntax validation above, and
+         * looks up parent entries directly out of the [queues] table
+         * (json_object_get, not the job-manager's queues.[ch] table, which
+         * does not exist yet when config is first validated).
+         */
+        json_object_foreach (queues, name, entry) {
+            const char *parent;
+
+            if (queue_entry_is_virtual (entry, &parent)) {
+                json_t *parent_entry;
+
+                if (streq (parent, name)) {
+                    errprintf (error,
+                               "error parsing [queues.%s] config table:"
+                               " parent queue is itself",
+                               name);
+                    goto inval;
+                }
+                if (!(parent_entry = json_object_get (queues, parent))) {
+                    errprintf (error,
+                               "error parsing [queues.%s] config table:"
+                               " parent queue '%s' is not configured",
+                               name,
+                               parent);
+                    goto inval;
+                }
+                if (queue_entry_is_virtual (parent_entry, NULL)) {
+                    errprintf (error,
+                               "error parsing [queues.%s] config table:"
+                               " parent queue '%s' is itself a virtual"
+                               " queue",
+                               name,
+                               parent);
+                    goto inval;
+                }
+            }
+        }
     }
     if (default_queue) {
+        /* A virtual queue may be the default queue, so only require that
+         * the name appear in [queues], not that it be non-virtual.
+         */
         if (!queues || !json_object_get (queues, default_queue)) {
             errprintf (error,
                        "the [policy] config table defines a default queue %s"

--- a/src/modules/job-list/match.c
+++ b/src/modules/job-list/match.c
@@ -301,6 +301,29 @@ static struct list_constraint *create_name_constraint (struct match_ctx *mctx,
     return create_string_constraint (mctx, "name", values, match_name, errp);
 }
 
+/* RFC 33 virtual queues: a constraint naming queue N matches a job
+ * whose own queue is N, or whose queue is a virtual queue with parent
+ * N, since vqueue jobs are scheduled as part of the parent's job
+ * list. A constraint naming a virtual queue matches only that
+ * virtual queue's jobs (no expansion, inheritance is one level).
+ */
+static bool queue_name_matches (struct match_ctx *mctx,
+                                const char *name,
+                                const char *job_queue)
+{
+    const char *parent;
+
+    if (!job_queue)
+        return false;
+    if (streq (name, job_queue))
+        return true;
+    if (mctx->queue_parents
+        && (parent = zhashx_lookup (mctx->queue_parents, job_queue))
+        && streq (name, parent))
+        return true;
+    return false;
+}
+
 static int match_queue (struct list_constraint *c,
                         const struct job *job,
                         unsigned int *comparisons,
@@ -310,7 +333,7 @@ static int match_queue (struct list_constraint *c,
     while (queue) {
         if (inc_check_comparison (c->mctx, comparisons, errp) < 0)
             return -1;
-        if (job->queue && streq (queue, job->queue))
+        if (queue_name_matches (c->mctx, queue, job->queue))
             return 1;
         queue = zlistx_next (c->values);
     }
@@ -918,11 +941,69 @@ static int config_parse_max_comparisons (struct match_ctx *mctx,
     return 0;
 }
 
+/* RFC 33 virtual queues: rebuild the vqueue name to parent name map
+ * from the [queues] config table. The map is built into a new hash
+ * that replaces the current one only on success: a rejected config
+ * reload leaves the old config in effect (see config_reload_cb in
+ * job-list.c), so it must leave the old map in effect too.
+ */
+static int config_parse_queue_parents (struct match_ctx *mctx,
+                                       const flux_conf_t *conf,
+                                       flux_error_t *errp)
+{
+    zhashx_t *queue_parents;
+    json_t *queues = NULL;
+    const char *name;
+    json_t *entry;
+
+    if (flux_conf_unpack (conf, NULL, "{s?o}", "queues", &queues) < 0) {
+        errprintf (errp, "error unpacking [queues] config table");
+        return -1;
+    }
+    if (!(queue_parents = zhashx_new ())) {
+        errprintf (errp, "out of memory building queue parent map");
+        return -1;
+    }
+    zhashx_set_destructor (queue_parents, wrap_free);
+    zhashx_set_duplicator (queue_parents, (zhashx_duplicator_fn *) strdup);
+
+    if (queues) {
+        json_object_foreach (queues, name, entry) {
+            json_t *parent;
+
+            if (!(parent = json_object_get (entry, "parent")))
+                continue;
+            if (!json_is_string (parent)) {
+                errprintf (errp,
+                           "queues.%s: 'parent' must be a string",
+                           name);
+                goto error;
+            }
+            if (zhashx_insert (queue_parents,
+                               name,
+                               (void *)json_string_value (parent)) < 0) {
+                errprintf (errp,
+                          "error building queue parent map entry for '%s'",
+                          name);
+                goto error;
+            }
+        }
+    }
+    zhashx_destroy (&mctx->queue_parents);
+    mctx->queue_parents = queue_parents;
+    return 0;
+error:
+    zhashx_destroy (&queue_parents);
+    return -1;
+}
+
 int job_match_config_reload (struct match_ctx *mctx,
                              const flux_conf_t *conf,
                              flux_error_t *errp)
 {
-    return config_parse_max_comparisons (mctx, conf, errp);
+    if (config_parse_max_comparisons (mctx, conf, errp) < 0)
+        return -1;
+    return config_parse_queue_parents (mctx, conf, errp);
 }
 
 struct match_ctx *match_ctx_create (flux_t *h)
@@ -937,6 +1018,13 @@ struct match_ctx *match_ctx_create (flux_t *h)
     if (config_parse_max_comparisons (mctx,
                                       flux_get_conf (mctx->h),
                                       &error) < 0) {
+        flux_log (mctx->h, LOG_ERR, "%s", error.text);
+        goto error;
+    }
+
+    if (config_parse_queue_parents (mctx,
+                                    flux_get_conf (mctx->h),
+                                    &error) < 0) {
         flux_log (mctx->h, LOG_ERR, "%s", error.text);
         goto error;
     }
@@ -974,8 +1062,10 @@ error:
 
 void match_ctx_destroy (struct match_ctx *mctx)
 {
-    if (mctx)
+    if (mctx) {
+        zhashx_destroy (&mctx->queue_parents);
         free (mctx);
+    }
 }
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/modules/job-list/match.h
+++ b/src/modules/job-list/match.h
@@ -18,12 +18,21 @@
 #include <flux/core.h> /* flux_error_t */
 #include <jansson.h>
 
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
 #include "job_data.h"
 
 struct match_ctx {
     flux_t *h;
     uint64_t max_comparisons;
     uint32_t max_hostlist;
+
+    /* RFC 33 virtual queues: map of vqueue name to parent queue name,
+     * built from the [queues] config table at load and config-reload.
+     * A job's queue is a key in this table iff it names a virtual
+     * queue.
+     */
+    zhashx_t *queue_parents;
 };
 
 struct match_ctx *match_ctx_create (flux_t *h);

--- a/src/modules/job-list/test/match.c
+++ b/src/modules/job-list/test/match.c
@@ -15,6 +15,7 @@
 #include <flux/core.h>
 
 #include "src/common/libtap/tap.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/modules/job-list/job_data.h"
 #include "src/modules/job-list/match.h"
 #include "ccan/str/str.h"
@@ -476,6 +477,190 @@ static void test_basic_queue (void)
         list_constraint_destroy (c);
         ctests++;
     }
+}
+
+/* zhashx_set_destructor for mctx.queue_parents in test_virtual_queue () */
+static void wrap_free_test (void **item)
+{
+    if (item) {
+        free (*item);
+        (*item) = NULL;
+    }
+}
+
+/* RFC 33 virtual queues: a constraint naming a queue that has vqueues
+ * matches jobs in that queue or in any of its vqueues. A constraint
+ * naming a vqueue matches only that vqueue's own jobs.
+ */
+static void test_virtual_queue (void)
+{
+    struct job *job;
+    struct list_constraint *c;
+    flux_error_t error;
+
+    if (!(mctx.queue_parents = zhashx_new ()))
+        BAIL_OUT ("failed to create queue_parents hash");
+    zhashx_set_destructor (mctx.queue_parents, wrap_free_test);
+    zhashx_set_duplicator (mctx.queue_parents,
+                           (zhashx_duplicator_fn *) strdup);
+    if (zhashx_insert (mctx.queue_parents, "expedite", "batch") < 0)
+        BAIL_OUT ("failed to insert into queue_parents hash");
+
+    c = create_list_constraint ("{ \"queue\": [ \"batch\" ] }");
+
+    job = setup_job (0,
+                     NULL,
+                     "batch",
+                     NULL,
+                     NULL,
+                     0,
+                     0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0);
+    ok (job_match (job, c, &error) == true,
+        "queue constraint on parent matches parent job");
+    job_destroy (job);
+
+    job = setup_job (0,
+                     NULL,
+                     "expedite",
+                     NULL,
+                     NULL,
+                     0,
+                     0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0);
+    ok (job_match (job, c, &error) == true,
+        "queue constraint on parent matches vqueue job");
+    job_destroy (job);
+
+    job = setup_job (0,
+                     NULL,
+                     "debug",
+                     NULL,
+                     NULL,
+                     0,
+                     0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0);
+    ok (job_match (job, c, &error) == false,
+        "queue constraint on parent does not match unrelated queue job");
+    job_destroy (job);
+
+    list_constraint_destroy (c);
+
+    c = create_list_constraint ("{ \"queue\": [ \"expedite\" ] }");
+
+    job = setup_job (0,
+                     NULL,
+                     "expedite",
+                     NULL,
+                     NULL,
+                     0,
+                     0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0);
+    ok (job_match (job, c, &error) == true,
+        "queue constraint on vqueue matches its own job");
+    job_destroy (job);
+
+    job = setup_job (0,
+                     NULL,
+                     "batch",
+                     NULL,
+                     NULL,
+                     0,
+                     0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0,
+                     0.0);
+    ok (job_match (job, c, &error) == false,
+        "queue constraint on vqueue does not match parent job");
+    job_destroy (job);
+
+    list_constraint_destroy (c);
+
+    zhashx_destroy (&mctx.queue_parents);
+}
+
+/* job_match_config_reload() builds the queue parent map into a new
+ * hash and swaps it in only on success: a rejected config reload
+ * leaves the old config in effect, so it must leave the old map in
+ * effect too. A malformed 'parent' is rejected rather than skipped.
+ */
+static void test_virtual_queue_config_reload (void)
+{
+    flux_conf_t *conf;
+    flux_error_t error;
+
+    if (!(conf = flux_conf_pack ("{s:{s:{} s:{s:s}}}",
+                                 "queues",
+                                   "batch",
+                                   "expedite",
+                                     "parent", "batch")))
+        BAIL_OUT ("flux_conf_pack failed");
+    ok (job_match_config_reload (&mctx, conf, &error) == 0,
+        "config reload with vqueue works");
+    flux_conf_decref (conf);
+    ok (mctx.queue_parents
+        && zhashx_lookup (mctx.queue_parents, "expedite") != NULL,
+        "queue parent map contains vqueue entry");
+
+    /* Invalid config: non-string parent is an error, and the map
+     * built from the previous config remains in effect.
+     */
+    if (!(conf = flux_conf_pack ("{s:{s:{} s:{s:i}}}",
+                                 "queues",
+                                   "batch",
+                                   "expedite",
+                                     "parent", 42)))
+        BAIL_OUT ("flux_conf_pack failed");
+    error.text[0] = '\0';
+    ok (job_match_config_reload (&mctx, conf, &error) < 0,
+        "config reload with non-string parent fails");
+    diag ("%s", error.text);
+    ok (strstr (error.text, "must be a string") != NULL,
+        "error message says parent must be a string");
+    flux_conf_decref (conf);
+    ok (mctx.queue_parents
+        && zhashx_lookup (mctx.queue_parents, "expedite") != NULL,
+        "failed reload leaves the previous queue parent map in effect");
+
+    /* Reload without queues clears the map */
+    if (!(conf = flux_conf_create ()))
+        BAIL_OUT ("flux_conf_create failed");
+    ok (job_match_config_reload (&mctx, conf, &error) == 0,
+        "config reload without [queues] works");
+    flux_conf_decref (conf);
+    ok (mctx.queue_parents
+        && zhashx_lookup (mctx.queue_parents, "expedite") == NULL,
+        "queue parent map no longer contains vqueue entry");
+
+    zhashx_destroy (&mctx.queue_parents);
 }
 
 struct basic_states_test {
@@ -2153,6 +2338,8 @@ int main (int argc, char *argv[])
     test_basic_userid ();
     test_basic_name ();
     test_basic_queue ();
+    test_virtual_queue ();
+    test_virtual_queue_config_reload ();
     test_basic_states ();
     test_basic_results ();
     test_corner_case_hostlist ();

--- a/src/modules/job-manager/plugins/limit-duration.c
+++ b/src/modules/job-manager/plugins/limit-duration.c
@@ -168,14 +168,56 @@ static int queues_parse (zhashx_t **zhp,
     if ((queues = json_object_get (conf, "queues"))) {
         const char *name;
         json_t *entry;
-        double duration;
         flux_error_t e;
 
         json_object_foreach (queues, name, entry) {
-            if (duration_parse (&duration, entry, &e) < 0) {
+            double duration = DURATION_INVALID;
+            double own;
+            json_t *parent = json_object_get (entry, "parent");
+
+            /* RFC 33 virtual queues: a vqueue with no own duration
+             * limit inherits its parent queue's limit. Read the
+             * parent's entry directly out of the [queues] table
+             * rather than the hash being built here, since
+             * json_object_foreach() iteration order is arbitrary
+             * and the parent may not have been processed yet. A
+             * malformed or unresolvable parent is a fatal error (fail
+             * closed): a vqueue silently defaulting to global/no limit
+             * would let jobs bypass the intended limit.
+             * conf_policy_validate() rejects this config up front, so
+             * reaching here means validation was bypassed.
+             */
+            if (parent) {
+                const char *parent_name;
+                json_t *parent_entry;
+
+                if (!json_is_string (parent)) {
+                    errprintf (error,
+                               "queues.%s: 'parent' must be a string",
+                               name);
+                    goto error;
+                }
+                parent_name = json_string_value (parent);
+                if (!(parent_entry = json_object_get (queues,
+                                                      parent_name))) {
+                    errprintf (error,
+                               "queues.%s: parent queue '%s' is not"
+                               " configured",
+                               name,
+                               parent_name);
+                    goto error;
+                }
+                if (duration_parse (&duration, parent_entry, &e) < 0) {
+                    errprintf (error, "queues.%s.%s", parent_name, e.text);
+                    goto error;
+                }
+            }
+            if (duration_parse (&own, entry, &e) < 0) {
                 errprintf (error, "queues.%s.%s", name, e.text);
                 goto error;
             }
+            if (own != DURATION_INVALID)
+                duration = own;
             queues_insert (zh, name, duration);
         }
     }

--- a/src/modules/job-manager/plugins/limit-job-size.c
+++ b/src/modules/job-manager/plugins/limit-job-size.c
@@ -280,13 +280,56 @@ static int queues_parse (zhashx_t **zhp,
         const char *name;
         json_t *entry;
         struct limits limits;
+        struct limits own;
         flux_error_t e;
 
         json_object_foreach (queues, name, entry) {
-            if (limits_parse (&limits, entry, &e) < 0) {
+            json_t *parent = json_object_get (entry, "parent");
+
+            limits_clear (&limits);
+
+            /* RFC 33 virtual queues: a vqueue inherits its parent
+             * queue's job-size limits, overlaid per-key by its own.
+             * Read the parent's entry directly out of the [queues]
+             * table rather than the hash being built here, since
+             * json_object_foreach() iteration order is arbitrary
+             * and the parent may not have been processed yet. A
+             * malformed or unresolvable parent is a fatal error (fail
+             * closed): a vqueue silently defaulting to global/no
+             * limits would let jobs bypass the intended limits.
+             * conf_policy_validate() rejects this config up front, so
+             * reaching here means validation was bypassed.
+             */
+            if (parent) {
+                const char *parent_name;
+                json_t *parent_entry;
+
+                if (!json_is_string (parent)) {
+                    errprintf (error,
+                               "queues.%s: 'parent' must be a string",
+                               name);
+                    goto error;
+                }
+                parent_name = json_string_value (parent);
+                if (!(parent_entry = json_object_get (queues,
+                                                      parent_name))) {
+                    errprintf (error,
+                               "queues.%s: parent queue '%s' is not"
+                               " configured",
+                               name,
+                               parent_name);
+                    goto error;
+                }
+                if (limits_parse (&limits, parent_entry, &e) < 0) {
+                    errprintf (error, "queues.%s.%s", parent_name, e.text);
+                    goto error;
+                }
+            }
+            if (limits_parse (&own, entry, &e) < 0) {
                 errprintf (error, "queues.%s.%s", name, e.text);
                 goto error;
             }
+            limits_override (&limits, &own);
             queues_insert (zh, name, &limits);
         }
     }

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -453,11 +453,16 @@ static int constraints_match_check (struct queue_ctx *qctx,
         return -1;
 
     /*  If current queue has constraints, then create a constraint object
-     *  for equivalence test below:
+     *  for equivalence test below. queue_requires() returns the effective
+     *  requires: for a virtual queue (RFC 33) its own requires is always
+     *  NULL (enforced by conf_policy.c), but its jobs carry the parent's
+     *  property constraint (injected by the constraints frobnicator
+     *  plugin), so the parent's requires is what must match here.
      */
     if (queue_requires (q)
         && !(expected = json_pack ("{s:O}",
-                                   "properties", queue_requires (q)))) {
+                                   "properties",
+                                   queue_requires (q)))) {
         errprintf (errp, "failed to get constraints for current queue");
         goto out;
     }
@@ -544,7 +549,10 @@ static int queue_update_cb (flux_plugin_t *p,
      *  and append an additional update of the job constraints.
      *
      *  This is done via two different calls below dependent on whether the
-     *  new queue has any constraints.
+     *  new queue has any constraints. As above, queue_requires() is the
+     *  effective requires: a job moved into a virtual queue must pick up
+     *  the parent's constraint, since that is what makes it schedule as
+     *  part of the parent's job list.
      */
     if (queue_requires (newq)) {
         /*  Replace current constraints with those of the new queue
@@ -555,7 +563,8 @@ static int queue_update_cb (flux_plugin_t *p,
                                    "feasibility", 1,
                                    "updates",
                                     "attributes.system.constraints",
-                                     "properties", queue_requires (newq));
+                                     "properties",
+                                     queue_requires (newq));
     }
     else {
         /*  New queue has no requirements. Set constraints to empty object.

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -247,14 +247,54 @@ error:
         flux_log_error (h, "error responding to job-manager.queue-enable");
 }
 
+/* This function returns true if an operation on the queue named
+ * 'name' (e.g. start or stop) applies to a job submitted to queue
+ * 'job_queue'. It is used by enqueue_jobs()/dequeue_jobs() to select
+ * jobs.
+ *
+ * A NULL 'name' applies to every job. Otherwise the operation
+ * applies to the job when:
+ *  - 'name' is the job's own queue, or
+ *  - 'name' is a non-virtual queue and the job's queue is one of its
+ *    virtual queues (RFC 33): a virtual queue's jobs are scheduled
+ *    as part of the parent queue, so an operation on the parent must
+ *    reach them. The converse is not true: an operation on a virtual
+ *    queue does not apply to its parent's or sibling queues' jobs.
+ *
+ * If either name no longer resolves to a configured queue (e.g.
+ * removed by a reload - such jobs are intentionally left in place,
+ * see the on_queue_change() N.B. above), fall back to an exact name
+ * comparison, matching pre-vqueue behavior.
+ */
+static bool queue_name_covers (struct queue_ctx *qctx,
+                               const char *name,
+                               const char *job_queue)
+{
+    struct queue *target;
+    struct queue *jq;
+
+    if (!name)
+        return true;
+    if (!job_queue)
+        return false;
+    if (!(target = queues_lookup (qctx->queues, name, NULL)))
+        return streq (job_queue, name);
+    if (!(jq = queues_lookup (qctx->queues, job_queue, NULL)))
+        return streq (job_queue, name);
+    if (queue_is_virtual (target))
+        return jq == target;
+    return queue_root (jq) == target;
+}
+
 static int enqueue_jobs (struct queue_ctx *qctx, const char *name)
 {
     struct job *job = zhashx_first (qctx->ctx->active_jobs);
     while (job) {
-        if (!name || (job->queue && streq (job->queue, name))) {
+        if (queue_name_covers (qctx, name, job->queue)) {
             if (!job->alloc_queued
                 && !job->alloc_pending
-                && job->state == FLUX_JOB_STATE_SCHED) {
+                && job->state == FLUX_JOB_STATE_SCHED
+                && queue_started (qctx, job)) {
                 if (alloc_enqueue_alloc_request (qctx->ctx->alloc, job) < 0)
                     return -1;
                 if (alloc_queue_recalc_pending (qctx->ctx->alloc) < 0)
@@ -272,7 +312,7 @@ static void dequeue_jobs (struct queue_ctx *qctx, const char *name)
         || alloc_pending_count (qctx->ctx->alloc) > 0) {
         struct job *job = zhashx_first (qctx->ctx->active_jobs);
         while (job) {
-            if (!name || (job->queue && streq (job->queue, name))) {
+            if (queue_name_covers (qctx, name, job->queue)) {
                 if (job->alloc_queued)
                     alloc_dequeue_alloc_request (qctx->ctx->alloc, job);
                 else if (job->alloc_pending)

--- a/src/modules/job-manager/queues.c
+++ b/src/modules/job-manager/queues.c
@@ -44,7 +44,17 @@ struct queue {
     bool is_started;            /* current queue state */
     bool is_started_sticky;     /* tracks is_started unless --nocheckpoint */
     char *stop_reason;          /* reason if stopped (optionally set) */
-    json_t *requires;           /* required properties array */
+    json_t *requires;           /* required properties array (own; a
+                                  * virtual queue's is always NULL - see
+                                  * queue_root() for the effective value)
+                                  */
+    struct queue *parent;       /* resolved parent queue (RFC 33 virtual
+                                  * queues), or NULL if not virtual. Not
+                                  * owned; borrowed from the same queues
+                                  * table. Inheritance is one level
+                                  * (validated elsewhere) so this is
+                                  * never itself virtual.
+                                  */
     struct queues *queues;      /* back-pointer for notify */
 };
 
@@ -90,6 +100,151 @@ static void queue_destructor (void **item)
     }
 }
 
+/* Extract the "parent" key from a queue's own config entry 'entry' (may
+ * be NULL). On success, '*namep' is set to the borrowed name string,
+ * or NULL if 'entry' has no "parent" key. Returns -1 if "parent" is
+ * present but not a string.
+ */
+static int entry_parent_name (json_t *entry, const char **namep)
+{
+    *namep = NULL;
+    if (!entry)
+        return 0;
+    return json_unpack (entry, "{s?s}", "parent", namep);
+}
+
+/* True if 'name's config entry in 'table' (the full desired [queues]
+ * config, or NULL) declares a "parent", i.e. 'name' is to be virtual.
+ * Used by queues_config_validate() to check a candidate parent's own
+ * virtual-ness directly against the desired config JSON, since at
+ * validation time the corresponding queue objects may not have their
+ * ->parent pointers resolved yet (JSON object iteration order is
+ * arbitrary).
+ */
+static bool entry_is_virtual (json_t *table, const char *name)
+{
+    const char *parent_name;
+
+    return table
+        && entry_parent_name (json_object_get (table, name),
+                              &parent_name) == 0
+        && parent_name != NULL;
+}
+
+/* Wire virtual queue 'q's ->parent pointer from its config 'entry'
+ * (RFC 33 virtual queues). Called only from queues_configure()'s second
+ * pass, after queues_config_validate() has already checked every parent
+ * reference in the same config (string, not self, resolves, not itself
+ * virtual). Those checks are thus guaranteed to hold and are not
+ * repeated here.
+ *
+ * Returns -1 on failure with errno set to EPROTO. This indicates a
+ * previous failure to validate, or some other unexpected error.
+ */
+static int resolve_parent (struct queue *q, json_t *entry)
+{
+    struct queue *parent;
+    struct queues *queues = q->queues;
+    const char *parent_name;
+
+    q->parent = NULL;
+    if (entry_parent_name (entry, &parent_name) < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    if (!parent_name)
+        return 0;
+    if (!queues->named
+        || !(parent = zhashx_lookup (queues->named, parent_name))) {
+        errno = EPROTO;
+        return -1;
+    }
+    q->parent = parent;
+    return 0;
+}
+
+/* Lookup and validate the "parent" key of config 'entry' (with queue 'name')
+ * against the live config table, without mutating any state. This is useful
+ * when validating a parent entry on a first config pass, as required by
+ * queues_add()/queues_updated(). 'name' is the queue being added/updated
+ * (NULL for the anon queue).
+ *
+ * On success returns 0 and sets '*parentp' to the parent queue, or NULL if
+ * 'entry' declares no parent. Returns -1 with 'error' filled in if 'parent'
+ * is malformed, not configured, names 'name' itself, is itself virtual, or
+ * is declared on the anonymous queue (whose creation removes every named
+ * queue, including any would-be parent).
+ *
+ * Note: Typically libfluxutil/conf_policy.c duplicates this same validation,
+ * so the checks done here are defense-in-depth.
+ */
+static int lookup_parent (struct queues *queues,
+                          const char *name,
+                          json_t *entry,
+                          struct queue **parentp,
+                          flux_error_t *error)
+{
+    struct queue *parent;
+    const char *parent_name;
+
+    *parentp = NULL;
+    if (entry_parent_name (entry, &parent_name) < 0) {
+        errprintf (error,
+                  "queue '%s': 'parent' must be a string",
+                  name ? name : "(anon)");
+        errno = EINVAL;
+        return -1;
+    }
+    if (!parent_name)
+        return 0;
+    if (!name) {
+        errprintf (error, "the anonymous queue cannot have a parent");
+        errno = EINVAL;
+        return -1;
+    }
+    if (streq (parent_name, name)) {
+        errprintf (error, "queue '%s': parent queue is itself", name);
+        errno = EINVAL;
+        return -1;
+    }
+    if (!queues->named
+        || !(parent = zhashx_lookup (queues->named, parent_name))) {
+        errprintf (error,
+                  "queue '%s': parent queue '%s' is not configured",
+                  name,
+                  parent_name);
+        errno = EINVAL;
+        return -1;
+    }
+    if (queue_is_virtual (parent)) {
+        errprintf (error,
+                  "queue '%s': parent queue '%s' is itself a virtual queue",
+                  name,
+                  parent_name);
+        errno = EINVAL;
+        return -1;
+    }
+    *parentp = parent;
+    return 0;
+}
+
+/* Parse the 'requires' config-derived field shared by queue_alloc() and
+ * queues_update(). 'parent' (RFC 33 virtual queues) is handled
+ * separately by resolve_parent() above, straight from the config JSON.
+ */
+static int queue_parse_config (struct queue *q, json_t *config)
+{
+    json_t *requires = NULL;
+
+    if (config && json_unpack (config, "{s?O}", "requires", &requires) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    json_decref (q->requires);
+    q->requires = requires;   /* may be NULL */
+    return 0;
+}
+
 static struct queue *queue_alloc (struct queues *queues,
                                   const char *name,
                                   json_t *config)
@@ -103,11 +258,8 @@ static struct queue *queue_alloc (struct queues *queues,
         goto error;
     q->is_enabled = true;
 
-    if (config
-        && json_unpack (config, "{s?O}", "requires", &q->requires) < 0) {
-        errno = EINVAL;
+    if (queue_parse_config (q, config) < 0)
         goto error;
-    }
 
     /* The anonymous queue begins life started; named queues do not. */
     if (name)
@@ -238,7 +390,11 @@ bool queues_queue_is_started (struct queues *queues, const char *name)
             return false;
         q = queues->anon;
     }
-    return q->is_started;
+    /* RFC 33 virtual queues: a job is eligible for scheduling only
+     * when both its own queue and (if virtual) the parent queue are
+     * started.  For a non-virtual queue, queue_root (q) == q.
+     */
+    return q->is_started && queue_root (q)->is_started;
 }
 
 /* First-class add/remove/update primitives */
@@ -277,10 +433,19 @@ static int remove_all_named_queues (struct queues *queues)
     return 0;
 }
 
-struct queue *queues_add (struct queues *queues,
-                          const char *name,
-                          json_t *config,
-                          flux_error_t *error)
+/* Internal: add a queue to the table without resolving its 'parent'
+ * (RFC 33 virtual queues) to a pointer. Used by
+ * queues_configure()'s per-entry loop, which defers resolution to a
+ * second pass across the *whole* table once every add/update/remove for
+ * this configure call has been applied - JSON object iteration order is
+ * arbitrary, so a virtual queue's parent may be processed after it, and
+ * a reload may re-point an existing queue's already-resolved parent.
+ * See queues_configure().
+ */
+static struct queue *queue_add_internal (struct queues *queues,
+                                         const char *name,
+                                         json_t *config,
+                                         flux_error_t *error)
 {
     struct queue *q;
     zhashx_t *named = NULL;
@@ -348,7 +513,37 @@ error:
     return NULL;
 }
 
-int queues_remove (struct queues *queues, const char *name)
+struct queue *queues_add (struct queues *queues,
+                          const char *name,
+                          json_t *config,
+                          flux_error_t *error)
+{
+    struct queue *q;
+    struct queue *parent;
+
+    /* Unlike queues_configure() (which defers to a whole-table second
+     * pass - see queue_add_internal() above), a standalone add has no
+     * further "table is now fully populated" step coming, so validate
+     * and look up 'parent' now, BEFORE the add mutates anything - see
+     * lookup_parent() for what a post-add failure would leave behind.
+     */
+    if (lookup_parent (queues, name, config, &parent, error) < 0)
+        return NULL;
+    if (!(q = queue_add_internal (queues, name, config, error)))
+        return NULL;
+    q->parent = parent;
+    return q;
+}
+
+/* Internal: remove a queue without checking for dependent virtual
+ * queues. Used by queues_configure(), whose up-front validation
+ * (queues_config_validate()) already guarantees that any surviving
+ * virtual queue's parent also survives, and whose second pass
+ * re-resolves every surviving queue's ->parent pointer - so removing
+ * a parent mid-configure is safe there and must not be rejected
+ * (e.g. a reload that drops a parent and its vqueues together).
+ */
+static int queue_remove_internal (struct queues *queues, const char *name)
 {
     struct queue *q;
 
@@ -365,33 +560,128 @@ int queues_remove (struct queues *queues, const char *name)
     return 0;
 }
 
+int queues_remove (struct queues *queues,
+                   const char *name,
+                   flux_error_t *error)
+{
+    struct queue *q;
+
+    if (!queues->named || !name) {
+        errprintf (error, "no named queues or no queue name given");
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(q = zhashx_lookup (queues->named, name))) {
+        errprintf (error, "queue '%s' does not exist", name);
+        errno = ENOENT;
+        return -1;
+    }
+    /* RFC 33 virtual queues: refuse to remove a queue that other
+     * queues name as their parent, else their ->parent pointers would
+     * dangle (use-after-free on the next status or effective-started
+     * query). Callers must remove or re-parent the virtual queues
+     * first. queues_configure() is exempt via queue_remove_internal()
+     * above - its validation and second pass maintain the invariant
+     * across the whole reconfigure.
+     */
+    if (!queue_is_virtual (q)) {
+        char vqueues[128];
+        size_t n = 0;
+        struct queue *child = queues_first (queues);
+        while (child) {
+            if (child->parent == q && n < sizeof (vqueues)) {
+                int len = snprintf (vqueues + n,
+                                    sizeof (vqueues) - n,
+                                    "%s%s",
+                                    n ? "," : "",
+                                    child->name);
+                if (len > 0)
+                    n += len;
+            }
+            child = queues_next (queues);
+        }
+        if (n > 0) {
+            errprintf (error,
+                       "queue '%s' is the parent of virtual queue%s %s",
+                       name,
+                       strchr (vqueues, ',') ? "s" : "",
+                       vqueues);
+            errno = EBUSY;
+            return -1;
+        }
+    }
+    return queue_remove_internal (queues, name);
+}
+
+/* Internal: refresh config-derived fields of an existing queue without
+ * resolving 'parent' to a pointer - see queue_add_internal() above for
+ * why queues_configure()'s per-entry loop needs this variant.
+ */
+static int queue_update_internal (struct queues *queues,
+                                  struct queue *q,
+                                  json_t *config,
+                                  flux_error_t *error)
+{
+    if (queue_parse_config (q, config) < 0) {
+        errprintf (error, "invalid queue config");
+        return -1;
+    }
+    notify (queues, q, "update");
+    return 0;
+}
+
 int queues_update (struct queues *queues,
                    struct queue *q,
                    json_t *config,
                    flux_error_t *error)
 {
-    json_t *requires = NULL;
+    struct queue *parent;
 
-    if (config && json_unpack (config, "{s?O}", "requires", &requires) < 0) {
+    /* An update may re-parent (or un-parent/parent) an existing queue.
+     * As with queues_add(), a standalone update has no whole-table
+     * second pass coming, so validate 'parent' BEFORE mutating anything
+     * - see lookup_parent() for what a post-mutation failure would
+     * leave behind - then apply it along with the config-derived
+     * fields, so the "update" observer sees the fully-updated queue
+     * (queues_configure() instead notifies per entry and resolves
+     * parents in its second pass). N.B. queue_parse_config() mutates
+     * nothing when it fails.
+     */
+    if (lookup_parent (queues, q->name, config, &parent, error) < 0)
+        return -1;
+    if (queue_parse_config (q, config) < 0) {
         errprintf (error, "invalid queue config");
-        errno = EINVAL;
         return -1;
     }
-    json_decref (q->requires);
-    q->requires = requires;   /* may be NULL */
+    q->parent = parent;
     notify (queues, q, "update");
     return 0;
 }
 
 /* Configuration */
 
-/* Structural validation of a [queues] config object, without mutating any
- * state: each queue's value must be a table. This is only what
- * queues_configure() needs to reject a bad config before its destructive
- * remove phase, keeping the reconfigure transactional. It is deliberately
- * not a full RFC 33 schema check (known keys, 'requires' property array,
- * 'policy' sub-table) - that is done up front by conf_policy_validate()
- * before any config reaches this class.
+/* Validate a [queues] config object without mutating any state, so
+ * queues_configure() can reject a bad config before its destructive remove
+ * phase and thereby keep the reconfigure transactional. Two passes:
+ *
+ *  1. Structural: each queue's value must be a table.
+ *  2. Parent references (RFC 33 virtual queues): a virtual queue's 'parent'
+ *     must be a string, must not name the queue itself, must resolve to
+ *     another entry in this same config, and that entry must not itself be
+ *     virtual (inheritance is one level). These mirror resolve_parent()'s
+ *     rules, but are checked here against the desired config JSON up front -
+ *     resolve_parent() otherwise runs only in queues_configure()'s second
+ *     pass, after queues have already been removed/added, so a bad parent
+ *     reaching it there would both partially apply the config and, if the
+ *     failing entry's dropped parent had left a sibling virtual queue's
+ *     ->parent dangling, leave that stale pointer unresolved. Pre-validating
+ *     makes the destructive phase unreachable on any such input.
+ *
+ * This is deliberately not a full RFC 33 schema check (known keys, 'requires'
+ * property array, 'policy' sub-table) - that is done up front by
+ * conf_policy_validate() before any config reaches this class. The parent
+ * checks here overlap conf_policy_validate()'s, but this class must remain
+ * self-protecting against bad config reaching queues_configure() directly.
  */
 static int queues_config_validate (json_t *config, flux_error_t *error)
 {
@@ -401,6 +691,39 @@ static int queues_config_validate (json_t *config, flux_error_t *error)
     json_object_foreach (config, name, value) {
         if (!json_is_object (value)) {
             errprintf (error, "queue %s: configuration must be a table", name);
+            errno = EINVAL;
+            return -1;
+        }
+    }
+    json_object_foreach (config, name, value) {
+        const char *parent_name;
+
+        if (entry_parent_name (value, &parent_name) < 0) {
+            errprintf (error, "queue '%s': 'parent' must be a string", name);
+            errno = EINVAL;
+            return -1;
+        }
+        if (!parent_name)
+            continue;
+        if (streq (parent_name, name)) {
+            errprintf (error, "queue '%s': parent queue is itself", name);
+            errno = EINVAL;
+            return -1;
+        }
+        if (!json_object_get (config, parent_name)) {
+            errprintf (error,
+                       "queue '%s': parent queue '%s' is not configured",
+                       name,
+                       parent_name);
+            errno = EINVAL;
+            return -1;
+        }
+        if (entry_is_virtual (config, parent_name)) {
+            errprintf (error,
+                       "queue '%s': parent queue '%s' is itself a virtual"
+                       " queue",
+                       name,
+                       parent_name);
             errno = EINVAL;
             return -1;
         }
@@ -416,10 +739,12 @@ int queues_configure (struct queues *queues,
         const char *name;
         json_t *value;
 
-        /* Validate the entire config before mutating any state. The apply
-         * phase below removes queues before adding/updating, so rejecting a
-         * malformed config up front is what keeps a failed reconfigure from
-         * leaving a partially-applied configuration behind.
+        /* Validate the entire config before mutating any state - both its
+         * structure and its virtual-queue parent references. The apply phase
+         * below removes queues before adding/updating, so rejecting a bad
+         * config up front is what keeps a failed reconfigure from leaving a
+         * partially-applied configuration (or a dangling ->parent pointer)
+         * behind.
          */
         if (queues_config_validate (config, error) < 0)
             return -1;
@@ -434,7 +759,7 @@ int queues_configure (struct queues *queues,
             name = zlistx_first (names);
             while (name) {
                 if (!json_object_get (config, name)) {
-                    if (queues_remove (queues, name) < 0) {
+                    if (queue_remove_internal (queues, name) < 0) {
                         errprintf (error,
                                    "remove: %s: %s",
                                    name,
@@ -448,12 +773,19 @@ int queues_configure (struct queues *queues,
             zlistx_destroy (&names);
         }
 
-        /* Add new queues / update existing ones */
+        /* Add new queues / update existing ones. Parent resolution
+         * (RFC 33 virtual queues) is deferred to a second pass below,
+         * once the table reflects the full desired config: JSON object
+         * iteration order is arbitrary, so a virtual queue's parent
+         * entry may not have been added/updated yet when the virtual
+         * queue itself is processed, and a reload may change which
+         * queue is whose parent.
+         */
         json_object_foreach (config, name, value) {
             struct queue *q;
             if (!queues->named
                 || !(q = zhashx_lookup (queues->named, name))) {
-                if (!queues_add (queues, name, value, error))
+                if (!queue_add_internal (queues, name, value, error))
                     return -1;
             }
             else {
@@ -461,8 +793,31 @@ int queues_configure (struct queues *queues,
                  * Administrative state (enable/start bits, reasons,
                  * sticky) is preserved per b362f73d7.
                  */
-                if (queues_update (queues, q, value, error) < 0)
+                if (queue_update_internal (queues, q, value, error) < 0)
                     return -1;
+            }
+        }
+
+        /* Second pass: now that every queue in the desired config is
+         * present with its config-derived fields refreshed, resolve
+         * 'parent' pointers. queues_config_validate() has already
+         * checked every parent reference against this same 'config'
+         * above, so resolve_parent() cannot fail here on referential
+         * grounds; it re-checks only enough to avoid storing a bogus
+         * pointer, and a -1 return would indicate an internal
+         * inconsistency (see resolve_parent()), which we still propagate
+         * with a caller-facing message.
+         */
+        json_object_foreach (config, name, value) {
+            struct queue *q;
+            if (queues->named
+                && (q = zhashx_lookup (queues->named, name))
+                && resolve_parent (q, value) < 0) {
+                errprintf (error,
+                           "queue '%s': failed to resolve parent: %s",
+                           name,
+                           strerror (errno));
+                return -1;
             }
         }
     }
@@ -490,24 +845,54 @@ static int set_string (json_t *o, const char *key, const char *val)
     return 0;
 }
 
+/* "start" is the effective started state. "blocked" is a keyword (RFC 33)
+ * identifying why a started queue is not scheduling: "scheduler" if the
+ * scheduler is offline, or "parent" for a virtual queue whose parent is
+ * stopped. It is included only in that case, alongside a "stop_reason"
+ * describing the condition for humans. A consumer can derive the queue's
+ * own started bit as (start || blocked-present).
+ */
 json_t *queue_status_encode (struct queue *q, bool sched_ready)
 {
-    json_t *o;
+    json_t *o = NULL;
     bool start;
+    const char *blocked_reason = NULL;
     const char *stop_reason;
+    char *parent_reason = NULL;
 
     if (!sched_ready) {
         start = false;
+        if (q->is_started)
+            blocked_reason = "scheduler";
         stop_reason = "Scheduler is offline";
     }
     else {
-        start = q->is_started;
+        start = queue_is_started_effective (q);
         stop_reason = q->stop_reason;
+        if (!start && q->is_started) {
+            /* Virtual queue with own bit started but parent stopped */
+            blocked_reason = "parent";
+            if (asprintf (&parent_reason,
+                          "parent queue '%s' is stopped",
+                          queue_name (queue_parent (q))) < 0) {
+                parent_reason = NULL;
+                goto error;
+            }
+            stop_reason = parent_reason;
+        }
     }
     if (!(o = json_pack ("{s:b s:b}",
                          "enable", q->is_enabled,
                          "start", start)))
         goto error;
+    if (queue_is_virtual (q)) {
+        if (set_string (o, "parent", queue_name (queue_parent (q))) < 0)
+            goto error;
+    }
+    if (blocked_reason) {
+        if (set_string (o, "blocked", blocked_reason) < 0)
+            goto error;
+    }
     if (!q->is_enabled && q->disable_reason) {
         if (set_string (o, "disable_reason", q->disable_reason) < 0)
             goto error;
@@ -516,10 +901,12 @@ json_t *queue_status_encode (struct queue *q, bool sched_ready)
         if (set_string (o, "stop_reason", stop_reason) < 0)
             goto error;
     }
+    free (parent_reason);
     return o;
 error:
     errno = ENOMEM;
     ERRNO_SAFE_WRAP (json_decref, o);
+    ERRNO_SAFE_WRAP (free, parent_reason);
     return NULL;
 }
 
@@ -715,7 +1102,11 @@ const char *queue_name (struct queue *q)
 
 json_t *queue_requires (struct queue *q)
 {
-    return q->requires;
+    /* Effective requires: a virtual queue (RFC 33) has no requires of
+     * its own, so return the parent's. queue_root (q) == q for a
+     * non-virtual queue, so this is the queue's own requires there.
+     */
+    return queue_root (q)->requires;
 }
 
 bool queue_is_enabled (struct queue *q)
@@ -736,6 +1127,28 @@ bool queue_is_started (struct queue *q)
 const char *queue_stop_reason (struct queue *q)
 {
     return q->stop_reason;
+}
+
+/* Virtual queue (RFC 33) accessors */
+
+bool queue_is_virtual (struct queue *q)
+{
+    return q->parent != NULL;
+}
+
+struct queue *queue_parent (struct queue *q)
+{
+    return q->parent;
+}
+
+struct queue *queue_root (struct queue *q)
+{
+    return q->parent ? q->parent : q;
+}
+
+bool queue_is_started_effective (struct queue *q)
+{
+    return q->is_started && queue_root (q)->is_started;
 }
 
 /* Per-queue mutators (fire notify) */

--- a/src/modules/job-manager/queues.h
+++ b/src/modules/job-manager/queues.h
@@ -40,12 +40,22 @@ int queues_configure (struct queues *queues,
                       flux_error_t *error);
 
 /* First-class add/remove/update (used by configure)
+ *
+ * queues_remove() refuses to remove a queue that other queues name as
+ * their parent (RFC 33 virtual queues), failing with EBUSY and an
+ * error naming the dependent virtual queues; remove or re-parent them
+ * first. (queues_configure() is not subject to this: its up-front
+ * validation guarantees a surviving virtual queue's parent survives
+ * any reload, so a parent and its virtual queues may be removed
+ * together.)
  */
 struct queue *queues_add (struct queues *queues,
                           const char *name,
                           json_t *config,
                           flux_error_t *error);
-int queues_remove (struct queues *queues, const char *name);
+int queues_remove (struct queues *queues,
+                   const char *name,
+                   flux_error_t *error);
 
 /* Refresh config-derived fields (requires, ...) of an existing queue;
  * administrative state (enable/start bits, reasons, sticky) is preserved.
@@ -118,11 +128,33 @@ json_t *queues_list_encode (struct queues *queues);
  * If q == NULL, assume anonymous queue.
  */
 const char *queue_name (struct queue *q);
+/* Effective requires: for a virtual queue (RFC 33) this is the parent's
+ * requires, since a vqueue has none of its own; for a non-virtual queue
+ * it is the queue's own requires.
+ */
 json_t *queue_requires (struct queue *q);
 bool queue_is_enabled (struct queue *q);
 const char *queue_disable_reason (struct queue *q);
+/* Own started bit; see queue_is_started_effective() below for a
+ * virtual queue's effective state.
+ */
 bool queue_is_started (struct queue *q);
 const char *queue_stop_reason (struct queue *q);
+
+/* Virtual queue (RFC 33) accessors.
+ *
+ * A queue is virtual iff its config sets 'parent'. Inheritance is one
+ * level: a vqueue's parent is validated (conf_policy.c and the second
+ * validation pass below) to never itself be virtual, so there is no
+ * chain to walk - queue_root() is a single pointer dereference.
+ */
+bool queue_is_virtual (struct queue *q);
+/* NULL if not virtual */
+struct queue *queue_parent (struct queue *q);
+/* 'q's parent if virtual, else 'q' itself */
+struct queue *queue_root (struct queue *q);
+/* Own started bit AND root's started bit */
+bool queue_is_started_effective (struct queue *q);
 
 /* Per-queue mutators
  * These methods fire notification.

--- a/src/modules/job-manager/test/queues.c
+++ b/src/modules/job-manager/test/queues.c
@@ -1057,7 +1057,7 @@ static void test_list_names (void)
 
     /* snapshot survives queue removal mid-iteration */
     name = zlistx_first (names);
-    ok (queues_remove (qs, "batch") == 0,
+    ok (queues_remove (qs, "batch", &error) == 0,
         "queues_remove during snapshot iteration works");
     ok (queues_lookup (qs, "batch", NULL) == NULL,
         "removed name no longer resolves");
@@ -1121,15 +1121,15 @@ static void test_add_remove_primitives (void)
 
     /* remove error cases */
     errno = 0;
-    ok (queues_remove (qs, "noexist") < 0 && errno == ENOENT,
+    ok (queues_remove (qs, "noexist", &error) < 0 && errno == ENOENT,
         "queues_remove unknown name fails with ENOENT");
     errno = 0;
-    ok (queues_remove (qs, NULL) < 0 && errno == EINVAL,
+    ok (queues_remove (qs, NULL, &error) < 0 && errno == EINVAL,
         "queues_remove NULL name fails with EINVAL");
 
     /* remove one queue */
     notify_reset ();
-    ok (queues_remove (qs, "debug") == 0,
+    ok (queues_remove (qs, "debug", &error) == 0,
         "queues_remove debug works");
     ok (notify_count == 1
         && streq (notify_log[0].event, "remove")
@@ -1160,7 +1160,7 @@ static void test_add_remove_primitives (void)
 
     /* remove in anon mode is an error */
     errno = 0;
-    ok (queues_remove (qs, "batch") < 0 && errno == EINVAL,
+    ok (queues_remove (qs, "batch", &error) < 0 && errno == EINVAL,
         "queues_remove in anon mode fails with EINVAL");
 
     queues_destroy (qs);
@@ -1421,6 +1421,7 @@ static void test_status_encode (void)
     json_t *o;
     int enable;
     int start;
+    const char *blocked;
     const char *reason;
 
     qs = queues_create ();
@@ -1463,13 +1464,21 @@ static void test_status_encode (void)
         "started status: start true, no stop_reason");
     json_decref (o);
 
-    /* started but scheduler offline: presented stopped + synthesized
-     * reason (own state untouched) */
+    /* started but scheduler offline: presented stopped + blocked +
+     * synthesized reason (own state untouched) */
     o = queue_status_encode (q, false);
-    ok (o && json_unpack (o, "{s:b s:b s:s !}", "enable", &enable,
-                          "start", &start, "stop_reason", &reason) == 0
-        && enable && !start && streq (reason, "Scheduler is offline"),
-        "sched offline: presented stopped with synthesized reason");
+    ok (o
+        && json_unpack (o,
+                        "{s:b s:b s:s s:s !}",
+                        "enable", &enable,
+                        "start", &start,
+                        "blocked", &blocked,
+                        "stop_reason", &reason) == 0
+        && enable
+        && !start
+        && streq (blocked, "scheduler")
+        && streq (reason, "Scheduler is offline"),
+        "sched offline: presented stopped and blocked with reason");
     ok (queue_is_started (q),
         "sched offline does not modify queue state");
     json_decref (o);

--- a/src/modules/job-manager/test/queues.c
+++ b/src/modules/job-manager/test/queues.c
@@ -1376,6 +1376,73 @@ static void test_configure_partial_failure (void)
     queues_destroy (qs);
 }
 
+/* A failed queues_configure() must not partially apply when the failure is
+ * an unresolvable virtual-queue parent (RFC 33), and in particular must not
+ * leave a sibling virtual queue's ->parent dangling. The bad new config here
+ * drops "batch" (which "vq" is parented to) and adds "aaa" naming a missing
+ * parent; "aaa" sorts before "vq" so a per-entry resolve would fail after
+ * "batch" was already freed, leaving vq->parent pointing at freed memory.
+ * The whole-config pre-check must reject this before any queue is touched.
+ * This path is unreachable via the broker (conf_policy_validate() rejects it
+ * first) but the class must be self-protecting against direct input.
+ */
+static void test_configure_bad_parent_transactional (void)
+{
+    struct queues *qs;
+    struct queue *batch;
+    struct queue *vq;
+    flux_error_t error;
+    json_t *config;
+    json_t *bad;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{} s:{s:s}}",
+                        "batch",
+                        "vq",
+                          "parent", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed");
+    json_decref (config);
+
+    batch = queues_lookup (qs, "batch", NULL);
+    vq = queues_lookup (qs, "vq", NULL);
+    if (!batch || !vq || queue_parent (vq) != batch)
+        BAIL_OUT ("initial vqueue config not as expected");
+
+    queues_set_notify (qs, notify_cb, NULL);
+    notify_reset ();
+
+    /* aaa names a missing parent; batch (vq's parent) is dropped. */
+    bad = json_pack ("{s:{s:s} s:{s:s}}",
+                     "aaa",
+                       "parent", "nosuchqueue",
+                     "vq",
+                       "parent", "batch");
+    if (!bad)
+        BAIL_OUT ("json_pack failed");
+    errno = 0;
+    ok (queues_configure (qs, bad, &error) < 0 && errno == EINVAL,
+        "configure with an unresolvable parent fails with EINVAL");
+    json_decref (bad);
+
+    ok (notify_count == 0, "no notifications fired on failed configure");
+    ok (queues_lookup (qs, "batch", NULL) == batch,
+        "batch still present (not freed) after failed configure");
+    ok (queues_lookup (qs, "aaa", NULL) == NULL,
+        "invalid queue was not added");
+    vq = queues_lookup (qs, "vq", NULL);
+    ok (vq != NULL && queue_parent (vq) == batch,
+        "vq's parent still points at the live batch queue");
+    ok (queue_root (vq) == batch, "vq's root still resolves to batch");
+
+    queues_destroy (qs);
+}
+
 /* A malformed entry inside the restore array (missing a required field)
  * fails with EINVAL. Covers the per-entry unpack error in restore_v1
  * and restore_v0.
@@ -1539,6 +1606,691 @@ static void test_list_encode (void)
     queues_destroy (qs);
 }
 
+/* ---------- virtual queue (RFC 33) tests -------------------------------- */
+
+static void test_vqueue_configure (void)
+{
+    struct queues *qs;
+    struct queue *batch;
+    struct queue *expedite;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* batch is a real queue, expedite is virtual with parent=batch.
+     * Pack expedite first in the object to exercise the "parent
+     * processed before the object it names" ordering case - jansson
+     * preserves insertion order, so this is deterministic.
+     */
+    config = json_pack ("{s:{s:s} s:{}}",
+                        "expedite",
+                          "parent", "batch",
+                        "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure with vqueue works (parent object added after child)");
+    json_decref (config);
+
+    batch = queues_lookup (qs, "batch", &error);
+    ok (batch != NULL, "batch found");
+    ok (!queue_is_virtual (batch), "batch is not virtual");
+    ok (queue_parent (batch) == NULL, "batch has no parent");
+    ok (queue_root (batch) == batch, "batch is its own root");
+
+    expedite = queues_lookup (qs, "expedite", &error);
+    ok (expedite != NULL, "expedite found");
+    ok (queue_is_virtual (expedite), "expedite is virtual");
+    ok (queue_parent (expedite) == batch, "expedite's parent is batch");
+    ok (queue_root (expedite) == batch, "expedite's root is batch");
+
+    /* Defense in depth: a config in which a queue names itself as parent
+     * is rejected by the second-pass parent resolution (conf_policy.c
+     * rejects this earlier in the normal broker path). */
+    config = json_pack ("{s:{s:s}}", "selfq", "parent", "selfq");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    errno = 0;
+    ok (queues_configure (qs, config, &error) < 0 && errno == EINVAL,
+        "configure with a self-parent queue fails with EINVAL");
+    json_decref (config);
+
+    queues_destroy (qs);
+}
+
+static void test_vqueue_reparent_on_reload (void)
+{
+    struct queues *qs;
+    struct queue *batch;
+    struct queue *debug;
+    struct queue *vq;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{} s:{} s:{s:s}}",
+                        "batch",
+                        "debug",
+                        "vq",
+                          "parent", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "initial configure: batch, debug, vq(parent=batch)");
+    json_decref (config);
+
+    batch = queues_lookup (qs, "batch", &error);
+    vq = queues_lookup (qs, "vq", &error);
+    ok (batch && vq && queue_parent (vq) == batch,
+        "vq initially parented to batch");
+
+    /* Reload: reparent vq to debug */
+    config = json_pack ("{s:{} s:{} s:{s:s}}",
+                        "batch",
+                        "debug",
+                        "vq",
+                          "parent", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "reload reparents vq to debug");
+    json_decref (config);
+
+    debug = queues_lookup (qs, "debug", &error);
+    vq = queues_lookup (qs, "vq", &error);
+    ok (vq != NULL, "vq still exists after reparent reload");
+    ok (queue_parent (vq) == debug, "vq is now parented to debug");
+    ok (queue_root (vq) == debug, "vq's root is now debug");
+
+    /* Reload again: vq loses its parent (becomes an ordinary queue) */
+    config = json_pack ("{s:{} s:{} s:{}}", "batch", "debug", "vq");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "reload removes vq's parent key");
+    json_decref (config);
+
+    vq = queues_lookup (qs, "vq", &error);
+    ok (vq != NULL, "vq still exists");
+    ok (!queue_is_virtual (vq), "vq is no longer virtual");
+    ok (queue_parent (vq) == NULL, "vq has no parent now");
+    ok (queue_root (vq) == vq, "vq is now its own root");
+
+    queues_destroy (qs);
+}
+
+static void test_vqueue_add_bad_parent (void)
+{
+    struct queues *qs;
+    struct queue *q;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    queues_set_notify (qs, notify_cb, NULL);
+
+    /* Missing parent. This would be the FIRST named queue: a failed
+     * add must leave the collection in anon mode (the add validates
+     * 'parent' before any state mutates), not stranded in named mode
+     * with an empty table and the anon queue destroyed.
+     */
+    notify_reset ();
+    errno = 0;
+    config = json_pack ("{s:s}", "parent", "nosuchqueue");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    q = queues_add (qs, "vq", config, &error);
+    json_decref (config);
+    ok (q == NULL && errno == EINVAL,
+        "queues_add with missing parent fails cleanly with EINVAL");
+    ok (queues_lookup (qs, "vq", NULL) == NULL,
+        "failed add leaves no half-added queue behind");
+    ok (!queues_have_named (qs)
+        && queues_lookup (qs, NULL, NULL) != NULL,
+        "failed first add leaves the anon queue in place");
+    ok (notify_count == 0, "failed add fires no notifications");
+
+    /* Add a real queue, then a vqueue-of-vqueue (parent is virtual) */
+    ok (queues_add (qs, "batch", NULL, &error) != NULL,
+        "add batch (real queue)");
+    config = json_pack ("{s:s}", "parent", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_add (qs, "expedite", config, &error) != NULL,
+        "add expedite (parent=batch) works");
+    json_decref (config);
+
+    notify_reset ();
+    errno = 0;
+    config = json_pack ("{s:s}", "parent", "expedite");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    q = queues_add (qs, "subq", config, &error);
+    json_decref (config);
+    ok (q == NULL && errno == EINVAL,
+        "queues_add with a virtual parent fails cleanly with EINVAL");
+    ok (queues_lookup (qs, "subq", NULL) == NULL,
+        "failed vqueue-of-vqueue add leaves no queue behind");
+    ok (notify_count == 0,
+        "failed vqueue-of-vqueue add fires no notifications");
+
+    /* A queue naming itself as parent is rejected (would otherwise
+     * leave q->parent == q, a queue that is its own parent). The
+     * standalone add path must catch this by name, since the queue
+     * being added is not in the table yet when 'parent' is validated.
+     */
+    errno = 0;
+    config = json_pack ("{s:s}", "parent", "selfq");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    q = queues_add (qs, "selfq", config, &error);
+    json_decref (config);
+    ok (q == NULL && errno == EINVAL,
+        "queues_add with self as parent fails cleanly with EINVAL");
+    ok (queues_lookup (qs, "selfq", NULL) == NULL,
+        "failed self-parent add leaves no queue behind");
+
+    /* queues_update with a bad parent fails cleanly BEFORE mutating:
+     * the queue's config-derived state is untouched and no "update"
+     * notification fires for the rejected change.
+     */
+    q = queues_lookup (qs, "batch", &error);
+    ok (q != NULL, "batch found for update test");
+    config = json_pack ("{s:[s]}", "requires", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_update (qs, q, config, &error) == 0,
+        "queues_update batch with requires works");
+    json_decref (config);
+    notify_reset ();
+    errno = 0;
+    config = json_pack ("{s:s}", "parent", "nosuchqueue");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_update (qs, q, config, &error) < 0 && errno == EINVAL,
+        "queues_update with missing parent fails cleanly with EINVAL");
+    json_decref (config);
+    ok (queue_requires (q) != NULL
+        && json_array_size (queue_requires (q)) == 1,
+        "failed update leaves the queue's requires untouched");
+    ok (notify_count == 0, "failed update fires no notifications");
+
+    /* queues_update making a queue its own parent is rejected too */
+    errno = 0;
+    config = json_pack ("{s:s}", "parent", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_update (qs, q, config, &error) < 0 && errno == EINVAL,
+        "queues_update with self as parent fails cleanly with EINVAL");
+    json_decref (config);
+
+    queues_destroy (qs);
+}
+
+/* queues_remove() of a queue that other queues name as their parent
+ * (RFC 33 virtual queues) must fail with EBUSY and an error naming the
+ * dependent virtual queues, else their ->parent pointers would dangle.
+ * queues_configure() is exempt: a reload may remove a parent and its
+ * virtual queues together.
+ */
+static void test_vqueue_remove_parent_busy (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{} s:{s:s} s:{s:s}}",
+                        "batch",
+                        "expedite",
+                          "parent", "batch",
+                        "background",
+                          "parent", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure batch with two vqueues works");
+    json_decref (config);
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (queues_remove (qs, "batch", &error) < 0 && errno == EBUSY,
+        "queues_remove of a parent with vqueues fails with EBUSY");
+    ok (strstr (error.text, "expedite") != NULL
+        && strstr (error.text, "background") != NULL,
+        "error message names the dependent virtual queues");
+    diag ("%s", error.text);
+    ok (queues_lookup (qs, "batch", NULL) != NULL,
+        "parent queue is still in the table");
+
+    /* Removing the virtual queues first unblocks the parent */
+    ok (queues_remove (qs, "expedite", &error) == 0,
+        "queues_remove expedite works");
+    errno = 0;
+    ok (queues_remove (qs, "batch", &error) < 0 && errno == EBUSY,
+        "parent removal still fails while one vqueue remains");
+    ok (queues_remove (qs, "background", &error) == 0,
+        "queues_remove background works");
+    ok (queues_remove (qs, "batch", &error) == 0,
+        "queues_remove batch works once no vqueues depend on it");
+
+    /* A whole-table reconfigure may drop a parent and its vqueues
+     * together (not subject to the EBUSY check)
+     */
+    config = json_pack ("{s:{} s:{s:s}}",
+                        "batch",
+                        "expedite",
+                          "parent", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "reconfigure batch + vqueue works");
+    json_decref (config);
+    config = json_pack ("{s:{}}", "debug");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "reconfigure removing parent and vqueue together works");
+    json_decref (config);
+    ok (queues_lookup (qs, "batch", NULL) == NULL
+        && queues_lookup (qs, "expedite", NULL) == NULL,
+        "parent and vqueue are both gone");
+
+    queues_destroy (qs);
+}
+
+/* queues_remove() of a parent with so many dependent virtual queues that
+ * the composed EBUSY message overflows flux_error_t.text (160 bytes) must
+ * still fail cleanly, and the error text must carry errprintf()'s '+'
+ * truncation marker in its final byte. queues_remove() builds the list of
+ * dependent vqueue names into a fixed 128-byte buffer, and errprintf()
+ * marks any message it had to truncate.
+ */
+static void test_vqueue_remove_parent_truncated (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* One real parent 'batch' plus many virtual queues parented to it.
+     * 50 four-character names comma-joined far exceeds queues_remove()'s
+     * 128-byte vqueue-name buffer, so the resulting message overruns the
+     * 160-byte error buffer and must be truncated.
+     */
+    if (!(config = json_object ()))
+        BAIL_OUT ("json_object failed");
+    if (json_object_set_new (config, "batch", json_object ()) < 0)
+        BAIL_OUT ("json_object_set_new failed");
+    for (int i = 0; i < 50; i++) {
+        char name[16];
+        snprintf (name, sizeof (name), "vq%02d", i);
+        if (json_object_set_new (config,
+                                 name,
+                                 json_pack ("{s:s}", "parent", "batch")) < 0)
+            BAIL_OUT ("json_object_set_new failed");
+    }
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure batch with 50 vqueues works");
+    json_decref (config);
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (queues_remove (qs, "batch", &error) < 0 && errno == EBUSY,
+        "queues_remove of a parent with many vqueues fails with EBUSY");
+    diag ("%s", error.text);
+    ok (strncmp (error.text, "queue 'batch' is the parent", 27) == 0,
+        "error message identifies the parent queue");
+    ok (strlen (error.text) == sizeof (error.text) - 1,
+        "error message fills the error buffer (was truncated)");
+    ok (error.text[sizeof (error.text) - 2] == '+',
+        "truncated error message ends with the '+' truncation marker");
+    ok (queues_lookup (qs, "batch", NULL) != NULL,
+        "parent queue is still in the table after the failed remove");
+
+    queues_destroy (qs);
+}
+
+static void test_vqueue_root_and_requires (void)
+{
+    struct queues *qs;
+    struct queue *batch;
+    struct queue *expedite;
+    flux_error_t error;
+    json_t *config;
+    json_t *req;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    req = json_pack ("[s]", "batch");
+    if (!req)
+        BAIL_OUT ("json_pack failed");
+    config = json_pack ("{s:{s:O} s:{s:s}}",
+                        "batch",
+                          "requires", req,
+                        "expedite",
+                          "parent", "batch");
+    json_decref (req);
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure batch (requires) + expedite (parent=batch)");
+    json_decref (config);
+
+    batch = queues_lookup (qs, "batch", &error);
+    expedite = queues_lookup (qs, "expedite", &error);
+    ok (batch && expedite, "both queues found");
+
+    ok (queue_requires (expedite) != NULL
+        && json_array_size (queue_requires (expedite)) == 1,
+        "vqueue's effective requires is the parent's");
+    ok (queue_requires (expedite) == queue_requires (batch),
+        "vqueue's effective requires is the same object as the parent's");
+    ok (queue_requires (batch) != NULL
+        && json_array_size (queue_requires (batch)) == 1,
+        "non-virtual queue's effective requires is its own");
+
+    queues_destroy (qs);
+}
+
+/* Effective-started 4-state matrix: parent x vqueue, started x stopped. */
+static void test_vqueue_effective_started (void)
+{
+    struct queues *qs;
+    struct queue *batch;
+    struct queue *vq;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{} s:{s:s}}",
+                        "batch",
+                        "vq",
+                          "parent", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0, "configure batch+vq");
+    json_decref (config);
+
+    batch = queues_lookup (qs, "batch", &error);
+    vq = queues_lookup (qs, "vq", &error);
+    ok (batch && vq, "both queues found");
+
+    /* Named queues start stopped: (parent stopped, vq stopped) */
+    ok (!queue_is_started (batch) && !queue_is_started (vq),
+        "initial: both own bits stopped");
+    ok (!queue_is_started_effective (vq),
+        "stopped+stopped: effective started is false");
+
+    /* parent started, vq stopped: vq must NOT be effectively started */
+    queue_start (batch, false);
+    ok (queue_is_started (batch) && !queue_is_started (vq),
+        "parent started, vq still stopped (own bits)");
+    ok (!queue_is_started_effective (vq),
+        "started(parent)+stopped(vq): effective started is false");
+    ok (queue_is_started_effective (batch),
+        "parent's own effective started is true (root == self)");
+
+    /* parent stopped, vq started: vq must NOT be effectively started
+     * (starting a vqueue under a stopped parent has no effect until
+     * the parent starts)
+     */
+    queue_stop (batch, NULL, false);
+    queue_start (vq, false);
+    ok (!queue_is_started (batch) && queue_is_started (vq),
+        "parent stopped, vq started (own bits)");
+    ok (!queue_is_started_effective (vq),
+        "stopped(parent)+started(vq): effective started is false");
+
+    /* both started: vq is now effectively started */
+    queue_start (batch, false);
+    ok (queue_is_started (batch) && queue_is_started (vq),
+        "both started (own bits)");
+    ok (queue_is_started_effective (vq),
+        "started+started: effective started is true");
+
+    queues_destroy (qs);
+}
+
+/* Status encode matrix for a vqueue: all 4 (parent x vqueue) started
+ * states, checking start/blocked/parent/stop_reason keys with a strict
+ * unpack. Also confirms a non-virtual queue's payload is unaffected
+ * (byte identical key set to pre-vqueue behavior) and that scheduler
+ * offline on a started queue reports blocked.
+ */
+static void test_vqueue_status_encode (void)
+{
+    struct queues *qs;
+    struct queue *batch;
+    struct queue *vq;
+    flux_error_t error;
+    json_t *config;
+    json_t *o;
+    int enable, start;
+    const char *blocked;
+    const char *parent;
+    const char *reason;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{} s:{s:s}}",
+                        "batch",
+                        "vq",
+                          "parent", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0, "configure batch+vq");
+    json_decref (config);
+
+    batch = queues_lookup (qs, "batch", &error);
+    vq = queues_lookup (qs, "vq", &error);
+    ok (batch && vq, "both queues found");
+
+    /* State 1: parent stopped, vq stopped - no blocked key */
+    o = queue_status_encode (vq, true);
+    ok (o != NULL, "status_encode works (stopped/stopped)");
+    ok (json_unpack (o,
+                     "{s:b s:b s:s !}",
+                     "enable", &enable,
+                     "start", &start,
+                     "parent", &parent) == 0
+        && !start
+        && streq (parent, "batch"),
+        "stopped/stopped: start=false, no blocked key, parent=batch");
+    json_decref (o);
+
+    /* State 2: parent started, vq stopped - still not blocked (own
+     * bit is the cause) */
+    queue_start (batch, false);
+    o = queue_status_encode (vq, true);
+    ok (o
+        && json_unpack (o,
+                        "{s:b s:b s:s !}",
+                        "enable", &enable,
+                        "start", &start,
+                        "parent", &parent) == 0
+        && !start,
+        "started(parent)/stopped(vq): start=false, no blocked key");
+    json_decref (o);
+
+    /* State 3: parent stopped, vq started - blocked "parent", synthesized
+     * reason names the parent */
+    queue_stop (batch, NULL, false);
+    queue_start (vq, false);
+    o = queue_status_encode (vq, true);
+    ok (o
+        && json_unpack (o,
+                        "{s:b s:b s:s s:s s:s !}",
+                        "enable", &enable,
+                        "start", &start,
+                        "parent", &parent,
+                        "blocked", &blocked,
+                        "stop_reason", &reason) == 0
+        && !start
+        && streq (blocked, "parent")
+        && streq (reason, "parent queue 'batch' is stopped"),
+        "stopped(parent)/started(vq): start=false blocked=parent with"
+        " synthesized stop_reason");
+    json_decref (o);
+
+    /* State 4: both started - no blocked key */
+    queue_start (batch, false);
+    o = queue_status_encode (vq, true);
+    ok (o
+        && json_unpack (o,
+                        "{s:b s:b s:s !}",
+                        "enable", &enable,
+                        "start", &start,
+                        "parent", &parent) == 0
+        && start,
+        "started/started: start=true, no blocked key");
+    json_decref (o);
+
+    /* Non-virtual queue payload: unaffected, no parent/blocked keys */
+    o = queue_status_encode (batch, true);
+    ok (o
+        && json_unpack (o,
+                        "{s:b s:b !}",
+                        "enable", &enable,
+                        "start", &start) == 0,
+        "non-virtual queue payload has exactly {enable,start} (no"
+        " parent/blocked keys) - unchanged from pre-vqueue behavior");
+    json_decref (o);
+
+    /* Scheduler offline on a started queue: blocked "scheduler" with
+     * synthesized reason (own state untouched) */
+    o = queue_status_encode (batch, false);
+    ok (o
+        && json_unpack (o,
+                        "{s:b s:b s:s s:s !}",
+                        "enable", &enable,
+                        "start", &start,
+                        "blocked", &blocked,
+                        "stop_reason", &reason) == 0
+        && !start
+        && streq (blocked, "scheduler")
+        && streq (reason, "Scheduler is offline"),
+        "sched offline on started queue: start=false blocked=scheduler");
+    ok (queue_is_started (batch),
+        "sched offline does not modify queue state");
+    json_decref (o);
+
+    /* Scheduler offline on a started vqueue (parent started): blocked is
+     * "scheduler", not "parent" - the offline condition takes precedence
+     * even though the queue is virtual. */
+    o = queue_status_encode (vq, false);
+    ok (o
+        && json_unpack (o,
+                        "{s:b s:b s:s s:s s:s !}",
+                        "enable", &enable,
+                        "start", &start,
+                        "parent", &parent,
+                        "blocked", &blocked,
+                        "stop_reason", &reason) == 0
+        && !start
+        && streq (parent, "batch")
+        && streq (blocked, "scheduler")
+        && streq (reason, "Scheduler is offline"),
+        "sched offline on started vqueue: blocked=scheduler not parent");
+    json_decref (o);
+
+    /* Scheduler offline on a stopped queue: not blocked */
+    queue_stop (batch, NULL, false);
+    o = queue_status_encode (batch, false);
+    ok (o
+        && json_unpack (o,
+                        "{s:b s:b s:s !}",
+                        "enable", &enable,
+                        "start", &start,
+                        "stop_reason", &reason) == 0
+        && !start
+        && streq (reason, "Scheduler is offline"),
+        "sched offline on stopped queue: no blocked key");
+    json_decref (o);
+
+    queues_destroy (qs);
+}
+
+/* Notify events for vqueues behave like ordinary queues: add/update on
+ * a vqueue fires the same event names, independent of parent linkage.
+ */
+static void test_vqueue_notify (void)
+{
+    struct queues *qs;
+    struct queue *vq;
+    flux_error_t error;
+    json_t *config;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+    queues_set_notify (qs, notify_cb, NULL);
+    notify_reset ();
+
+    config = json_pack ("{s:{} s:{s:s}}",
+                        "batch",
+                        "vq",
+                          "parent", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    ok (queues_configure (qs, config, &error) == 0,
+        "configure batch+vq fires notify events");
+    json_decref (config);
+
+    bool saw_vq_add = false;
+    for (int i = 0; i < notify_count; i++) {
+        if (streq (notify_log[i].name, "vq")
+            && streq (notify_log[i].event, "add"))
+            saw_vq_add = true;
+    }
+    ok (saw_vq_add, "vq add event fired same as an ordinary queue");
+
+    vq = queues_lookup (qs, "vq", &error);
+    ok (vq != NULL, "vq found");
+
+    notify_reset ();
+    ok (queue_start (vq, false) == 0, "start vq");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "start"),
+        "vq start event fired same as an ordinary queue");
+
+    notify_reset ();
+    ok (queue_stop (vq, "down", false) == 0, "stop vq");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "stop"),
+        "vq stop event fired same as an ordinary queue");
+
+    notify_reset ();
+    ok (queue_disable (vq, "maint") == 0, "disable vq");
+    ok (notify_count == 1
+        && streq (notify_log[0].event, "disable"),
+        "vq disable event fired same as an ordinary queue");
+
+    queues_destroy (qs);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -1565,12 +2317,23 @@ int main (int argc, char *argv[])
     test_add_invalid_config ();
     test_update_invalid_config ();
     test_configure_partial_failure ();
+    test_configure_bad_parent_transactional ();
     test_restore_bad_entry ();
     test_admin_ops ();
     test_admin_ops_reenter ();
     test_list_names ();
     test_status_encode ();
     test_list_encode ();
+
+    test_vqueue_configure ();
+    test_vqueue_reparent_on_reload ();
+    test_vqueue_add_bad_parent ();
+    test_vqueue_remove_parent_busy ();
+    test_vqueue_remove_parent_truncated ();
+    test_vqueue_root_and_requires ();
+    test_vqueue_effective_started ();
+    test_vqueue_status_encode ();
+    test_vqueue_notify ();
 
     done_testing ();
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -361,6 +361,7 @@ TESTSCRIPTS = \
 	python/t0045-job-shape-parser.py \
 	python/t0046-job-watcher.py \
 	python/t0047-flux-argument-parser.py \
+	python/t0048-frobnicator-vqueue.py \
 	python/t0100-modprobe.py \
 	python/t1000-service-add-remove.py \
 	python/t6010-fake-resources.py

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -171,6 +171,7 @@ TESTSCRIPTS = \
 	t2240-queue-cmd.t \
 	t2241-queue-cmd-list.t \
 	t2245-policy-config.t \
+	t2246-queue-virtual.t \
 	t2260-job-list.t \
 	t2261-job-list-update.t \
 	t2262-job-list-stats.t \

--- a/t/python/t0034-queuelist.py
+++ b/t/python/t0034-queuelist.py
@@ -18,7 +18,8 @@ except ModuleNotFoundError:
     from flux.utils import tomli as tomllib
 
 import flux
-from flux.queue import QueueList
+from flux.queue import QueueInfo, QueueList
+from flux.resource import resource_list
 from subflux import rerun_under_flux
 
 
@@ -100,6 +101,44 @@ class TestQueueList(unittest.TestCase):
         self.assertFalse(qlist.debug.started)
         self.assertEqual(qlist.debug.limits.duration, 3600.0)
         self.assertEqual(qlist.debug.limits.timelimit, 3600.0)
+
+    def test_003_vqueue_stale_parent(self):
+        # A QueueInfo parent (sourced from the queue-status RPC) missing
+        # from the config (a separate RPC, so a config reload can race
+        # the two) must raise, not fall back to the full instance
+        # resource set or drop the parent's limits layer.
+        resources = resource_list(self.fh).get()
+        config = {
+            "queues": {
+                "batch": {"requires": ["batch"]},
+            }
+        }
+        with self.assertRaises(ValueError) as ctx:
+            QueueInfo(
+                "expedite",
+                config,
+                resources,
+                enabled=True,
+                started=True,
+                default=False,
+                parent="gone",
+            )
+        self.assertIn("parent queue 'gone' is not configured", str(ctx.exception))
+
+        # The limits/defaults lookup path fails the same way even when
+        # constructed with a then-valid parent that a raced config lost:
+        qinfo = QueueInfo(
+            "expedite",
+            config,
+            resources,
+            enabled=True,
+            started=True,
+            default=False,
+            parent="batch",
+        )
+        qinfo.config = {"queues": {}}
+        with self.assertRaises(ValueError):
+            list(qinfo._config_entries())
 
 
 if __name__ == "__main__":

--- a/t/python/t0048-frobnicator-vqueue.py
+++ b/t/python/t0048-frobnicator-vqueue.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+
+import subflux  # noqa: F401 - To set up PYTHONPATH
+from flux.job.frobnicator.plugins.constraints import QueueConfig
+from flux.job.frobnicator.plugins.defaults import DefaultsConfig
+from pycotap import TAPTestRunner
+
+
+def defaults_config(system):
+    return {"policy": {"jobspec": {"defaults": {"system": system}}}}
+
+
+class TestConstraintsVQueue(unittest.TestCase):
+    """RFC 33 virtual queue constraint inheritance in the frobnicator."""
+
+    def test_vqueue_inherits_parent_requires(self):
+        qc = QueueConfig(
+            {
+                "queues": {
+                    "batch": {"requires": ["batch"]},
+                    "expedite": {"parent": "batch"},
+                }
+            }
+        )
+        # The vqueue's effective properties are the parent's.
+        self.assertEqual(qc.queue_properties("expedite"), ["batch"])
+        self.assertEqual(qc.queue_properties("expedite"), qc.queue_properties("batch"))
+
+    def test_nonvirtual_queue_uses_own_requires(self):
+        qc = QueueConfig({"queues": {"batch": {"requires": ["batch"]}}})
+        self.assertEqual(qc.queue_properties("batch"), ["batch"])
+
+    def test_unknown_queue_returns_none(self):
+        qc = QueueConfig({"queues": {"batch": {"requires": ["batch"]}}})
+        self.assertIsNone(qc.queue_properties("nosuchqueue"))
+
+    def test_vqueue_missing_parent_fails_closed(self):
+        # A vqueue whose parent is not configured must raise, not
+        # silently drop the parent's constraint (which would place the
+        # job outside the parent's resource slice).
+        qc = QueueConfig({"queues": {"expedite": {"parent": "nosuchqueue"}}})
+        with self.assertRaises(ValueError):
+            qc.queue_properties("expedite")
+
+
+class TestDefaultsVQueue(unittest.TestCase):
+    """RFC 33 virtual queue defaults inheritance in the frobnicator."""
+
+    def test_vqueue_inherits_parent_defaults(self):
+        dc = DefaultsConfig(
+            {
+                "queues": {
+                    "batch": defaults_config({"duration": "1h"}),
+                    "expedite": {"parent": "batch"},
+                }
+            }
+        )
+        self.assertEqual(dc.queue_defaults("expedite"), {"duration": "1h"})
+
+    def test_vqueue_own_defaults_override_parent(self):
+        expedite = defaults_config({"duration": "5m"})
+        expedite["parent"] = "batch"
+        dc = DefaultsConfig(
+            {
+                "queues": {
+                    "batch": defaults_config({"duration": "1h", "queue": "batch"}),
+                    "expedite": expedite,
+                }
+            }
+        )
+        # Own duration overrides the parent's; the parent's other keys
+        # are still inherited beneath.
+        eff = dc.queue_defaults("expedite")
+        self.assertEqual(eff["duration"], "5m")
+        self.assertEqual(eff["queue"], "batch")
+
+    def test_vqueue_missing_parent_fails_closed(self):
+        # DefaultsConfig validates every queue at construction, so a
+        # vqueue with an unconfigured parent must raise there.
+        with self.assertRaises(ValueError):
+            DefaultsConfig({"queues": {"expedite": {"parent": "nosuchqueue"}}})
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -193,6 +193,10 @@ test_expect_success 'flux-queue: queue says scheduling stopped' '
 	EOT
 	test_cmp sched_stat.exp sched_stat.out
 '
+test_expect_success 'flux-queue: scheduler offline lists as plain stopped' '
+	test "$(flux queue list -no {scheduling})" = "stopped" &&
+	test "$(flux queue list -no {started.ascii})" = "n"
+'
 
 test_expect_success 'flux-queue: queue contains 1 active job' '
 	COUNT=$(${LIST_JOBS} | wc -l) &&

--- a/t/t2241-queue-cmd-list.t
+++ b/t/t2241-queue-cmd-list.t
@@ -18,6 +18,10 @@ test_expect_success 'flux-queue: default lists expected fields' '
 	grep NGPUS default.out
 '
 
+test_expect_success 'flux-queue: PARENT column is hidden with no vqueues configured' '
+	test_must_fail grep PARENT default.out
+'
+
 test_expect_success 'flux-queue: FLUX_QUEUE_LIST_FORMAT_DEFAULT works' '
 	FLUX_QUEUE_LIST_FORMAT_DEFAULT="{limits.min.nnodes} {limits.max.ngpus}" \
 		flux queue list > default_override.out &&

--- a/t/t2246-queue-virtual.t
+++ b/t/t2246-queue-virtual.t
@@ -30,6 +30,29 @@ test_expect_success 'config queues, resources, and a vqueue' '
 	flux resource list -o rlist
 '
 
+test_expect_success 'flux queue list shows PARENT column when a vqueue is configured' '
+	flux queue list >list.out &&
+	head -1 list.out | grep PARENT &&
+	test "$(flux queue list -q expedite -no "{parent}")" = "batch" &&
+	test "$(flux queue list -q batch -no "{parent}")" = "" &&
+	test "$(flux queue list -q debug -no "{parent}")" = ""
+'
+
+test_expect_success 'flux resource list does not show vqueue in QUEUE column' '
+	flux resource list >rlist-noqueue.out &&
+	test_must_fail grep expedite rlist-noqueue.out
+'
+
+test_expect_success 'flux resource list -q vqueue selects the parent ranks' '
+	flux resource list -no "{ranks}" -q expedite >vq-ranks.out &&
+	flux resource list -no "{ranks}" -q batch >pq-ranks.out &&
+	test_cmp pq-ranks.out vq-ranks.out
+'
+
+test_expect_success 'flux resource list -q vqueue shows vqueue in QUEUE column' '
+	test "$(flux resource list -s up -no "{queue}" -q expedite)" = "expedite"
+'
+
 test_expect_success 'invalid config: vqueue parent missing is rejected' '
 	test_must_fail flux config load 2>orphan.err <<-EOT &&
 	[queues.batch]
@@ -195,6 +218,41 @@ test_expect_success 'flux queue status shows vqueue blocked by stopped parent' '
 	grep "Scheduling is stopped: parent queue .batch. is stopped" \
 	  vqstatus2.out &&
 	flux queue start --all
+'
+
+test_expect_success 'flux queue list shows three-state SCHED/ST for a blocked vqueue' '
+	flux queue stop batch &&
+	flux queue start expedite &&
+	test "$(flux queue list -q expedite -no "{scheduling}")" \
+	  = "stopped (parent)" &&
+	test "$(flux queue list -q expedite -no "{started.ascii}")" = "p" &&
+	test "$(flux queue list -q batch -no "{scheduling}")" = "stopped" &&
+	test "$(flux queue list -q batch -no "{started.ascii}")" = "n" &&
+	flux queue start --all &&
+	test "$(flux queue list -q expedite -no "{scheduling}")" = "started" &&
+	test "$(flux queue list -q expedite -no "{started.ascii}")" = "y"
+'
+
+test_expect_success 'flux queue list renders the paused glyph in yellow' '
+	flux queue stop batch &&
+	flux queue start expedite &&
+	test "$(flux queue list -q expedite -no "{color_started}")" \
+	  = "$(printf "\033[01;33m")" &&
+	test "$(flux queue list -q batch -no "{color_started}")" \
+	  = "$(printf "\033[01;31m")" &&
+	flux queue start --all &&
+	test "$(flux queue list -q expedite -no "{color_started}")" \
+	  = "$(printf "\033[01;32m")"
+'
+
+test_expect_success 'scheduler offline renders vqueue as stopped, not paused' '
+	flux queue start --all &&
+	flux module remove sched-simple &&
+	test_when_finished "flux module load sched-simple && flux queue start --all" &&
+	test "$(flux queue list -q expedite -no "{scheduling}")" = "stopped" &&
+	test "$(flux queue list -q expedite -no "{started.ascii}")" = "n" &&
+	test "$(flux queue list -q expedite -no "{color_started}")" \
+	  = "$(printf "\033[01;31m")"
 '
 
 test_expect_success 'flux job update into vqueue picks up parent constraint' '

--- a/t/t2246-queue-virtual.t
+++ b/t/t2246-queue-virtual.t
@@ -342,4 +342,113 @@ test_expect_success 'config reload updating parent limit is picked up' '
 	  expedite-reload.err
 '
 
+test_expect_success 'job-list: submit jobs to parent and vqueue for listing tests' '
+	flux config load <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+
+	[queues.expedite]
+	parent = "batch"
+
+	[queues.debug]
+	requires = [ "debug" ]
+
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+	flux queue start --all &&
+	flux bulksubmit -q {} --urgency=hold hostname \
+	  ::: batch expedite >joblist-parent.ids &&
+	sed -n 1p joblist-parent.ids >joblist-parent.jobid &&
+	sed -n 2p joblist-parent.ids >joblist-vqueue.jobid
+'
+
+test_expect_success 'job-list: flux jobs -q parent includes vqueue jobs' '
+	flux jobs -no {id} -q batch | sort >joblist-parent.out &&
+	sort joblist-parent.ids >joblist-parent.exp &&
+	test_cmp joblist-parent.exp joblist-parent.out
+'
+
+test_expect_success 'job-list: flux jobs -q vqueue lists only vqueue job' '
+	flux jobs -no {id} -q expedite >joblist-vqueue.out &&
+	test_cmp joblist-vqueue.jobid joblist-vqueue.out
+'
+
+test_expect_success 'job-list: RPC queue constraint on parent includes vqueue job' '
+	id=$(id -u) &&
+	constraint="{ and: [ {userid:[${id}]}, {states:[\"active\"]}, \
+	  {queue:[\"batch\"]}] }" &&
+	jq -j -c -n "{max_entries:1000, attrs:[], constraint:${constraint}}" \
+	  | ${FLUX_BUILD_DIR}/t/request/rpc_stream job-list.list \
+	  | jq .jobs[].id | flux job id -t f58 | sort >joblist-rpc-parent.out &&
+	sort joblist-parent.ids >joblist-rpc-parent.exp &&
+	test_cmp joblist-rpc-parent.exp joblist-rpc-parent.out
+'
+
+test_expect_success 'job-list: RPC queue constraint on vqueue is exact' '
+	id=$(id -u) &&
+	constraint="{ and: [ {userid:[${id}]}, {states:[\"active\"]}, \
+	  {queue:[\"expedite\"]}] }" &&
+	jq -j -c -n "{max_entries:1000, attrs:[], constraint:${constraint}}" \
+	  | ${FLUX_BUILD_DIR}/t/request/rpc_stream job-list.list \
+	  | jq .jobs[].id | flux job id -t f58 >joblist-rpc-vqueue.out &&
+	test_cmp joblist-vqueue.jobid joblist-rpc-vqueue.out
+'
+
+test_expect_success 'cleanup vqueue job listing jobs' '
+	flux cancel $(cat joblist-parent.jobid) &&
+	flux cancel $(cat joblist-vqueue.jobid) &&
+	flux job wait-event $(cat joblist-parent.jobid) clean &&
+	flux job wait-event $(cat joblist-vqueue.jobid) clean
+'
+
+test_expect_success 'configure two virtual queues sharing a parent' '
+	flux config load <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+
+	[queues.expedite]
+	parent = "batch"
+
+	[queues.standby]
+	parent = "batch"
+
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+	flux queue enable --all &&
+	flux queue start --all
+'
+
+test_expect_success 'stopping one vqueue leaves its sibling and parent started' '
+	flux queue stop expedite &&
+	test "$(flux queue list -q expedite -no "{started.ascii}")" = "n" &&
+	test "$(flux queue list -q standby -no "{started.ascii}")" = "y" &&
+	test "$(flux queue list -q batch -no "{started.ascii}")" = "y"
+'
+
+test_expect_success 'starting one vqueue leaves its sibling stopped' '
+	flux queue stop --all &&
+	flux queue start expedite &&
+	test "$(flux queue list -q expedite -no "{started.ascii}")" = "p" &&
+	test "$(flux queue list -q standby -no "{started.ascii}")" = "n" &&
+	test "$(flux queue list -q batch -no "{started.ascii}")" = "n"
+'
+
+test_expect_success 'starting the parent releases only the started sibling' '
+	flux queue start batch &&
+	test "$(flux queue list -q expedite -no "{started.ascii}")" = "y" &&
+	test "$(flux queue list -q standby -no "{started.ascii}")" = "n" &&
+	test "$(flux queue list -q batch -no "{started.ascii}")" = "y"
+'
+
+test_expect_success 'disabling one vqueue leaves its sibling and parent enabled' '
+	flux queue enable --all &&
+	flux queue disable -m test expedite &&
+	test "$(flux queue list -q expedite -no "{enabled.ascii}")" = "n" &&
+	test "$(flux queue list -q standby -no "{enabled.ascii}")" = "y" &&
+	test "$(flux queue list -q batch -no "{enabled.ascii}")" = "y" &&
+	flux queue enable --all
+'
+
 test_done

--- a/t/t2246-queue-virtual.t
+++ b/t/t2246-queue-virtual.t
@@ -1,0 +1,212 @@
+#!/bin/sh
+test_description='Test RFC 33 virtual queues (vqueues)'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 full -Slog-stderr-level=1
+
+test_expect_success 'config queues, resources, and a vqueue' '
+	flux R encode -r 0-3 -p batch:0-2 -p debug:3 \
+	   | flux kvs put -r resource.R=- &&
+	flux config load <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+
+	[queues.expedite]
+	parent = "batch"
+	policy.jobspec.defaults.system.duration = "5m"
+
+	[queues.debug]
+	requires = [ "debug" ]
+
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+	flux queue start --all &&
+	flux module unload sched-simple &&
+	flux module reload resource &&
+	flux module load sched-simple &&
+	flux queue list &&
+	flux resource list -o rlist
+'
+
+test_expect_success 'invalid config: vqueue parent missing is rejected' '
+	test_must_fail flux config load 2>orphan.err <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.orphan]
+	parent = "nosuchqueue"
+	EOT
+	grep "parent queue .nosuchqueue. is not configured" orphan.err
+'
+
+test_expect_success 'invalid config: vqueue parent is the queue itself' '
+	test_must_fail flux config load 2>selfparent.err <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.selfq]
+	parent = "selfq"
+	EOT
+	grep "parent queue is itself" selfparent.err
+'
+
+test_expect_success 'invalid config: vqueue parent is itself virtual' '
+	test_must_fail flux config load 2>subexpedite.err <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.expedite]
+	parent = "batch"
+	[queues.subexpedite]
+	parent = "expedite"
+	EOT
+	grep "parent queue .expedite. is itself a virtual queue" subexpedite.err
+'
+
+test_expect_success 'invalid config: vqueue with requires is rejected' '
+	test_must_fail flux config load 2>requires.err <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.expedite]
+	parent = "batch"
+	requires = [ "expedite" ]
+	EOT
+	grep "a virtual queue must not set .requires." requires.err
+'
+
+test_expect_success 'invalid config: vqueue with policy.scheduler is rejected' '
+	test_must_fail flux config load 2>scheduler.err <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.expedite]
+	parent = "batch"
+	policy.scheduler.foo = 1
+	EOT
+	grep "a virtual queue must not set .policy.scheduler." scheduler.err
+'
+
+test_expect_success 'invalid config: vqueue parent is not a string is rejected' '
+	test_must_fail flux config load 2>parenttype.err <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.expedite]
+	parent = 42
+	EOT
+	grep -i "expected string" parenttype.err
+'
+
+test_expect_success 'invalid vqueue config fails the instance at startup' '
+	cat >startup-badvq.toml <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.orphan]
+	parent = "nosuchqueue"
+	EOT
+	test_must_fail flux start --config-path=startup-badvq.toml \
+	  true 2>startup-badvq.err &&
+	grep "parent queue .nosuchqueue. is not configured" startup-badvq.err
+'
+
+test_expect_success 'valid config: vqueue as default queue is accepted' '
+	flux config load <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.expedite]
+	parent = "batch"
+	[policy.jobspec.defaults.system]
+	queue = "expedite"
+	EOT
+	flux config load <<-EOT
+	[queues.batch]
+	requires = [ "batch" ]
+
+	[queues.expedite]
+	parent = "batch"
+	policy.jobspec.defaults.system.duration = "5m"
+
+	[queues.debug]
+	requires = [ "debug" ]
+
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+'
+
+test_expect_success 'submit to vqueue succeeds and job keeps vqueue name' '
+	jobid=$(flux submit -q expedite --urgency=hold hostname) &&
+	echo $jobid >expedite.jobid &&
+	test "$(flux jobs -no {queue} $jobid)" = "expedite"
+'
+
+test_expect_success 'vqueue job jobspec carries parent property constraint' '
+	jobid=$(cat expedite.jobid) &&
+	flux job info $jobid jobspec | jq -e \
+	  ".attributes.system.constraints.properties == [\"batch\"]"
+'
+
+test_expect_success 'cleanup held vqueue job' '
+	flux cancel $(cat expedite.jobid) &&
+	flux job wait-event $(cat expedite.jobid) clean
+'
+
+test_expect_success 'AND rule: parent stopped + vqueue started holds the job' '
+	flux queue stop batch &&
+	flux queue start expedite &&
+	jobid=$(flux submit -q expedite --wait-event=priority hostname) &&
+	echo $jobid >and-rule.jobid &&
+	flux queue status -v >and-rule.out &&
+	grep "^0 alloc requests queued" and-rule.out &&
+	grep "^0 alloc requests pending to scheduler" and-rule.out
+'
+
+test_expect_success 'starting the parent releases the vqueue job' '
+	jobid=$(cat and-rule.jobid) &&
+	flux queue start batch &&
+	flux job wait-event -t 20 $jobid clean
+'
+
+test_expect_success 'vqueue holds new jobs while parent jobs still run' '
+	flux queue start --all &&
+	flux queue stop expedite &&
+	vqid=$(flux submit -q expedite --wait-event=priority hostname) &&
+	pqid=$(flux submit -q batch hostname) &&
+	echo $vqid >held.jobid &&
+	flux job wait-event -t 20 $pqid clean &&
+	flux queue status -v >held.out &&
+	grep "^0 alloc requests queued" held.out &&
+	grep "^0 alloc requests pending to scheduler" held.out
+'
+
+test_expect_success 'starting the vqueue releases its held job' '
+	flux queue start expedite &&
+	flux job wait-event -t 20 $(cat held.jobid) clean
+'
+
+test_expect_success 'flux queue status shows expected output for the vqueue' '
+	flux queue start --all &&
+	flux queue status expedite >vqstatus.out &&
+	grep "submission is enabled" vqstatus.out &&
+	grep "Scheduling is started" vqstatus.out
+'
+
+test_expect_success 'flux queue status shows vqueue blocked by stopped parent' '
+	flux queue stop batch &&
+	flux queue start expedite &&
+	flux queue status expedite >vqstatus2.out &&
+	grep "Scheduling is stopped: parent queue .batch. is stopped" \
+	  vqstatus2.out &&
+	flux queue start --all
+'
+
+test_expect_success 'flux job update into vqueue picks up parent constraint' '
+	jobid=$(flux submit --urgency=hold -q debug hostname) &&
+	flux job info $jobid jobspec | jq -e \
+	  ".attributes.system.constraints.properties == [\"debug\"]" &&
+	flux update --wait $jobid queue=expedite &&
+	flux job info $jobid jobspec | jq -e \
+	  ".attributes.system.constraints.properties == [\"batch\"]" &&
+	test "$(flux jobs -no {queue} $jobid)" = "expedite" &&
+	flux cancel $jobid &&
+	flux job wait-event $jobid clean
+'
+
+test_done

--- a/t/t2246-queue-virtual.t
+++ b/t/t2246-queue-virtual.t
@@ -209,4 +209,79 @@ test_expect_success 'flux job update into vqueue picks up parent constraint' '
 	flux job wait-event $jobid clean
 '
 
+test_expect_success 'configure parent duration and job-size limits' '
+	flux config load <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	policy.limits.duration = "1h"
+	policy.limits.job-size.max.nnodes = 2
+
+	[queues.expedite]
+	parent = "batch"
+	policy.limits.duration = "30m"
+
+	[queues.debug]
+	requires = [ "debug" ]
+
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+	flux queue start --all
+'
+
+test_expect_success 'vqueue duration override rejects jobs over its own limit' '
+	test_must_fail flux submit -q expedite -t 45m hostname \
+	  2>expedite-duration.err &&
+	grep "duration (45m) exceeds.*limit of 30m for queue expedite" \
+	  expedite-duration.err
+'
+
+test_expect_success 'vqueue inherits parent job-size limit' '
+	test_must_fail flux submit -q expedite -N 3 hostname \
+	  2>expedite-jobsize.err &&
+	grep "exceeds policy limit of 2 for queue expedite" \
+	  expedite-jobsize.err
+'
+
+test_expect_success 'vqueue job within both inherited and own limits passes' '
+	flux submit -q expedite -N 2 -t 20m hostname
+'
+
+test_expect_success 'parent queue job still honors parent duration limit' '
+	test_must_fail flux submit -q batch -t 2h hostname \
+	  2>batch-duration.err &&
+	grep "duration (2h) exceeds.*limit of 1h for queue batch" \
+	  batch-duration.err
+'
+
+test_expect_success 'parent queue job still honors parent job-size limit' '
+	test_must_fail flux submit -q batch -N 3 hostname \
+	  2>batch-jobsize.err &&
+	grep "exceeds policy limit of 2 for queue batch" \
+	  batch-jobsize.err
+'
+
+test_expect_success 'config reload updating parent limit is picked up' '
+	flux config load <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	policy.limits.duration = "1h"
+	policy.limits.job-size.max.nnodes = 1
+
+	[queues.expedite]
+	parent = "batch"
+	policy.limits.duration = "30m"
+
+	[queues.debug]
+	requires = [ "debug" ]
+
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+	test_must_fail flux submit -q expedite -N 2 hostname \
+	  2>expedite-reload.err &&
+	grep "exceeds policy limit of 1 for queue expedite" \
+	  expedite-reload.err
+'
+
 test_done

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -188,6 +188,23 @@ test_expect_success 'flux-resource -q, --queue reports invalid queue' '
 		< $FLUKE_INPUT 2>badqueue.err &&
 	grep "foo: no such queue" badqueue.err
 '
+# Defense in depth: a live instance rejects this config up front, but
+# --config-file input is not validated, and a virtual queue with an
+# unresolvable parent must not fall through to matching every node.
+test_expect_success 'flux-resource -q reports vqueue with unconfigured parent' '
+	cat >dangling.config <<-EOT &&
+	{
+	  "queues": {
+	    "batch": { "requires": [ "batch" ] },
+	    "expedite": { "parent": "notaqueue" }
+	  }
+	}
+	EOT
+	test_must_fail flux resource list --queue=expedite \
+		--from-stdin --config-file=dangling.config \
+		< $FLUKE_INPUT 2>dangling.err &&
+	grep "parent queue .notaqueue. is not configured" dangling.err
+'
 test_expect_success 'flux-resource list supports --include' '
 	flux resource list -s all -ni 0 --no-skip-empty >list-include.output &&
 	test_debug "cat list-include.output" &&


### PR DESCRIPTION
This adds support for RFC 33 virtual queues per the plan in #7738.

A virtual queue is an alternate submission name for another queue's resources with different policy. It is declared by setting `parent` in a `[queues]` entry, inherits the parent's policy per key (each key the virtual queue sets overrides just that key), and has its own enable/disable and start/stop administrative state. Jobs submitted to a virtual queue keep its name for listing and accounting, but are scheduled as part of the parent queue: the frobnicator injects the parent's `requires` constraint, and the scheduler needs no knowledge of virtual queues at all (a companion flux-sched PR maps virtual queue jobs to the parent's internal queue for Fluxion's per-queue policies; see flux-framework/flux-sched#1536).

An example use case is allowing a subset of users to bypass queue limits. Note that flux-core does not yet enforce per-queue access (flux-framework/rfc#536 defined the semantics; enforcement is future work), so restricting who may use a virtual queue currently requires an external mechanism such as the flux-accounting priority plugin.

### Example

```toml
[queues.batch]
requires = [ "batch" ]
policy.limits.duration = "8h"

[queues.expedite]
parent = "batch"
policy.limits.duration = "1h"

[queues.debug]
requires = [ "debug" ]

[policy.jobspec.defaults.system]
queue = "batch"
```

`expedite` submits jobs onto batch's nodes under its own duration limit, while inheriting any other limits from `batch`:

```console
$ flux queue list
QUEUE    PARENT   EN ST TDEFAULT   TLIMIT     NNODES     NCORES      NGPUS
batch*            ✔  ✔       inf       8h        0-3        0-3        0-0
expedite batch    ✔  ✔       inf       1h        0-3        0-3        0-0
debug             ✔  ✔       inf      inf        0-1        0-1        0-0

$ flux submit -q expedite -t 30m -N1 hostname
ƒH43DyZ
$ flux jobs -a -q expedite -no "{id.f58} {queue}"
ƒH43DyZ expedite
$ flux job info ƒH43DyZ jobspec | jq -c .attributes.system.constraints
{"properties":["batch"]}
```

`flux jobs -q batch` also lists the job, since virtual queue jobs are part of the parent's job list.

### Administrative state

A virtual queue is stopped, started, enabled, and disabled independently of its parent, but its jobs are only eligible for scheduling when both it and its parent are started. A virtual queue that is started while its parent is stopped is shown as *paused* (⏸) in `flux queue list`:

```console
$ flux queue stop batch
batch: Scheduling is stopped
$ flux queue list
QUEUE    PARENT   EN ST TDEFAULT   TLIMIT     NNODES     NCORES      NGPUS
batch*            ✔  ✗       inf       8h        0-3        0-3        0-0
expedite batch    ✔  ⏸       inf       1h        0-3        0-3        0-0
debug             ✔  ✔       inf      inf        0-1        0-1        0-0
$ flux queue status expedite
expedite: Job submission is enabled
expedite: Scheduling is stopped: parent queue 'batch' is stopped
```

The queue resumes on its own when the parent is started - no administrative action on the virtual queue is needed (the RFC 33 `blocked` status key, added in rfc#542, is what drives this display).

Stopping only the virtual queue holds its pending jobs without affecting the parent's, e.g. for submit-ahead workflows. Similarly, disable affects submission to that queue name only:

```console
$ flux queue disable --message="maintenance" expedite
expedite: Job submission is disabled: maintenance
$ flux queue status expedite
expedite: Job submission is disabled: maintenance
expedite: Scheduling is started
```

### Notes

 - Config validation rejects a virtual queue whose parent is missing or itself virtual (inheritance is one level), and a virtual queue that sets `requires` or `policy.scheduler`. A virtual queue may be the default queue.
 - `flux resource list` excludes virtual queues from the default QUEUE column (they would duplicate the parent's rows) but resolves them to the parent's resources when requested via `-q`.
 - The queue-status RPC gains additive `parent` and `blocked` keys per flux-framework/rfc#542.

Builds on the queues class refactoring in #7749. Closes the flux-core tasks in #7738.

