### PR TITLE
strip instance-local properties from R generated for jobs

### DIFF
--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -667,10 +667,14 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
         # directly so the override never holds a mutable reference to pool state.
         selected_ranks = {rank for rank, _, _ in selected}
 
+        # Omit instance-local properties (RFC 20 leading '+') from the R
+        # generated for the job. If every property is instance-local this
+        # yields {}, which Rv1Set._build_dict() then omits from the encoded
+        # R via its "if self._properties" guard.
         properties = {
             prop: ranks & selected_ranks
             for prop, ranks in self._properties.items()
-            if ranks & selected_ranks
+            if ranks & selected_ranks and not prop.startswith("+")
         }
         ranks = {}
         for rank, alloc_cores, alloc_gpus in selected:

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -127,6 +127,32 @@ static void alloc_destroy (struct alloc *ctx)
     }
 }
 
+/* Omit RFC 20 instance-local properties (leading '+') from 'R'
+ * Returns the number of properties removed: 0 if R is unchanged.
+ */
+static int strip_instance_local_properties (json_t *R)
+{
+    json_t *execution;
+    json_t *properties;
+    const char *name;
+    json_t *value;
+    void *tmp;
+    int count = 0;
+
+    if (!(execution = json_object_get (R, "execution"))
+        || !(properties = json_object_get (execution, "properties")))
+        return 0;
+    json_object_foreach_safe (properties, tmp, name, value) {
+        if (name[0] == '+') {
+            (void)json_object_del (properties, name);
+            count++;
+        }
+    }
+    if (count > 0 && json_object_size (properties) == 0)
+        (void)json_object_del (execution, "properties");
+    return count;
+}
+
 static struct alloc *alloc_create (const flux_msg_t *msg,
                                    const char *R,
                                    const char *fmt,
@@ -155,7 +181,14 @@ static struct alloc *alloc_create (const flux_msg_t *msg,
     }
     if (!(ctx->txn = flux_kvs_txn_create ()))
         goto error;
-    if (flux_kvs_txn_put (ctx->txn, 0, key, R) < 0)
+    /* Strip RFC 20 instance-local properties.
+     * Commit result instead of original if R was modified.
+     */
+    if (strip_instance_local_properties (ctx->R) > 0) {
+        if (flux_kvs_txn_pack (ctx->txn, 0, key, "O", ctx->R) < 0)
+            goto error;
+    }
+    else if (flux_kvs_txn_put (ctx->txn, 0, key, R) < 0)
         goto error;
     return ctx;
 error:

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -124,6 +124,20 @@ R_props = {
     },
 }
 
+# 4 nodes with a hardware property ("fast") and an RFC 20 instance-local
+# property ("+batch", a leading '+'); used to test that instance-local
+# properties are omitted from allocation R while still matching constraints.
+R_local_props = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0-3", "children": {"core": "0-1"}}],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": ["node0", "node1", "node2", "node3"],
+        "properties": {"fast": "0-1", "+batch": "0-3"},
+    },
+}
+
 
 class TestRv1PoolConstruct(unittest.TestCase):
     def test_from_dict(self):
@@ -346,6 +360,26 @@ class TestRv1PoolAlloc(unittest.TestCase):
         a = pool.alloc(1, rr(0, 1, 1, constraint={"properties": ["slow"]}))
         self.assertIn("slow", a._properties)
         self.assertNotIn("fast", a._properties)
+
+    def test_alloc_omits_instance_local_properties(self):
+        # RFC 20: instance-local properties (leading '+') describe the instance,
+        # not the hardware, so a scheduler must not copy them into the job's R.
+        # Hardware properties on the allocated ranks are still propagated.
+        pool = Rv1Pool(R_local_props)
+        self.assertIn("+batch", pool._properties)
+        a = pool.alloc(1, rr(0, 1, 1, constraint={"properties": ["fast"]}))
+        self.assertIn("fast", a._properties)
+        self.assertNotIn("+batch", a._properties)
+        self.assertNotIn("+batch", a.to_dict()["execution"].get("properties", {}))
+
+    def test_alloc_matches_instance_local_constraint(self):
+        # A '+' membership property still selects ranks even though it is
+        # omitted from the resulting allocation R.
+        pool = Rv1Pool(R_local_props)
+        self.assertIn("+batch", pool._properties)
+        a = pool.alloc(1, rr(0, 1, 1, constraint={"properties": ["+batch"]}))
+        self.assertEqual(a.nnodes(), 1)
+        self.assertNotIn("+batch", a._properties)
 
 
 class TestRv1PoolIssue2473(unittest.TestCase):

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -28,6 +28,7 @@ test_expect_success 'sched-simple: reload resource with properties and R.schedul
 	flux module unload sched-simple &&
 	flux kvs put resource.R="$(flux kvs get resource.R |
 		flux R set-property xx:0-1 |
+		flux R set-property +batch:0-3 |
 		jq ".+{scheduling:{test:\"data\"}}")" &&
 	flux module reload resource noverify &&
 	flux module load sched-simple
@@ -35,6 +36,15 @@ test_expect_success 'sched-simple: reload resource with properties and R.schedul
 test_expect_success 'sched-simple: allocated R contains execution.properties' '
 	flux run -n1 --requires=xx hostname &&
 	flux job info $(flux job last) R | jq -e ".execution.properties.xx"
+'
+test_expect_success 'sched-simple: instance-local property omitted from job R' '
+	flux run -n1 --requires=+batch hostname &&
+	flux job info $(flux job last) R >batch_R.json &&
+	test_debug "jq -S .execution.properties <batch_R.json" &&
+	test_must_fail jq -e ".execution.properties[\"+batch\"]" <batch_R.json
+'
+test_expect_success 'sched-simple: instance-local property present in instance R' '
+	flux kvs get resource.R | jq -e ".execution.properties[\"+batch\"]"
 '
 test_expect_success 'sched-simple: allocated R contains R.scheduling' '
 	flux run -n1 hostname &&

--- a/t/t2309-sched-schedutil.t
+++ b/t/t2309-sched-schedutil.t
@@ -56,6 +56,23 @@ test_expect_success 'alloc: success response carries scheduler annotation' '
 	test "$(flux jobs -no {annotations.sched.resource_summary} $jobid)" \
 		= "rank[0-1]"
 '
+test_expect_success 'alloc: grant R with hardware and instance-local props' '
+	flux R encode -r0-1 -c0-1 \
+		| flux R set-property xx:0-1 \
+		| flux R set-property +batch:0-1 >prop_R.json &&
+	flux kvs put test.schedutil.R="$(cat prop_R.json)"
+'
+test_expect_success "alloc: libschedutil strips '+' properties from job R" '
+	jobid=$(flux submit hostname) &&
+	flux job wait-event -t 30 $jobid alloc &&
+	flux job info $jobid R >stripped_R.json &&
+	test_debug "jq -S .execution.properties <stripped_R.json" &&
+	jq -e ".execution.properties.xx == \"0-1\"" <stripped_R.json &&
+	test_must_fail jq -e ".execution.properties[\"+batch\"]" <stripped_R.json
+'
+test_expect_success 'alloc: restore canned R without properties' '
+	flux kvs put test.schedutil.R="$(cat shim_R.json)"
+'
 test_expect_success 'deny: unschedulable jobs receive an exception' '
 	flux kvs put test.schedutil.mode=deny &&
 	jobid=$(flux submit hostname) &&


### PR DESCRIPTION
This PR implements the removal of _instance-local_ properties (`+` prefix) for R subsets generated for jobs as recently specified in [RFC 20](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_20.html#properties).

The removal is done in libschedutil before writing _R_ to the KVS, so no changes should be necessary in Fluxion or other non-Python schedulers. For Python schedulers, removal is done in `Rv1Pool.alloc()`, from which all current in-tree Python schedulers inherit, but any future Python scheduler that overrides this method will have to implement the property removal as specified in RFC 20.

