### PR TITLE
testsuite: add libschedutil test coverage

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -196,6 +196,7 @@ TESTSCRIPTS = \
 	t2306-sched-fifo.t \
 	t2307-sched-backfill.t \
 	t2308-sched-generator.t \
+	t2309-sched-schedutil.t \
 	t2310-resource-module.t \
 	t2311-resource-drain.t \
 	t2312-resource-exclude.t \
@@ -561,6 +562,7 @@ check_LTLIBRARIES = \
 	module/legacy.la \
 	module/hang.la \
 	request/req.la \
+	sched/schedutil-shim.la \
 	ingest/job-manager.la \
 	disconnect/watcher.la \
 	shell/plugins/dummy.la \
@@ -865,6 +867,14 @@ ingest_job_manager_la_SOURCES = ingest/job-manager.c
 ingest_job_manager_la_CPPFLAGS = $(test_cppflags)
 ingest_job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
 ingest_job_manager_la_LIBADD = $(test_ldadd)
+
+sched_schedutil_shim_la_SOURCES = sched/schedutil-shim.c
+sched_schedutil_shim_la_CPPFLAGS = $(test_cppflags)
+sched_schedutil_shim_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
+sched_schedutil_shim_la_LIBADD = \
+	$(top_builddir)/src/common/libschedutil/libschedutil.la \
+	$(top_builddir)/src/common/librlist/librlist.la \
+	$(test_ldadd)
 
 ingest_submitbench_SOURCES = ingest/submitbench.c
 ingest_submitbench_CPPFLAGS = $(test_cppflags)

--- a/t/sched/schedutil-shim.c
+++ b/t/sched/schedutil-shim.c
@@ -1,0 +1,254 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* schedutil-shim.c - minimal libschedutil consumer for testing
+ *
+ * This is a bare-bones scheduler broker module whose sole purpose is to
+ * exercise libschedutil (src/common/libschedutil).  It is NOT a real
+ * scheduler: it tracks no resources and makes no scheduling decisions.
+ * It completes the RFC 27 hello/ready handshake and, for each sched.alloc
+ * request, drives one of libschedutil's response functions so a test can
+ * observe what the library commits to the KVS and returns to job-manager.
+ *
+ * Behavior is controlled by two KVS keys that the test sets before
+ * submitting jobs:
+ *
+ *   test.schedutil.mode  (string, default "success")
+ *      "success" - respond with schedutil_alloc_respond_success_pack(),
+ *                  granting the R stored in test.schedutil.R.
+ *      "deny"    - respond with schedutil_alloc_respond_deny().
+ *      "hold"    - cache the request without responding, so the test can
+ *                  drive a sched.cancel (answered with
+ *                  schedutil_alloc_respond_cancel()).
+ *
+ *   test.schedutil.R     (string) R granted in "success" mode.
+ *
+ * The most recently held alloc request message is retained so that a
+ * cancel can be answered against it.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libschedutil/init.h"
+#include "src/common/libschedutil/hello.h"
+#include "src/common/libschedutil/ready.h"
+#include "src/common/libschedutil/alloc.h"
+#include "src/common/libschedutil/free.h"
+#include "ccan/str/str.h"
+
+struct shim {
+    schedutil_t *util;
+    const flux_msg_t *held;     // most recent held alloc request (mode=hold)
+};
+
+/* Read a string value from a KVS key, or NULL if unset.  Caller frees.
+ */
+static char *kvs_get_string (flux_t *h, const char *key)
+{
+    flux_future_t *f;
+    const char *s;
+    char *cpy = NULL;
+
+    if (!(f = flux_kvs_lookup (h, NULL, 0, key)))
+        return NULL;
+    if (flux_kvs_lookup_get (f, &s) == 0 && s)
+        cpy = strdup (s);
+    flux_future_destroy (f);
+    return cpy;
+}
+
+/* Synchronously commit a string value to a KVS key.  Returns 0 on success,
+ * -1 on error with errno set.  Caller frees nothing.
+ */
+static int kvs_put_string (flux_t *h, const char *key, const char *val)
+{
+    flux_kvs_txn_t *txn;
+    flux_future_t *f = NULL;
+    int rc = -1;
+
+    if (!(txn = flux_kvs_txn_create ()))
+        return -1;
+    if (flux_kvs_txn_put (txn, 0, key, val) < 0
+        || !(f = flux_kvs_commit (h, NULL, 0, txn))
+        || flux_future_get (f, NULL) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+    return rc;
+}
+
+static void alloc_cb (flux_t *h, const flux_msg_t *msg, void *arg)
+{
+    struct shim *ctx = arg;
+    char *mode = kvs_get_string (h, "test.schedutil.mode");
+    char *R = NULL;
+
+    if (mode && streq (mode, "deny")) {
+        if (schedutil_alloc_respond_deny (ctx->util,
+                                          msg,
+                                          "denied for test") < 0)
+            flux_log_error (h, "schedutil_alloc_respond_deny");
+    }
+    else if (mode && streq (mode, "hold")) {
+        /* Annotate the pending request before caching it, so a test can
+         * observe an annotation update on a job that has not been allocated.
+         */
+        if (schedutil_alloc_respond_annotate_pack (ctx->util,
+                                                   msg,
+                                                   "{s:{s:s}}",
+                                                   "sched",
+                                                   "reason_pending",
+                                                   "held for test") < 0)
+            flux_log_error (h, "schedutil_alloc_respond_annotate_pack");
+        flux_msg_decref (ctx->held);
+        ctx->held = flux_msg_incref (msg);
+    }
+    else { // "success" (default)
+        if (!(R = kvs_get_string (h, "test.schedutil.R"))) {
+            flux_log (h, LOG_ERR, "alloc: test.schedutil.R is unset");
+            if (schedutil_alloc_respond_deny (ctx->util, msg, "no R set") < 0)
+                flux_log_error (h, "schedutil_alloc_respond_deny");
+        }
+        /* Attach an annotation to exercise the success-response annotation
+         * argument, mirroring how a real scheduler reports a resource summary.
+         */
+        else if (schedutil_alloc_respond_success_pack (ctx->util,
+                                                       msg,
+                                                       R,
+                                                       "{s:{s:s}}",
+                                                       "sched",
+                                                       "resource_summary",
+                                                       "rank[0-1]") < 0)
+            flux_log_error (h, "schedutil_alloc_respond_success_pack");
+    }
+    free (mode);
+    free (R);
+}
+
+static void cancel_cb (flux_t *h, const flux_msg_t *msg, void *arg)
+{
+    struct shim *ctx = arg;
+
+    if (ctx->held) {
+        if (schedutil_alloc_respond_cancel (ctx->util, ctx->held) < 0)
+            flux_log_error (h, "schedutil_alloc_respond_cancel");
+        flux_msg_decref (ctx->held);
+        ctx->held = NULL;
+    }
+}
+
+static void free_cb (flux_t *h, const flux_msg_t *msg, const char *R, void *arg)
+{
+    struct shim *ctx = arg;
+
+    if (schedutil_free_respond (ctx->util, msg) < 0)
+        flux_log_error (h, "schedutil_free_respond");
+}
+
+/* Record R for a job reported during the hello handshake so a test can
+ * verify what libschedutil handed back -- in particular the partial R
+ * computed when the job-manager reports resources released to housekeeping.
+ * The R is stored at test.schedutil.hello.<jobid>.
+ */
+static int hello_cb (flux_t *h, const flux_msg_t *msg, const char *R, void *arg)
+{
+    flux_jobid_t id;
+    char key[64];
+    char *fail;
+
+    if (flux_msg_unpack (msg, "{s:I}", "id", &id) < 0)
+        return -1;
+    /* Fail the callback on request so libschedutil raises a fatal exception
+     * on the running job (the scheduler-cannot-reallocate path).
+     */
+    if ((fail = kvs_get_string (h, "test.schedutil.hello_fail"))) {
+        int rc = streq (fail, "1") ? -1 : 0;
+        free (fail);
+        if (rc < 0)
+            return -1;
+    }
+    (void)snprintf (key,
+                    sizeof (key),
+                    "test.schedutil.hello.%ju",
+                    (uintmax_t)id);
+    if (kvs_put_string (h, key, R) < 0) {
+        flux_log_error (h, "hello_cb: recording R for %ju", (uintmax_t)id);
+        return -1;
+    }
+    return 0;
+}
+
+static struct schedutil_ops ops = {
+    .hello = hello_cb,
+    .alloc = alloc_cb,
+    .free = free_cb,
+    .cancel = cancel_cb,
+    .prioritize = NULL,
+};
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    struct shim ctx = {0};
+    int rc = -1;
+    const char *mode = "unlimited";
+    int queue_depth = -1;
+
+    /* Optional "ready-mode=MODE" argument selects the concurrency mode
+     * passed to schedutil_ready() (default "unlimited"), letting a test
+     * exercise the "limited=N" path.
+     */
+    for (int i = 0; i < argc; i++) {
+        if (strstarts (argv[i], "ready-mode="))
+            mode = argv[i] + 11;
+        else {
+            flux_log (h, LOG_ERR, "unknown module option: %s", argv[i]);
+            errno = EINVAL;
+            goto done;
+        }
+    }
+    if (!(ctx.util = schedutil_create (h,
+                                       SCHEDUTIL_HELLO_PARTIAL_OK,
+                                       &ops,
+                                       &ctx))) {
+        flux_log_error (h, "schedutil_create");
+        goto done;
+    }
+    /* Complete the hello/ready handshake before advertising running, so a
+     * ready failure (e.g. an invalid mode) is a clean module load failure
+     * rather than a runtime crash of an already-running module.
+     */
+    if (schedutil_hello (ctx.util) < 0) {
+        flux_log_error (h, "schedutil_hello");
+        goto done;
+    }
+    if (schedutil_ready (ctx.util, mode, &queue_depth) < 0) {
+        flux_log_error (h, "schedutil_ready");
+        goto done;
+    }
+    flux_log (h, LOG_DEBUG, "ready: mode=%s queue_depth=%d", mode, queue_depth);
+    if (flux_module_set_running (h) < 0)
+        goto done;
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_msg_decref (ctx.held);
+    schedutil_destroy (ctx.util);
+    return rc;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t2309-sched-schedutil.t
+++ b/t/t2309-sched-schedutil.t
@@ -1,0 +1,182 @@
+#!/bin/sh
+
+test_description='Test the libschedutil convenience library
+
+Drive libschedutil through a minimal test scheduler (schedutil-shim) that
+does no real scheduling.  The shim grants a canned R controlled by KVS
+keys, so these tests exercise the library alloc/deny/cancel response paths
+and confirm what libschedutil commits to the KVS and returns to the
+job-manager.
+'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2 job
+
+SHIM=${FLUX_BUILD_DIR}/t/sched/.libs/schedutil-shim.so
+
+# The shim grants a fixed two-rank R to every job it allocates.
+flux R encode -r0-1 -c0-1 >shim_R.json
+
+# True once housekeeping for job $1 has released one rank back to the
+# scheduler and holds exactly one straggler (pending and allocated both "1").
+one_rank_released () {
+	flux module stats job-manager \
+		| jq -e ".housekeeping.running[\"$1\"]
+		         | .pending == \"1\" and .allocated == \"1\"" \
+		>/dev/null 2>&1
+}
+
+test_expect_success 'unload sched-simple and job-exec' '
+	flux module remove sched-simple &&
+	flux module remove job-exec
+'
+test_expect_success 'reload ingest without validator' '
+	flux module reload -f job-ingest disable-validator
+'
+test_expect_success 'configure shim to grant canned R' '
+	flux kvs put test.schedutil.mode=success &&
+	flux kvs put test.schedutil.R="$(cat shim_R.json)"
+'
+test_expect_success 'load schedutil-shim as the scheduler' '
+	flux module load ${SHIM}
+'
+test_expect_success 'alloc: job receives an alloc event' '
+	jobid=$(flux submit hostname) &&
+	flux job wait-event -t 30 $jobid alloc
+'
+test_expect_success 'alloc: libschedutil committed R to the KVS' '
+	flux job info $jobid R >alloc_R.json &&
+	test_debug "jq -S . <alloc_R.json" &&
+	jq -e ".execution.R_lite[0].rank == \"0-1\"" <alloc_R.json
+'
+test_expect_success 'alloc: success response carries scheduler annotation' '
+	test "$(flux jobs -no {annotations.sched.resource_summary} $jobid)" \
+		= "rank[0-1]"
+'
+test_expect_success 'deny: unschedulable jobs receive an exception' '
+	flux kvs put test.schedutil.mode=deny &&
+	jobid=$(flux submit hostname) &&
+	flux job wait-event -t 30 $jobid exception &&
+	flux job eventlog $jobid | grep -i "denied for test"
+'
+test_expect_success 'annotate: pending job receives an annotation update' '
+	flux kvs put test.schedutil.mode=hold &&
+	jobid=$(flux submit --flags=debug hostname) &&
+	flux job wait-event -t 30 $jobid debug.alloc-request &&
+	test "$(flux jobs -no {annotations.sched.reason_pending} $jobid)" \
+		= "held for test"
+'
+test_expect_success 'cancel: a held alloc request can be canceled' '
+	flux cancel $jobid &&
+	flux job wait-event -t 30 $jobid exception
+'
+test_expect_success 'hello: restore job-exec and run a long testexec job' '
+	flux kvs put test.schedutil.mode=success &&
+	flux kvs put test.schedutil.R="$(flux R encode -r0-1 -c0-1)" &&
+	flux module load job-exec &&
+	jobid=$(flux submit -N2 \
+		--setattr=system.exec.test.run_duration=100s hostname) &&
+	flux job wait-event -t 30 $jobid start
+'
+test_expect_success 'hello: scheduler reload replays the running job' '
+	flux module reload ${SHIM} &&
+	test $(flux jobs -no {state} $jobid) = "RUN"
+'
+test_expect_success 'hello: shim received the full R for the running job' '
+	kid=$(flux job id $jobid) &&
+	test_wait_until "flux kvs get test.schedutil.hello.$kid" &&
+	flux kvs get test.schedutil.hello.$kid >hello_R.json &&
+	test_debug "jq -S . <hello_R.json" &&
+	jq -e ".execution.R_lite[0].rank == \"0-1\"" <hello_R.json
+'
+test_expect_success 'hello: clean up the running job' '
+	flux cancel $jobid &&
+	flux job wait-event -t 30 $jobid clean
+'
+#
+# Exercise the partial-R hello path: when a job hands some of its ranks to
+# housekeeping and the scheduler restarts, the job-manager reports the still-
+# held ranks via the "free" key and libschedutil hands the shim a partial R
+# with the released ranks removed.
+#
+test_expect_success 'partial: configure housekeeping with a straggler' '
+	cat >housekeeping.sh <<-EOT &&
+	#!/bin/sh
+	test \$(flux getattr rank) -eq 1 && sleep 300
+	exit 0
+	EOT
+	chmod +x housekeeping.sh &&
+	flux config load <<-EOT
+	[job-manager.housekeeping]
+	command = [ "$(pwd)/housekeeping.sh" ]
+	release-after = "1s"
+	EOT
+'
+test_expect_success 'partial: run a job and let rank 0 release to housekeeping' '
+	jobid=$(flux submit -N2 \
+		--setattr=system.exec.test.run_duration=0.1s hostname) &&
+	flux job wait-event -t 30 $jobid clean &&
+	test_wait_until "one_rank_released $jobid"
+'
+test_expect_success 'partial: reload scheduler while rank 1 straggles' '
+	flux module reload ${SHIM}
+'
+test_expect_success 'partial: shim received R with the freed rank removed' '
+	kid=$(flux job id $jobid) &&
+	test_wait_until "flux kvs get test.schedutil.hello.$kid" &&
+	flux kvs get test.schedutil.hello.$kid >partial_R.json &&
+	test_debug "jq -S . <partial_R.json" &&
+	jq -e ".execution.R_lite[0].rank == \"1\"" <partial_R.json
+'
+test_expect_success 'partial: release the straggler' '
+	flux housekeeping kill --all --signal=9 &&
+	flux job wait-event -t 30 $jobid clean
+'
+test_expect_success 'remove housekeeping config' '
+	echo {} | flux config load
+'
+#
+# When the scheduler cannot reallocate a running job during the hello
+# handshake (ops->hello returns -1), libschedutil raises a fatal exception
+# on the job.  Drive that path with the shim hello_fail hook.
+#
+test_expect_success 'exception: run a long testexec job' '
+	flux kvs put test.schedutil.mode=success &&
+	flux kvs put test.schedutil.R="$(flux R encode -r0-1 -c0-1)" &&
+	jobid=$(flux submit -N2 \
+		--setattr=system.exec.test.run_duration=100s hostname) &&
+	flux job wait-event -t 30 $jobid start
+'
+test_expect_success 'exception: hello failure raises a fatal job exception' '
+	flux kvs put test.schedutil.hello_fail=1 &&
+	flux module reload ${SHIM} &&
+	flux job wait-event -t 30 $jobid exception >exception.out &&
+	test_debug "cat exception.out" &&
+	grep "type=\"scheduler-restart\"" exception.out &&
+	flux job wait-event -t 30 $jobid clean &&
+	flux kvs put test.schedutil.hello_fail=0
+'
+test_expect_success 'unload schedutil-shim' '
+	flux module remove schedutil-shim
+'
+#
+# schedutil_ready() accepts "unlimited" (tested above via the default) and
+# "limited=N"; exercise the latter by loading the shim with ready-mode.
+#
+test_expect_success 'ready: shim loads with limited concurrency mode' '
+	flux module load ${SHIM} ready-mode=limited=2 &&
+	jobid=$(flux submit hostname) &&
+	flux job wait-event -t 30 $jobid alloc &&
+	flux module remove schedutil-shim
+'
+test_expect_success 'ready: invalid mode is rejected' '
+	test_must_fail flux module load ${SHIM} ready-mode=bogus
+'
+test_expect_success 'restore sched-simple' '
+	flux module load sched-simple
+'
+
+test_done


### PR DESCRIPTION
Problem: libschedutil has no test coverage in flux-core.

Add schedutil-shim, a minimal broker module that links libschedutil and is used only for testing libschedutil functionality, and add a new sharness test t2309-sched-schedutil.t that uses the shim to exercise libschedutil functionality.

Fixes #7762 