### PR TITLE
job-exec: add background process recovery support

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -35,8 +35,8 @@ exec.service
    configured.  See :man5:`flux-config-systemd`.
 
 exec.method
-   (optional) Select the execution implementation used to launch jobs.
-   The only valid value is ``bulk-exec``, which is also the default.
+   (optional) Select the execution implementation used to launch jobs,
+   either ``bulk-exec`` or ``bgexec``.  (Default: ``bulk-exec``).
    Note that a job may instead select the :ref:`testexec` implementation
    by including an ``attributes.system.exec.test`` object in its jobspec.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1259,3 +1259,4 @@ claude
 codebase
 unreviewed
 usernetes
+bgexec

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -46,6 +46,8 @@ libsubprocess_la_SOURCES = \
 	fbuf_watcher.c \
 	bulk-exec.h \
 	bulk-exec.c \
+	bgexec.h \
+	bgexec.c \
 	msgchan.h \
 	msgchan.c
 

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -62,6 +62,7 @@ TESTS = \
 	test_stdio.t \
 	test_channel.t \
 	test_remote.t \
+	test_bgexec.t \
 	test_iostress.t \
 	test_iochan.t \
 	test_fbuf.t \
@@ -152,6 +153,13 @@ test_remote_t_CPPFLAGS = \
 	$(test_cppflags)
 test_remote_t_LDADD = $(test_ldadd)
 test_remote_t_LDFLAGS = $(test_ldflags)
+
+test_bgexec_t_SOURCES = test/bgexec.c
+test_bgexec_t_CPPFLAGS = \
+	-DTEST_SUBPROCESS_DIR=\"$(top_builddir)/src/common/libsubprocess/\" \
+	$(test_cppflags)
+test_bgexec_t_LDADD = $(test_ldadd)
+test_bgexec_t_LDFLAGS = $(test_ldflags)
 
 test_iostress_t_SOURCES = test/iostress.c
 test_iostress_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libsubprocess/bgexec.c
+++ b/src/common/libsubprocess/bgexec.c
@@ -1,0 +1,956 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <sys/wait.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <flux/core.h>
+#include <flux/idset.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/aux.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libjob/idf58.h"
+#include "src/common/libioencode/ioencode.h"
+#include "ccan/str/str.h"
+
+#include "subprocess.h"
+#include "bgexec.h"
+
+enum task_state {
+    BGEXEC_TASK_PENDING = 0, /* created; bg not yet issued or in flight   */
+    BGEXEC_TASK_STARTED,     /* bg response success; wait outstanding     */
+    BGEXEC_TASK_EXITED,      /* wait response received                    */
+    BGEXEC_TASK_FAILED,      /* bg response error (pre-RUNNING failure)   */
+};
+
+struct bgexec_task {
+    struct bgexec *bg;
+    int rank;
+    enum task_state state;
+    flux_cmd_t *cmd;
+    char *label;
+
+    pid_t pid;
+    int status;              /* raw wait status (valid once EXITED)       */
+    int errnum;              /* launch/wait failure errno                 */
+    char *errmsg;            /* launch/wait failure string                */
+
+    flux_future_t *bg_future;   /* in-flight start RPC                    */
+    flux_future_t *wait_future; /* in-flight wait RPC                     */
+};
+
+struct exec_cmd {
+    struct idset *ranks;
+    flux_cmd_t *cmd;
+};
+
+struct bgexec {
+    flux_t *h;
+
+    char *service;
+    flux_jobid_t id;
+    char *name;
+
+    struct aux_item *aux;
+
+    int max_start_per_loop;  /* Max bg RPCs started per event loop cb     */
+    int total;               /* Total tasks expected to run               */
+    int started;             /* Number of tasks that reached STARTED      */
+    int complete;            /* Number of tasks that completed            */
+
+    int exit_status;         /* Largest wait status of all exited tasks   */
+
+    unsigned int active:1;
+
+    flux_watcher_t *prep;
+    flux_watcher_t *check;
+    flux_watcher_t *idle;
+
+    struct idset *exit_batch;         /* Support for batched exit notify   */
+    flux_watcher_t *exit_batch_timer; /* Timer for batched exit notify     */
+
+    zlist_t *commands;
+    zlist_t *tasks;
+    struct idset *pushed_ranks;  /* union of ranks across pushed commands   */
+
+    struct bgexec_ops *handlers;
+    void *arg;
+};
+
+extern char **environ;
+
+/*  Per-rank handle accessors
+ */
+
+int bgexec_task_rank (struct bgexec_task *task)
+{
+    return task ? task->rank : -1;
+}
+
+int bgexec_task_status (struct bgexec_task *task)
+{
+    return task ? task->status : 0;
+}
+
+int bgexec_task_signaled (struct bgexec_task *task)
+{
+    if (!task || !WIFSIGNALED (task->status))
+        return 0;
+    return WTERMSIG (task->status);
+}
+
+int bgexec_task_errnum (struct bgexec_task *task)
+{
+    return task ? task->errnum : 0;
+}
+
+const char *bgexec_task_errmsg (struct bgexec_task *task)
+{
+    return task ? task->errmsg : NULL;
+}
+
+flux_cmd_t *bgexec_task_cmd (struct bgexec_task *task)
+{
+    return task ? task->cmd : NULL;
+}
+
+/*  Aggregate accessors
+ */
+
+int bgexec_rc (struct bgexec *bg)
+{
+    if (!bg) {
+        errno = EINVAL;
+        return -1;
+    }
+    return bg->exit_status;
+}
+
+int bgexec_total (struct bgexec *bg)
+{
+    return bg ? bg->total : 0;
+}
+
+int bgexec_started_count (struct bgexec *bg)
+{
+    return bg ? bg->started : 0;
+}
+
+int bgexec_complete (struct bgexec *bg)
+{
+    return bg ? bg->complete : 0;
+}
+
+int bgexec_active_count (struct bgexec *bg)
+{
+    if (!bg)
+        return 0;
+    return bg->total - bg->complete;
+}
+
+struct idset *bgexec_active_ranks (struct bgexec *bg)
+{
+    struct bgexec_task *task;
+    struct idset *ranks;
+
+    if (!bg || !bg->tasks) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(ranks = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        return NULL;
+    /*  A task is active until it reaches a terminal state (EXITED or
+     *  FAILED).  This includes PENDING tasks so the idset stays consistent
+     *  with bgexec_active_count() during the launch ramp.
+     */
+    task = zlist_first (bg->tasks);
+    while (task) {
+        if (task->state != BGEXEC_TASK_EXITED
+            && task->state != BGEXEC_TASK_FAILED
+            && task->rank >= 0) {
+            if (idset_set (ranks, task->rank) < 0)
+                goto error;
+        }
+        task = zlist_next (bg->tasks);
+    }
+    return ranks;
+error:
+    idset_destroy (ranks);
+    return NULL;
+}
+
+const char *bgexec_service_name (struct bgexec *bg)
+{
+    if (!bg)
+        return NULL;
+    return bg->service;
+}
+
+struct bgexec_task *bgexec_get_task (struct bgexec *bg, int rank)
+{
+    struct bgexec_task *task;
+
+    if (!bg || rank < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    task = zlist_first (bg->tasks);
+    while (task) {
+        if (task->rank == rank)
+            return task;
+        task = zlist_next (bg->tasks);
+    }
+    errno = ENOENT;
+    return NULL;
+}
+
+int bgexec_aux_set (struct bgexec *bg,
+                    const char *key,
+                    void *val,
+                    flux_free_f free_fn)
+{
+    if (!bg) {
+        errno = EINVAL;
+        return -1;
+    }
+    return aux_set (&bg->aux, key, val, free_fn);
+}
+
+void *bgexec_aux_get (struct bgexec *bg, const char *key)
+{
+    if (!bg) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return aux_get (bg->aux, key);
+}
+
+/*  Exit batching: coalesce task exits that happen within 0.01s into a
+ *  single on_exit callback.
+ */
+
+static void exit_notify (struct bgexec *bg)
+{
+    if (bg->handlers->on_exit)
+        (*bg->handlers->on_exit) (bg, bg->arg, bg->exit_batch);
+    /*  Clear the batch unconditionally.  bgexec_cancel() adds discarded
+     *  ranks directly (with no timer) and calls exit_notify(): if the clear
+     *  were gated on the timer those ranks would linger and reappear in a
+     *  later on_exit() when a still-running task exits.
+     */
+    flux_watcher_destroy (bg->exit_batch_timer);
+    bg->exit_batch_timer = NULL;
+    idset_range_clear (bg->exit_batch, 0, INT_MAX);
+}
+
+static void exit_batch_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
+{
+    struct bgexec *bg = arg;
+    exit_notify (bg);
+}
+
+static void exit_batch_append (struct bgexec *bg, struct bgexec_task *task)
+{
+    if (task->rank >= 0 && idset_set (bg->exit_batch, task->rank) < 0) {
+        flux_log_error (bg->h, "bgexec: exit_batch_append:idset_set");
+        return;
+    }
+    if (!bg->exit_batch_timer) {
+        flux_reactor_t *r = flux_get_reactor (bg->h);
+        bg->exit_batch_timer = flux_timer_watcher_create (r,
+                                                          0.01,
+                                                          0.,
+                                                          exit_batch_cb,
+                                                          bg);
+        if (!bg->exit_batch_timer) {
+            flux_log_error (bg->h, "bgexec: exit_batch_append:timer create");
+            return;
+        }
+        flux_watcher_start (bg->exit_batch_timer);
+    }
+}
+
+static void add_completed (struct bgexec *bg, struct bgexec_task *task)
+{
+    exit_batch_append (bg, task);
+
+    if (++bg->complete == bg->total) {
+        exit_notify (bg);
+        if (bg->handlers->on_complete)
+            (*bg->handlers->on_complete) (bg, bg->arg);
+    }
+}
+
+/*  Feed any retained early-output from a wait response to on_output.
+ */
+static void deliver_output (struct bgexec *bg,
+                            struct bgexec_task *task,
+                            json_t *output)
+{
+    size_t i;
+
+    if (!output || !bg->handlers->on_output)
+        return;
+    for (i = 0; i < json_array_size (output); i++) {
+        const char *stream = NULL;
+        char *data = NULL;
+        int len = 0;
+        if (iodecode (json_array_get (output, i),
+                      &stream,
+                      NULL,
+                      &data,
+                      &len,
+                      NULL) < 0)
+            continue;
+        if (data && len > 0)
+            (*bg->handlers->on_output) (bg,
+                                        task,
+                                        stream,
+                                        data,
+                                        len,
+                                        bg->arg);
+        free (data);
+    }
+}
+
+static void task_set_error (struct bgexec_task *task,
+                            int errnum,
+                            const char *errmsg)
+{
+    task->errnum = errnum;
+    free (task->errmsg);
+    task->errmsg = errmsg ? strdup (errmsg) : NULL;
+}
+
+/*  wait RPC response: transition STARTED -> EXITED and collect status.
+ */
+static void wait_continuation (flux_future_t *f, void *arg)
+{
+    struct bgexec_task *task = arg;
+    struct bgexec *bg = task->bg;
+    int status;
+    json_t *output = NULL;
+
+    if (flux_rpc_get_unpack (f,
+                             "{s:i s?o}",
+                             "status", &status,
+                             "output", &output) < 0) {
+        /* wait failed: e.g. the process was not found on a recovery wait
+         * because it did not survive.  Surface via on_error and complete
+         * the task.
+         */
+        task->state = BGEXEC_TASK_FAILED;
+        task_set_error (task, errno, future_strerror (f, errno));
+        if (bg->handlers->on_error)
+            (*bg->handlers->on_error) (bg, task, bg->arg);
+        goto done;
+    }
+    deliver_output (bg, task, output);
+    task->status = status;
+    task->state = BGEXEC_TASK_EXITED;
+    if (status > bg->exit_status)
+        bg->exit_status = status;
+done:
+    flux_future_destroy (f);
+    task->wait_future = NULL;
+    add_completed (bg, task);
+}
+
+static int task_issue_wait (struct bgexec_task *task)
+{
+    struct bgexec *bg = task->bg;
+    flux_future_t *f;
+
+    if (!(f = flux_rexec_wait (bg->h,
+                               bg->service,
+                               task->rank,
+                               -1,
+                               task->label)))
+        return -1;
+    if (flux_future_then (f, -1., wait_continuation, task) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    task->wait_future = f;
+    return 0;
+}
+
+/*  bg RPC response: transition PENDING -> STARTED (and issue wait) or
+ *  PENDING -> FAILED.
+ */
+static void bg_continuation (flux_future_t *f, void *arg)
+{
+    struct bgexec_task *task = arg;
+    struct bgexec *bg = task->bg;
+    int pid;
+
+    if (flux_rpc_get_unpack (f, "{s:i}", "pid", &pid) < 0) {
+        task->state = BGEXEC_TASK_FAILED;
+        task_set_error (task, errno, future_strerror (f, errno));
+        flux_future_destroy (f);
+        task->bg_future = NULL;
+        if (bg->handlers->on_error)
+            (*bg->handlers->on_error) (bg, task, bg->arg);
+        add_completed (bg, task);
+        return;
+    }
+    task->pid = pid;
+    task->state = BGEXEC_TASK_STARTED;
+    flux_future_destroy (f);
+    task->bg_future = NULL;
+
+    if (++bg->started == bg->total) {
+        if (bg->handlers->on_start)
+            (*bg->handlers->on_start) (bg, bg->arg);
+    }
+
+    /* Pipelined: issue this rank's wait immediately.  A failure here leaves
+     * the subprocess running on the server with no wait outstanding: it is
+     * orphaned (will run to completion uncollected), so say so.
+     */
+    if (task_issue_wait (task) < 0) {
+        task->state = BGEXEC_TASK_FAILED;
+        task_set_error (task,
+                        errno,
+                        "started but failed to issue wait: "
+                        "subprocess orphaned");
+        if (bg->handlers->on_error)
+            (*bg->handlers->on_error) (bg, task, bg->arg);
+        add_completed (bg, task);
+    }
+}
+
+static int task_issue_bg (struct bgexec_task *task)
+{
+    struct bgexec *bg = task->bg;
+    flux_future_t *f;
+
+    if (!(f = flux_rexec_bg (bg->h,
+                             bg->service,
+                             task->rank,
+                             FLUX_SUBPROCESS_FLAGS_WAITABLE,
+                             task->cmd)))
+        return -1;
+    if (flux_future_then (f, -1., bg_continuation, task) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    task->bg_future = f;
+    return 0;
+}
+
+/*  Count tasks still awaiting their bg RPC to be issued.
+ */
+static int count_startable (struct bgexec *bg)
+{
+    struct bgexec_task *task;
+    int count = 0;
+
+    task = zlist_first (bg->tasks);
+    while (task) {
+        if (task->state == BGEXEC_TASK_PENDING && !task->bg_future)
+            count++;
+        task = zlist_next (bg->tasks);
+    }
+    return count;
+}
+
+static void bgexec_stop (struct bgexec *bg)
+{
+    flux_watcher_stop (bg->prep);
+    flux_watcher_stop (bg->check);
+}
+
+/*  Issue up to 'max' bg RPCs for PENDING tasks (-1 for no limit).
+ */
+static int start_pending (struct bgexec *bg, int max)
+{
+    struct bgexec_task *task;
+    int count = 0;
+
+    task = zlist_first (bg->tasks);
+    while (task && (max < 0 || count < max)) {
+        if (task->state == BGEXEC_TASK_PENDING && !task->bg_future) {
+            if (task_issue_bg (task) < 0)
+                return -1;
+            count++;
+        }
+        task = zlist_next (bg->tasks);
+    }
+    return 0;
+}
+
+static void prep_cb (flux_reactor_t *r,
+                     flux_watcher_t *w,
+                     int revents,
+                     void *arg)
+{
+    struct bgexec *bg = arg;
+
+    if (count_startable (bg) > 0) {
+        flux_watcher_start (bg->idle);
+        flux_watcher_start (bg->check);
+    }
+    else
+        bgexec_stop (bg);
+}
+
+static void check_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
+{
+    struct bgexec *bg = arg;
+
+    flux_watcher_stop (bg->idle);
+    flux_watcher_stop (bg->check);
+    if (start_pending (bg, bg->max_start_per_loop) < 0) {
+        /*  A whole-object launch-pacing failure (e.g. flux_rexec_bg()
+         *  itself failed).  Report it with a NULL task and stop the loop.
+         *  The as-yet-unlaunched PENDING tasks are left non-terminal, so
+         *  on_complete will not fire: the caller must treat on_error() with
+         *  a NULL task as fatal and destroy the object.
+         */
+        flux_log_error (bg->h, "bgexec: start_pending failed");
+        bgexec_stop (bg);
+        if (bg->handlers->on_error)
+            (*bg->handlers->on_error) (bg, NULL, bg->arg);
+    }
+}
+
+static void task_destroy (struct bgexec_task *task)
+{
+    if (task) {
+        int saved_errno = errno;
+        flux_future_destroy (task->bg_future);
+        flux_future_destroy (task->wait_future);
+        flux_cmd_destroy (task->cmd);
+        free (task->label);
+        free (task->errmsg);
+        free (task);
+        errno = saved_errno;
+    }
+}
+
+/*  Build the deterministic per-rank label "<name>-<rank>-<jobid.f58plain>".
+ */
+static char *task_label_create (struct bgexec *bg, int rank)
+{
+    char idbuf[21];
+    char *label;
+
+    if (flux_job_id_encode (bg->id, "f58plain", idbuf, sizeof (idbuf)) < 0)
+        return NULL;
+    if (asprintf (&label, "%s-%d-%s", bg->name, rank, idbuf) < 0)
+        return NULL;
+    return label;
+}
+
+static struct bgexec_task *task_create (struct bgexec *bg,
+                                        int rank,
+                                        flux_cmd_t *cmd)
+{
+    struct bgexec_task *task;
+
+    if (!(task = calloc (1, sizeof (*task))))
+        return NULL;
+    task->bg = bg;
+    task->rank = rank;
+    task->pid = -1;
+    task->state = BGEXEC_TASK_PENDING;
+    if (!(task->cmd = flux_cmd_copy (cmd))
+        || !(task->label = task_label_create (bg, rank))
+        || flux_cmd_set_label (task->cmd, task->label) < 0)
+        goto error;
+    return task;
+error:
+    task_destroy (task);
+    return NULL;
+}
+
+/*  Expand all pushed commands into per-rank task objects.
+ */
+static int expand_tasks (struct bgexec *bg)
+{
+    struct exec_cmd *cmd;
+
+    cmd = zlist_first (bg->commands);
+    while (cmd) {
+        uint32_t rank = idset_first (cmd->ranks);
+        while (rank != IDSET_INVALID_ID) {
+            struct bgexec_task *task;
+            if (!(task = task_create (bg, rank, cmd->cmd)))
+                return -1;
+            if (zlist_append (bg->tasks, task) < 0) {
+                task_destroy (task);
+                errno = ENOMEM;
+                return -1;
+            }
+            zlist_freefn (bg->tasks,
+                          task,
+                          (zlist_free_fn *) task_destroy,
+                          true);
+            rank = idset_next (cmd->ranks, rank);
+        }
+        cmd = zlist_next (bg->commands);
+    }
+    return 0;
+}
+
+int bgexec_start (flux_t *h, struct bgexec *bg)
+{
+    flux_reactor_t *r;
+
+    if (!h || !bg || bg->active) {
+        errno = EINVAL;
+        return -1;
+    }
+    bg->h = h;
+    /*  Commit to this run before expand_tasks(): on partial failure it may
+     *  have appended some tasks, so the object is not safely re-startable
+     *  and must be destroyed.  Setting active now makes a retry fail EINVAL
+     *  rather than double-expand.
+     */
+    bg->active = 1;
+    if (expand_tasks (bg) < 0)
+        return -1;
+    r = flux_get_reactor (h);
+    bg->prep = flux_prepare_watcher_create (r, prep_cb, bg);
+    bg->check = flux_check_watcher_create (r, check_cb, bg);
+    bg->idle = flux_idle_watcher_create (r, NULL, NULL);
+    if (!bg->prep || !bg->check || !bg->idle)
+        return -1;
+    flux_watcher_start (bg->prep);
+    return 0;
+}
+
+int bgexec_wait (flux_t *h, struct bgexec *bg)
+{
+    struct bgexec_task *task;
+
+    if (!h || !bg || bg->active) {
+        errno = EINVAL;
+        return -1;
+    }
+    bg->h = h;
+    bg->active = 1;
+    if (expand_tasks (bg) < 0)
+        return -1;
+
+    /* Wait-only entry: the processes are already running, so there is no
+     * bg (launch) phase.  Mark every task STARTED first, then fire on_start
+     * once, then issue the waits.  Doing all the STARTED marking before any
+     * callback keeps on_start's "all tasks have reached STARTED" contract
+     * exact, and ensures no per-task wait failure (which fires on_error /
+     * on_complete via add_completed) is observed before on_start.
+     */
+    task = zlist_first (bg->tasks);
+    while (task) {
+        task->state = BGEXEC_TASK_STARTED;
+        bg->started++;
+        task = zlist_next (bg->tasks);
+    }
+    if (bg->started == bg->total && bg->handlers->on_start)
+        (*bg->handlers->on_start) (bg, bg->arg);
+
+    task = zlist_first (bg->tasks);
+    while (task) {
+        struct bgexec_task *next = zlist_next (bg->tasks);
+        if (task_issue_wait (task) < 0) {
+            task->state = BGEXEC_TASK_FAILED;
+            task_set_error (task, errno, "failed to issue wait request");
+            if (bg->handlers->on_error)
+                (*bg->handlers->on_error) (bg, task, bg->arg);
+            add_completed (bg, task);
+        }
+        task = next;
+    }
+    return 0;
+}
+
+int bgexec_cancel (struct bgexec *bg)
+{
+    struct bgexec_task *task;
+    bool discarded = false;
+
+    if (!bg) {
+        errno = EINVAL;
+        return -1;
+    }
+    /*  Stop the pacing loop so no further bg RPCs are issued, and mark the
+     *  object active so a later bgexec_start()/bgexec_wait() fails EINVAL
+     *  rather than re-expanding tasks on top of the discarded ones.
+     */
+    bgexec_stop (bg);
+    bg->active = 1;
+
+    /*  If cancel arrives before bgexec_start()/bgexec_wait() has expanded
+     *  the pushed commands, expand them now so the pending work can be
+     *  discarded.
+     */
+    if (zlist_size (bg->tasks) == 0 && expand_tasks (bg) < 0)
+        return -1;
+
+    /*  Discard tasks that never launched (PENDING with no start RPC in
+     *  flight): count them complete and add them to the exit batch, but do
+     *  not fire on_error -- they were abandoned, not failed.  Tasks with a
+     *  start RPC in flight complete via bg_continuation; STARTED tasks are
+     *  left for bgexec_kill() + wait to collect.
+     */
+    task = zlist_first (bg->tasks);
+    while (task) {
+        if (task->state == BGEXEC_TASK_PENDING && !task->bg_future) {
+            task->state = BGEXEC_TASK_EXITED;
+            if (task->rank >= 0
+                && idset_set (bg->exit_batch, task->rank) < 0)
+                flux_log_error (bg->h, "bgexec_cancel: idset_set");
+            bg->complete++;
+            discarded = true;
+        }
+        task = zlist_next (bg->tasks);
+    }
+    if (discarded) {
+        exit_notify (bg);
+        if (bg->complete == bg->total && bg->handlers->on_complete)
+            (*bg->handlers->on_complete) (bg, bg->arg);
+    }
+    return 0;
+}
+
+int bgexec_set_max_per_loop (struct bgexec *bg, int max)
+{
+    if (!bg || max == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    bg->max_start_per_loop = max;
+    return 0;
+}
+
+static void exec_cmd_destroy (void *arg)
+{
+    struct exec_cmd *cmd = arg;
+    if (cmd) {
+        int saved_errno = errno;
+        idset_destroy (cmd->ranks);
+        flux_cmd_destroy (cmd->cmd);
+        free (cmd);
+        errno = saved_errno;
+    }
+}
+
+static struct exec_cmd *exec_cmd_create (const struct idset *ranks,
+                                         flux_cmd_t *cmd)
+{
+    struct exec_cmd *c = calloc (1, sizeof (*c));
+    if (!c)
+        return NULL;
+    if (!(c->ranks = idset_copy (ranks))
+        || !(c->cmd = flux_cmd_copy (cmd)))
+        goto error;
+    return c;
+error:
+    exec_cmd_destroy (c);
+    return NULL;
+}
+
+int bgexec_push_cmd (struct bgexec *bg,
+                     const struct idset *ranks,
+                     flux_cmd_t *cmd)
+{
+    struct exec_cmd *c;
+
+    if (!bg || !ranks || !cmd || idset_count (ranks) == 0 || bg->active) {
+        errno = EINVAL;
+        return -1;
+    }
+    /*  Per-rank labels are derived from (name, rank, jobid), so a rank may
+     *  appear in only one pushed command; a duplicate would collide on the
+     *  server and double-count bg->total.  Reject an overlap up front.
+     */
+    if (idset_has_intersection (bg->pushed_ranks, ranks)) {
+        errno = EEXIST;
+        return -1;
+    }
+    if (idset_add (bg->pushed_ranks, ranks) < 0)
+        return -1;
+    if (!(c = exec_cmd_create (ranks, cmd)))
+        goto error;
+    if (zlist_append (bg->commands, c) < 0) {
+        exec_cmd_destroy (c);
+        errno = ENOMEM;
+        goto error;
+    }
+    zlist_freefn (bg->commands, c, exec_cmd_destroy, true);
+    bg->total += idset_count (ranks);
+    return 0;
+error:
+    /*  Roll back the rank registration so the object is unchanged on
+     *  failure (no intersection was found above, so subtracting is safe).
+     */
+    idset_subtract (bg->pushed_ranks, ranks);
+    return -1;
+}
+
+/*  Loop through all child futures of a failed kill and log rank-specific
+ *  errors.
+ */
+void bgexec_kill_log_error (flux_future_t *f, flux_jobid_t id)
+{
+    flux_t *h;
+    const char *name;
+
+    if (!f)
+        return;
+    h = flux_future_get_flux (f);
+    name = flux_future_first_child (f);
+    while (name) {
+        flux_future_t *cf = flux_future_get_child (f, name);
+        uint32_t rank = flux_rpc_get_nodeid (cf);
+        if (flux_future_is_ready (cf)
+            && flux_future_get (cf, NULL) < 0
+            && errno != ESRCH
+            && rank != FLUX_NODEID_ANY) {
+            flux_log (h,
+                      LOG_ERR,
+                      "%s: bgexec_kill: %s (rank %lu): %s",
+                      idf58 (id),
+                      flux_get_hostbyrank (h, rank),
+                      (unsigned long)rank,
+                      future_strerror (cf, errno));
+        }
+        name = flux_future_next_child (f);
+    }
+}
+
+/*  Send 'signum' to 'task' by label via a "<service>.kill" RPC.
+ */
+static flux_future_t *task_kill (struct bgexec_task *task, int signum)
+{
+    struct bgexec *bg = task->bg;
+    char *topic;
+    flux_future_t *f;
+
+    if (asprintf (&topic, "%s.kill", bg->service) < 0)
+        return NULL;
+    f = flux_rpc_pack (bg->h,
+                       topic,
+                       task->rank,
+                       0,
+                       "{s:i s:i s:s}",
+                       "pid", -1,
+                       "signum", signum,
+                       "label", task->label);
+    ERRNO_SAFE_WRAP (free, topic);
+    return f;
+}
+
+flux_future_t *bgexec_kill (struct bgexec *bg,
+                            const struct idset *ranks,
+                            int signum)
+{
+    struct bgexec_task *task;
+    flux_future_t *cf;
+
+    if (!bg || signum < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(cf = flux_future_wait_all_create ()))
+        return NULL;
+    flux_future_set_flux (cf, bg->h);
+
+    task = zlist_first (bg->tasks);
+    while (task) {
+        /* Only started-but-not-completed tasks are killable. */
+        if (task->state == BGEXEC_TASK_STARTED
+            && (!ranks || idset_test (ranks, task->rank))) {
+            flux_future_t *f;
+            char s[16];
+            if ((f = task_kill (task, signum))) {
+                (void) snprintf (s, sizeof (s), "%d", task->rank);
+                if (flux_future_push (cf, s, f) < 0)
+                    flux_future_destroy (f);
+            }
+        }
+        task = zlist_next (bg->tasks);
+    }
+    /*  If no child futures were pushed, no signals were sent: return
+     *  ENOENT.
+     */
+    if (!flux_future_first_child (cf)) {
+        flux_future_destroy (cf);
+        errno = ENOENT;
+        return NULL;
+    }
+    return cf;
+}
+
+void bgexec_destroy (struct bgexec *bg)
+{
+    if (bg) {
+        int saved_errno = errno;
+        zlist_destroy (&bg->tasks);
+        zlist_destroy (&bg->commands);
+        idset_destroy (bg->exit_batch);
+        idset_destroy (bg->pushed_ranks);
+        flux_watcher_destroy (bg->prep);
+        flux_watcher_destroy (bg->check);
+        flux_watcher_destroy (bg->idle);
+        flux_watcher_destroy (bg->exit_batch_timer);
+        aux_destroy (&bg->aux);
+        free (bg->name);
+        free (bg->service);
+        free (bg);
+        errno = saved_errno;
+    }
+}
+
+struct bgexec *bgexec_create (struct bgexec_ops *ops,
+                              const char *service,
+                              flux_jobid_t id,
+                              const char *name,
+                              void *arg)
+{
+    struct bgexec *bg;
+
+    if (!ops || !service || !name) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(bg = calloc (1, sizeof (*bg)))
+        || !(bg->service = strdup (service))
+        || !(bg->name = strdup (name)))
+        goto error;
+    bg->id = id;
+    bg->handlers = ops;
+    bg->arg = arg;
+    bg->max_start_per_loop = 1;
+    if (!(bg->tasks = zlist_new ())
+        || !(bg->commands = zlist_new ())
+        || !(bg->exit_batch = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || !(bg->pushed_ranks = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        goto error;
+    return bg;
+error:
+    bgexec_destroy (bg);
+    return NULL;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libsubprocess/bgexec.h
+++ b/src/common/libsubprocess/bgexec.h
@@ -1,0 +1,239 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* bgexec - background/waitable bulk subprocess execution
+ *
+ * Launch a set of subprocesses across broker ranks and collect their exit
+ * status, built on the RFC 42 background primitives flux_rexec_bg(3) +
+ * flux_rexec_wait(3) rather than the streaming flux_rexec_ex(3).  The start
+ * and wait phases are decoupled: because the subprocess server retains an
+ * exited-but-unwaited process until it is waited on, the wait may be
+ * re-issued by a client that started the processes, went away, and came
+ * back.  Each subprocess is addressed by a deterministic per-rank label
+ * derived from (name, rank, jobid), so wait needs no state persisted from
+ * the start.
+ *
+ * Task accounting
+ * ---------------
+ * Each rank is a "task" with a state: PENDING (created, not yet launched),
+ * STARTED (launch succeeded, wait outstanding), EXITED (wait collected
+ * status), or FAILED (launch failed before the process ran).  EXITED and
+ * FAILED are terminal.  The accessors report on this set:
+ *
+ *   bgexec_total()         tasks expected to run (fixed once commands are
+ *                          pushed)
+ *   bgexec_started_count() tasks that have reached STARTED
+ *   bgexec_complete()      tasks in a terminal state (EXITED + FAILED)
+ *   bgexec_active_count()  tasks not yet terminal (total - complete),
+ *   bgexec_active_ranks()  and the ranks they occupy
+ *
+ * on_complete fires when complete == total.  A task counts toward complete
+ * whether it exited, failed to launch, or was discarded by bgexec_cancel();
+ * every task reaches a terminal state exactly once, so the counts are
+ * monotonic within the lifetime of one bgexec object.
+ *
+ * Recovery
+ * --------
+ * The bgexec object is designed to be recoverable across a client restart.
+ * The caller may destroy the bgexec object without disturbing its subprocs.
+ * On restart, the caller creates a fresh bgexec object, re-pushes the same
+ * commands (regenerating the same labels), and calls bgexec_wait() instead
+ * of bgexec_start().
+ *
+ * Every task begins at PENDING as before, but skips the launch phase:
+ * bgexec_wait() marks each task STARTED and issues its wait by label
+ * directly.  A process that already exited in the previous incarnation is
+ * collected from the server's retained state, and one still running is
+ * waited on as usual; either way the task reaches EXITED when the wait
+ * response arrives.  From the new object's point of view the accounting is
+ * otherwise indistinguishable from a normal run.
+ *
+ * If a subprocess did not survive, so the server has no retained state
+ * for its label, the recovery wait fails rather than returning a status.
+ * The task moves to FAILED and on_error() fires with the wait errno and
+ * message on the task; it still counts toward completion.  The error
+ * reports that the label is unknown to the server, but cannot distinguish
+ * whether the subprocess ran and exited (its status now lost) or never
+ * started, so the caller must treat a failed recovery wait as a lost
+ * subprocess of unknown disposition.
+ */
+
+#ifndef _SUBPROCESS_BGEXEC_H
+#define _SUBPROCESS_BGEXEC_H 1
+
+#include <flux/core.h>
+#include <flux/idset.h>
+
+struct bgexec;
+struct bgexec_task;
+
+/*  Per-rank handle accessors.  The task handle is owned by the bgexec
+ *  object and is valid for the lifetime of that object.
+ */
+
+/* Broker rank the task runs on, or -1 if unknown. */
+int bgexec_task_rank (struct bgexec_task *task);
+
+/* Raw wait status (identical to the value flux_subprocess_status(3) would
+ * return: decode with WIFEXITED/WEXITSTATUS/WIFSIGNALED/WTERMSIG).  Only
+ * meaningful once the task has exited.
+ */
+int bgexec_task_status (struct bgexec_task *task);
+
+/* Terminating signal number if the task was killed by a signal, else 0. */
+int bgexec_task_signaled (struct bgexec_task *task);
+
+/* errno from on_error() launch failure, else 0.
+ */
+int bgexec_task_errnum (struct bgexec_task *task);
+
+/* Human readable error string from on_error() launch failure, else NULL. */
+const char *bgexec_task_errmsg (struct bgexec_task *task);
+
+/* The command the task runs (e.g. for labeling output). */
+flux_cmd_t *bgexec_task_cmd (struct bgexec_task *task);
+
+typedef void (*bgexec_cb_f) (struct bgexec *bg, void *arg);
+
+typedef void (*bgexec_exit_f) (struct bgexec *bg,
+                               void *arg,
+                               const struct idset *ranks);
+
+typedef void (*bgexec_error_f) (struct bgexec *bg,
+                                struct bgexec_task *task,
+                                void *arg);
+
+typedef void (*bgexec_io_f) (struct bgexec *bg,
+                             struct bgexec_task *task,
+                             const char *stream,
+                             const char *data,
+                             int data_len,
+                             void *arg);
+
+/*  Callbacks fire from the reactor while the bgexec object is being driven.
+ *  A callback MUST NOT destroy the bgexec object; destroy it from outside
+ *  the reactor context (typically after on_complete or a NULL-task
+ *  on_error has returned).
+ *
+ *  on_start fires once, only if EVERY task reaches STARTED.  On the launch
+ *  path (bgexec_start) a single launch failure means on_start never fires,
+ *  even though other ranks are running -- gate on on_error/on_complete, not
+ *  the absence of on_start.  On the wait path (bgexec_wait) all tasks are
+ *  marked STARTED up front, so on_start always fires.
+ *
+ *  on_error(task=NULL) signals a whole-object launch-pacing failure: no
+ *  further tasks will start and on_complete will NOT fire.  Treat it as
+ *  fatal and destroy the object.  on_error(task!=NULL) reports one task's
+ *  launch or wait failure; that task still counts toward on_complete.
+ *
+ *  on_exit reports each rank exactly once.  A task discarded by
+ *  bgexec_cancel() is reported through on_exit with a zero exit status
+ *  (it never ran), indistinguishable by status alone from a clean exit.
+ */
+struct bgexec_ops {
+    bgexec_cb_f    on_start;    /* all tasks have reached STARTED        */
+    bgexec_exit_f  on_exit;     /* a batch of tasks has exited           */
+    bgexec_cb_f    on_complete; /* all tasks have exited or failed       */
+    bgexec_error_f on_error;    /* a task failed to launch or be waited  */
+    bgexec_io_f    on_output;   /* early telemetry retained by wait      */
+};
+
+struct bgexec *bgexec_create (struct bgexec_ops *ops,
+                              const char *service,
+                              flux_jobid_t id,
+                              const char *name,
+                              void *arg);
+
+void bgexec_destroy (struct bgexec *bg);
+
+void *bgexec_aux_get (struct bgexec *bg, const char *key);
+
+int bgexec_aux_set (struct bgexec *bg,
+                    const char *key,
+                    void *val,
+                    flux_free_f free_fn);
+
+/*  Set maximum number of flux_rexec_bg(3) calls per event loop iteration.
+ *  The default is 1.  Pass -1 for no max; 0 is rejected (EINVAL).
+ */
+int bgexec_set_max_per_loop (struct bgexec *bg, int max);
+
+/*  Register a command to run on a non-empty set of ranks.  Must be called
+ *  before bgexec_start(), bgexec_wait(), or bgexec_cancel(); pushing after
+ *  any of those fails with EINVAL.  A rank may appear in only one pushed
+ *  command (labels are per-rank); pushing a rank already covered by an
+ *  earlier command fails with EEXIST and leaves the object unchanged.  An
+ *  empty rank set is rejected with EINVAL.
+ */
+int bgexec_push_cmd (struct bgexec *bg,
+                     const struct idset *ranks,
+                     flux_cmd_t *cmd);
+
+/*  Start all pushed commands with flux_rexec_bg(3) and wait for them with
+ *  flux_rexec_wait(3).  If the bgexec object is destroyed, subprocesses
+ *  are left to run on their own.  If any exit while not being waited for,
+ *  the subprocess server retains state so that bgexec_wait(3) can collect
+ *  it later.  Fails with EINVAL if the object has already been started or
+ *  waited on (start and wait are each once-only and mutually exclusive).
+ */
+int bgexec_start (flux_t *h, struct bgexec *bg);
+
+/*  Wait on all pushed commands with flux_rexec_wait(3).
+ *  This is for re-attaching after destroying and recreating the bgexec
+ *  object.  Fails with EINVAL if the object has already been started or
+ *  waited on.
+ */
+int bgexec_wait (flux_t *h, struct bgexec *bg);
+
+/*  Cancel: discard every task that has not yet been launched (mark it
+ *  complete, counting toward on_complete) and stop issuing new starts.
+ *  Tasks whose start RPC is already in flight complete normally, and
+ *  already-started tasks are left for bgexec_kill() + wait to collect.
+ */
+int bgexec_cancel (struct bgexec *bg);
+
+/*  Send signal to ranks.  Set ranks=NULL for all.  Kills by label.
+ */
+flux_future_t *bgexec_kill (struct bgexec *bg,
+                            const struct idset *ranks,
+                            int signum);
+
+/*  Log per-rank kill errors for a failed bgexec_kill() RPC.
+ */
+void bgexec_kill_log_error (flux_future_t *f, flux_jobid_t id);
+
+/* Returns max wait status returned from all exited tasks */
+int bgexec_rc (struct bgexec *bg);
+
+/* Returns total number of tasks expected to run */
+int bgexec_total (struct bgexec *bg);
+
+/* Returns number of tasks that have reached STARTED */
+int bgexec_started_count (struct bgexec *bg);
+
+/* Returns number of tasks that have completed (exited or failed) */
+int bgexec_complete (struct bgexec *bg);
+
+/* Returns number of tasks that are still active */
+int bgexec_active_count (struct bgexec *bg);
+
+/* Returns idset of ranks on which tasks are still active */
+struct idset *bgexec_active_ranks (struct bgexec *bg);
+
+/* Get subprocess remote exec service name (never returns NULL) */
+const char *bgexec_service_name (struct bgexec *bg);
+
+/* Get the per-rank task handle for a rank, or NULL with errno set. */
+struct bgexec_task *bgexec_get_task (struct bgexec *bg, int rank);
+
+#endif /* !_SUBPROCESS_BGEXEC_H */
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libsubprocess/test/bgexec.c
+++ b/src/common/libsubprocess/test/bgexec.c
@@ -1,0 +1,920 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Unit tests for bgexec, run against the in-process rcmdsrv mock server.
+ *
+ * The mock server implements the RFC 42 subprocess protocol (like rexec),
+ * so it exercises the real client-side start/wait/kill code paths in
+ * bgexec without a live broker.  It does not simulate a broker restart
+ * (server survival across restart is an sdexec concern, a follow-on); the
+ * recovery-wait test proves the wait-only-by-label protocol path by having
+ * a "previous incarnation" start waitable background processes and then
+ * reconstructing their labels in a fresh bgexec object.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <signal.h>
+#include <limits.h>
+#include <sys/wait.h>
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/idset.h>
+
+#include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "src/common/libsubprocess/server.h"
+#include "src/common/libsubprocess/subprocess.h"
+#include "src/common/libsubprocess/bgexec.h"
+
+#include "rcmdsrv.h"
+
+#define SERVER_NAME "test-bgexec"
+
+extern char **environ;
+
+/* Aggregate observations collected by the callbacks for a single run.
+ */
+struct scorecard {
+    int cb_on_start;
+    int cb_on_complete;
+    int exit_batches;
+    int exited_ranks;   /* total ranks reported across all cb_on_exit batches */
+    char exit_seen[64]; /* ranks already reported through cb_on_exit          */
+    int exit_dups;      /* ranks reported through cb_on_exit more than once */
+    int errors;
+    int last_error_rank;
+    int last_error_errno;
+    char output[4096];  /* concatenated cb_on_output data */
+};
+
+static void cb_on_start (struct bgexec *bg, void *arg)
+{
+    struct scorecard *sc = arg;
+    sc->cb_on_start++;
+}
+
+static void cb_on_exit (struct bgexec *bg, void *arg, const struct idset *ranks)
+{
+    struct scorecard *sc = arg;
+    unsigned int rank;
+
+    sc->exit_batches++;
+    sc->exited_ranks += idset_count (ranks);
+    /*  A rank must be reported through on_exit at most once.  Track which
+     *  ranks have been seen so a stale exit_batch entry reappearing in a
+     *  later batch is caught as a duplicate.
+     */
+    rank = idset_first (ranks);
+    while (rank != IDSET_INVALID_ID) {
+        if (rank < sizeof (sc->exit_seen)) {
+            if (sc->exit_seen[rank])
+                sc->exit_dups++;
+            sc->exit_seen[rank] = 1;
+        }
+        rank = idset_next (ranks, rank);
+    }
+}
+
+static void cb_on_complete (struct bgexec *bg, void *arg)
+{
+    struct scorecard *sc = arg;
+    sc->cb_on_complete++;
+}
+
+static void cb_on_error (struct bgexec *bg, struct bgexec_task *task, void *arg)
+{
+    struct scorecard *sc = arg;
+    sc->errors++;
+    if (task) {
+        sc->last_error_rank = bgexec_task_rank (task);
+        sc->last_error_errno = bgexec_task_errnum (task);
+    }
+}
+
+static void cb_on_output (struct bgexec *bg,
+                       struct bgexec_task *task,
+                       const char *stream,
+                       const char *data,
+                       int len,
+                       void *arg)
+{
+    struct scorecard *sc = arg;
+    size_t used = strlen (sc->output);
+    if (used + len < sizeof (sc->output)) {
+        memcpy (sc->output + used, data, len);
+        sc->output[used + len] = '\0';
+    }
+}
+
+static struct bgexec_ops test_ops = {
+    .on_start = cb_on_start,
+    .on_exit = cb_on_exit,
+    .on_complete = cb_on_complete,
+    .on_error = cb_on_error,
+    .on_output = cb_on_output,
+};
+
+static const flux_jobid_t TEST_JOBID = 1234;
+
+/* Push cmd (argv) on ranks [0, nranks) into a new bgexec and return it. */
+static struct bgexec *setup (flux_t *h,
+                             struct scorecard *sc,
+                             int nranks,
+                             char **argv,
+                             int argc)
+{
+    struct bgexec *bg;
+    struct idset *ranks;
+    flux_cmd_t *cmd;
+    int i;
+
+    memset (sc, 0, sizeof (*sc));
+    if (!(bg = bgexec_create (&test_ops,
+                              SERVER_NAME,
+                              TEST_JOBID,
+                              "shell",
+                              sc)))
+        BAIL_OUT ("bgexec_create failed");
+    if (!(ranks = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        BAIL_OUT ("idset_create failed");
+    for (i = 0; i < nranks; i++) {
+        if (idset_set (ranks, i) < 0)
+            BAIL_OUT ("idset_set failed");
+    }
+    if (!(cmd = flux_cmd_create (argc, argv, environ)))
+        BAIL_OUT ("flux_cmd_create failed");
+    if (bgexec_push_cmd (bg, ranks, cmd) < 0)
+        BAIL_OUT ("bgexec_push_cmd failed");
+    flux_cmd_destroy (cmd);
+    idset_destroy (ranks);
+    return bg;
+}
+
+/* Basic start: all ranks launch, cb_on_start fires once, all exit 0, and
+ * cb_on_complete fires once.
+ */
+static void test_basic (flux_t *h)
+{
+    char *av[] = { "true", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 3, av, ARRAY_SIZE (av) - 1);
+
+    ok (bgexec_total (bg) == 3,
+        "basic: bgexec_total is 3");
+    ok (bgexec_start (h, bg) == 0,
+        "basic: bgexec_start works");
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
+        "basic: reactor ran to completion");
+    ok (sc.cb_on_start == 1,
+        "basic: cb_on_start fired once (got %d)", sc.cb_on_start);
+    ok (sc.cb_on_complete == 1,
+        "basic: cb_on_complete fired once (got %d)", sc.cb_on_complete);
+    ok (sc.exited_ranks == 3,
+        "basic: all 3 ranks reported exited (got %d)", sc.exited_ranks);
+    ok (sc.errors == 0,
+        "basic: no errors (got %d)", sc.errors);
+    ok (bgexec_rc (bg) == 0,
+        "basic: exit status is 0 (got 0x%04x)", bgexec_rc (bg));
+    ok (bgexec_complete (bg) == 3,
+        "basic: complete count is 3 (got %d)", bgexec_complete (bg));
+    bgexec_destroy (bg);
+}
+
+/* A rank exits nonzero: exit status reflects the max wait status. */
+static void test_nonzero (flux_t *h)
+{
+    char *av[] = { "false", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 2, av, ARRAY_SIZE (av) - 1);
+    int status;
+
+    ok (bgexec_start (h, bg) == 0,
+        "nonzero: bgexec_start works");
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
+        "nonzero: reactor ran to completion");
+    ok (sc.cb_on_complete == 1,
+        "nonzero: cb_on_complete fired once");
+    status = bgexec_rc (bg);
+    ok (WIFEXITED (status) && WEXITSTATUS (status) == 1,
+        "nonzero: exit status decodes to exit code 1 (got 0x%04x)",
+        status);
+    bgexec_destroy (bg);
+}
+
+/* Pre-RUNNING launch failure (exec of nonexistent file) is surfaced on the
+ * start response as cb_on_error with errno ENOENT, and still counts toward
+ * completion.  Because a rank fails to start, cb_on_start does not fire.
+ */
+static void test_launch_failure (flux_t *h)
+{
+    char *av[] = { "/noexist", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 1, av, ARRAY_SIZE (av) - 1);
+
+    ok (bgexec_start (h, bg) == 0,
+        "launch_failure: bgexec_start works");
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
+        "launch_failure: reactor ran to completion");
+    ok (sc.errors == 1,
+        "launch_failure: cb_on_error fired once (got %d)", sc.errors);
+    ok (sc.last_error_errno == ENOENT,
+        "launch_failure: error errno is ENOENT (got %d)",
+        sc.last_error_errno);
+    ok (sc.cb_on_start == 0,
+        "launch_failure: cb_on_start did not fire");
+    ok (sc.cb_on_complete == 1,
+        "launch_failure: cb_on_complete still fired");
+    ok (bgexec_complete (bg) == 1,
+        "launch_failure: task counted as complete");
+    bgexec_destroy (bg);
+}
+
+/* Mixed launch failure + success: the good rank runs and exits, the bad
+ * rank errors; both count toward completion; cb_on_start does not fire since
+ * not all ranks reached STARTED.
+ */
+static void test_mixed (flux_t *h)
+{
+    struct bgexec *bg;
+    struct scorecard sc;
+    struct idset *ranks;
+    char *good[] = { "true", NULL };
+    char *bad[] = { "/noexist", NULL };
+    flux_cmd_t *cmd_good = NULL, *cmd_bad = NULL;
+
+    memset (&sc, 0, sizeof (sc));
+    if (!(bg = bgexec_create (&test_ops,
+                              SERVER_NAME,
+                              TEST_JOBID,
+                              "shell",
+                              &sc)))
+        BAIL_OUT ("bgexec_create failed");
+    if (!(cmd_good = flux_cmd_create (ARRAY_SIZE (good) - 1, good, environ))
+        || !(cmd_bad = flux_cmd_create (ARRAY_SIZE (bad) - 1, bad, environ)))
+        BAIL_OUT ("flux_cmd_create failed");
+    if (!(ranks = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        BAIL_OUT ("idset_create failed");
+
+    idset_set (ranks, 0);
+    if (bgexec_push_cmd (bg, ranks, cmd_good) < 0)
+        BAIL_OUT ("bgexec_push_cmd (good) failed");
+    idset_clear (ranks, 0);
+    idset_set (ranks, 1);
+    if (bgexec_push_cmd (bg, ranks, cmd_bad) < 0)
+        BAIL_OUT ("bgexec_push_cmd (bad) failed");
+
+    ok (bgexec_start (h, bg) == 0,
+        "mixed: bgexec_start works");
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
+        "mixed: reactor ran to completion");
+    ok (sc.errors == 1,
+        "mixed: exactly one cb_on_error (got %d)", sc.errors);
+    ok (sc.last_error_rank == 1,
+        "mixed: error was for rank 1 (got %d)", sc.last_error_rank);
+    ok (sc.cb_on_start == 0,
+        "mixed: cb_on_start did not fire (a rank failed to start)");
+    ok (sc.cb_on_complete == 1,
+        "mixed: cb_on_complete fired");
+    ok (bgexec_complete (bg) == 2,
+        "mixed: both tasks complete (got %d)", bgexec_complete (bg));
+
+    flux_cmd_destroy (cmd_good);
+    flux_cmd_destroy (cmd_bad);
+    idset_destroy (ranks);
+    bgexec_destroy (bg);
+}
+
+/* Early telemetry: a process that emits stderr before exiting has that
+ * output retained by the server and delivered via cb_on_output from the wait
+ * response.
+ */
+static void test_output (flux_t *h)
+{
+    char *av[] = { TEST_SUBPROCESS_DIR "test_echo", "-E", "foo", "bar", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 1, av, ARRAY_SIZE (av) - 1);
+
+    ok (bgexec_start (h, bg) == 0,
+        "output: bgexec_start works");
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
+        "output: reactor ran to completion");
+    ok (sc.cb_on_complete == 1,
+        "output: cb_on_complete fired");
+    ok (streq (sc.output, "foo\nbar\n"),
+        "output: retained stderr delivered via cb_on_output (got '%s')",
+        sc.output);
+    bgexec_destroy (bg);
+}
+
+/* Kill: start long-running processes, signal them by label, and verify
+ * they are reported as terminated by signal.
+ */
+static void test_kill (flux_t *h)
+{
+    char *av[] = { "sleep", "30", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 2, av, ARRAY_SIZE (av) - 1);
+    flux_reactor_t *r = flux_get_reactor (h);
+    struct bgexec_task *task;
+    flux_future_t *f;
+
+    ok (bgexec_start (h, bg) == 0,
+        "kill: bgexec_start works");
+    /* Pump the reactor until all ranks have started (cb_on_start fired). */
+    while (sc.cb_on_start == 0)
+        flux_reactor_run (r, FLUX_REACTOR_ONCE);
+    ok (sc.cb_on_start == 1,
+        "kill: cb_on_start fired");
+    ok (bgexec_active_count (bg) == 2,
+        "kill: 2 tasks active (got %d)", bgexec_active_count (bg));
+
+    f = bgexec_kill (bg, NULL, SIGTERM);
+    ok (f != NULL,
+        "kill: bgexec_kill returned a future");
+    ok (flux_future_wait_for (f, 5.) == 0 && flux_future_get (f, NULL) == 0,
+        "kill: kill RPC succeeded");
+    flux_future_destroy (f);
+
+    ok (flux_reactor_run (r, 0) >= 0,
+        "kill: reactor ran to completion");
+    ok (sc.cb_on_complete == 1,
+        "kill: cb_on_complete fired");
+    task = bgexec_get_task (bg, 0);
+    ok (task != NULL && bgexec_task_signaled (task) == SIGTERM,
+        "kill: rank 0 terminated by SIGTERM (got %d)",
+        task ? bgexec_task_signaled (task) : -1);
+    bgexec_destroy (bg);
+}
+
+/* Build the deterministic label bgexec uses internally, so the test can
+ * start a "previous incarnation" process the recovery wait can find.
+ */
+static char *make_label (int rank)
+{
+    char idbuf[21];
+    char *label;
+    if (flux_job_id_encode (TEST_JOBID, "f58plain", idbuf, sizeof (idbuf)) < 0)
+        BAIL_OUT ("flux_job_id_encode failed");
+    if (asprintf (&label, "shell-%d-%s", rank, idbuf) < 0)
+        BAIL_OUT ("asprintf failed");
+    return label;
+}
+
+/* Start a waitable background process with the bgexec label for 'rank'
+ * (as a prior incarnation would), and leave it unwaited.
+ */
+static void prior_start (flux_t *h, int rank, char **av, int ac)
+{
+    flux_cmd_t *cmd;
+    flux_future_t *f;
+    char *label = make_label (rank);
+
+    if (!(cmd = flux_cmd_create (ac, av, environ))
+        || flux_cmd_set_label (cmd, label) < 0)
+        BAIL_OUT ("prior_start: cmd setup failed");
+    f = flux_rexec_bg (h,
+                       SERVER_NAME,
+                       rank,
+                       FLUX_SUBPROCESS_FLAGS_WAITABLE,
+                       cmd);
+    if (!f)
+        BAIL_OUT ("prior_start: flux_rexec_bg failed");
+    ok (flux_rpc_get (f, NULL) == 0,
+        "recover: prior incarnation started rank %d", rank);
+    flux_future_destroy (f);
+    flux_cmd_destroy (cmd);
+    free (label);
+}
+
+/* Recovery wait: a fresh bgexec reconstructs the per-rank labels and
+ * collects status of processes started by a prior incarnation via
+ * bgexec_wait(), without a start phase.  This is the restart recovery path.
+ */
+static void test_recover_wait (flux_t *h)
+{
+    char *av[] = { "true", NULL };
+    struct scorecard sc;
+    struct bgexec *bg;
+    int i;
+
+    /* Prior incarnation launches two waitable background processes. */
+    for (i = 0; i < 2; i++)
+        prior_start (h, i, av, ARRAY_SIZE (av) - 1);
+
+    bg = setup (h, &sc, 2, av, ARRAY_SIZE (av) - 1);
+    ok (bgexec_wait (h, bg) == 0,
+        "recover: bgexec_wait works");
+    ok (sc.cb_on_start == 1,
+        "recover: cb_on_start fired (all tasks STARTED)");
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
+        "recover: reactor ran to completion");
+    ok (sc.cb_on_complete == 1,
+        "recover: cb_on_complete fired");
+    ok (sc.exited_ranks == 2,
+        "recover: both ranks reported exited (got %d)", sc.exited_ranks);
+    ok (sc.errors == 0,
+        "recover: no errors (got %d)", sc.errors);
+    ok (bgexec_rc (bg) == 0,
+        "recover: recovered exit status 0 (got 0x%04x)", bgexec_rc (bg));
+    bgexec_destroy (bg);
+}
+
+/* Recovery wait on a nonexistent process: the wait RPC fails and the task
+ * is surfaced via cb_on_error.
+ */
+static void test_recover_missing (flux_t *h)
+{
+    char *av[] = { "true", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 1, av, ARRAY_SIZE (av) - 1);
+
+    ok (bgexec_wait (h, bg) == 0,
+        "recover_missing: bgexec_wait works");
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
+        "recover_missing: reactor ran to completion");
+    ok (sc.errors == 1,
+        "recover_missing: cb_on_error fired for missing process (got %d)",
+        sc.errors);
+    ok (sc.cb_on_complete == 1,
+        "recover_missing: cb_on_complete fired");
+    bgexec_destroy (bg);
+}
+
+/* Cancel before start: every task is pending, so all are discarded to
+ * complete, cb_on_complete fires, and no task launches or errors.
+ */
+static void test_cancel_before_start (flux_t *h)
+{
+    char *av[] = { "true", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 3, av, ARRAY_SIZE (av) - 1);
+
+    ok (bgexec_cancel (bg) == 0,
+        "cancel: bgexec_cancel before start works");
+    ok (bgexec_complete (bg) == 3,
+        "cancel: all 3 pending tasks discarded to complete (got %d)",
+        bgexec_complete (bg));
+    ok (sc.cb_on_complete == 1,
+        "cancel: cb_on_complete fired once (got %d)", sc.cb_on_complete);
+    ok (sc.errors == 0,
+        "cancel: discarded tasks did not fire cb_on_error (got %d)", sc.errors);
+    ok (sc.cb_on_start == 0,
+        "cancel: cb_on_start did not fire (nothing launched)");
+    ok (bgexec_started_count (bg) == 0,
+        "cancel: started_count is 0 (got %d)", bgexec_started_count (bg));
+    /* A start after cancel must fail rather than re-expand the discarded
+     * tasks.
+     */
+    ok (bgexec_start (h, bg) < 0 && errno == EINVAL,
+        "cancel: bgexec_start after cancel fails with EINVAL");
+    /* Reactor should have no outstanding work. */
+    ok (flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_NOWAIT) >= 0,
+        "cancel: reactor idle after cancel");
+    bgexec_destroy (bg);
+}
+
+/* Cancel after all ranks have started: started tasks are left for kill+wait,
+ * so cancel discards nothing.  Kill then collects them.
+ */
+static void test_cancel_after_start (flux_t *h)
+{
+    char *av[] = { "sleep", "30", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 2, av, ARRAY_SIZE (av) - 1);
+    flux_reactor_t *r = flux_get_reactor (h);
+    flux_future_t *f;
+
+    ok (bgexec_start (h, bg) == 0,
+        "cancel_after: bgexec_start works");
+    while (sc.cb_on_start == 0)
+        flux_reactor_run (r, FLUX_REACTOR_ONCE);
+    ok (bgexec_started_count (bg) == 2,
+        "cancel_after: started_count is 2 (got %d)",
+        bgexec_started_count (bg));
+
+    ok (bgexec_cancel (bg) == 0,
+        "cancel_after: bgexec_cancel works");
+    ok (bgexec_complete (bg) == 0,
+        "cancel_after: started tasks not discarded by cancel (got %d)",
+        bgexec_complete (bg));
+
+    /* kill + wait collects the started tasks. */
+    f = bgexec_kill (bg, NULL, SIGTERM);
+    ok (f != NULL && flux_future_wait_for (f, 5.) == 0,
+        "cancel_after: kill RPC completed");
+    flux_future_destroy (f);
+    ok (flux_reactor_run (r, 0) >= 0,
+        "cancel_after: reactor ran to completion");
+    ok (sc.cb_on_complete == 1,
+        "cancel_after: cb_on_complete fired after kill+wait");
+    bgexec_destroy (bg);
+}
+
+/* Cancel discards some pending ranks while another rank is still running,
+ * then kill+wait collects the runner.  The discarded ranks are reported
+ * through cb_on_exit at cancel time; the runner is reported when it exits.
+ * No rank may appear in cb_on_exit twice -- a regression guard for the
+ * exit_batch not being cleared on the cancel path.
+ */
+static void test_cancel_then_exit (flux_t *h)
+{
+    char *av[] = { "sleep", "30", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 3, av, ARRAY_SIZE (av) - 1);
+    flux_reactor_t *r = flux_get_reactor (h);
+    flux_future_t *f;
+
+    /* Pace one launch per loop iteration, then run exactly one iteration so
+     * a single rank's bg RPC is in flight while the other two remain PENDING
+     * with no RPC issued.  Cancel then discards those two (reporting them
+     * through cb_on_exit) and leaves the in-flight rank to become the runner.
+     */
+    ok (bgexec_set_max_per_loop (bg, 1) == 0,
+        "cancel_then_exit: max_per_loop set to 1");
+    ok (bgexec_start (h, bg) == 0,
+        "cancel_then_exit: bgexec_start works");
+    flux_reactor_run (r, FLUX_REACTOR_NOWAIT);
+
+    ok (bgexec_cancel (bg) == 0,
+        "cancel_then_exit: bgexec_cancel works");
+    ok (bgexec_complete (bg) == 2,
+        "cancel_then_exit: 2 unissued ranks discarded (got %d)",
+        bgexec_complete (bg));
+    ok (sc.exit_dups == 0,
+        "cancel_then_exit: no rank reported twice through cb_on_exit so far");
+
+    /* Collect the surviving runner; its exit must not re-report the
+     * discarded ranks through a stale exit batch.
+     */
+    while (bgexec_started_count (bg) < 1)
+        flux_reactor_run (r, FLUX_REACTOR_ONCE);
+    f = bgexec_kill (bg, NULL, SIGKILL);
+    ok (f != NULL && flux_future_wait_for (f, 5.) == 0,
+        "cancel_then_exit: kill RPC completed");
+    flux_future_destroy (f);
+    ok (flux_reactor_run (r, 0) >= 0,
+        "cancel_then_exit: reactor ran to completion");
+    ok (sc.cb_on_complete == 1,
+        "cancel_then_exit: cb_on_complete fired once (got %d)",
+        sc.cb_on_complete);
+    ok (sc.exited_ranks == 3,
+        "cancel_then_exit: 3 rank-exits reported total (got %d)",
+        sc.exited_ranks);
+    ok (sc.exit_dups == 0,
+        "cancel_then_exit: no rank reported twice through cb_on_exit");
+    bgexec_destroy (bg);
+}
+
+/* Exit batching: several ranks running the same fast command exit close
+ * together and are coalesced into fewer cb_on_exit batches than ranks.
+ */
+static void test_exit_batching (flux_t *h)
+{
+    char *av[] = { "true", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 4, av, ARRAY_SIZE (av) - 1);
+
+    ok (bgexec_start (h, bg) == 0,
+        "batching: bgexec_start works");
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
+        "batching: reactor ran to completion");
+    ok (sc.exited_ranks == 4,
+        "batching: all 4 ranks reported exited (got %d)", sc.exited_ranks);
+    ok (sc.exit_batches >= 1 && sc.exit_batches <= 4,
+        "batching: exits coalesced into %d batch(es) for 4 ranks",
+        sc.exit_batches);
+    ok (sc.exit_batches < 4,
+        "batching: fewer batches than ranks (coalescing occurred, got %d)",
+        sc.exit_batches);
+    bgexec_destroy (bg);
+}
+
+/* Targeted kill: signal only a subset of ranks by label; unlisted ranks
+ * keep running.  Also exercises the empty-selection ENOENT path.
+ */
+static void test_kill_targeted (flux_t *h)
+{
+    char *av[] = { "sleep", "30", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 3, av, ARRAY_SIZE (av) - 1);
+    flux_reactor_t *r = flux_get_reactor (h);
+    struct idset *target;
+    struct bgexec_task *task;
+    flux_future_t *f;
+
+    ok (bgexec_start (h, bg) == 0,
+        "kill_targeted: bgexec_start works");
+    while (sc.cb_on_start == 0)
+        flux_reactor_run (r, FLUX_REACTOR_ONCE);
+
+    /* Kill an empty set -> no child futures pushed -> ENOENT. */
+    if (!(target = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        BAIL_OUT ("idset_create failed");
+    ok (bgexec_kill (bg, target, SIGTERM) == NULL && errno == ENOENT,
+        "kill_targeted: empty rank set returns ENOENT");
+
+    /* Kill only rank 1. */
+    idset_set (target, 1);
+    f = bgexec_kill (bg, target, SIGTERM);
+    ok (f != NULL && flux_future_wait_for (f, 5.) == 0,
+        "kill_targeted: targeted kill RPC completed");
+    flux_future_destroy (f);
+
+    /* Pump until rank 1 completes; ranks 0 and 2 remain active. */
+    while (bgexec_complete (bg) < 1)
+        flux_reactor_run (r, FLUX_REACTOR_ONCE);
+    task = bgexec_get_task (bg, 1);
+    ok (task != NULL && bgexec_task_signaled (task) == SIGTERM,
+        "kill_targeted: rank 1 terminated by SIGTERM (got %d)",
+        task ? bgexec_task_signaled (task) : -1);
+    ok (bgexec_active_count (bg) == 2,
+        "kill_targeted: ranks 0 and 2 still active (got %d)",
+        bgexec_active_count (bg));
+
+    /* Clean up the survivors. */
+    f = bgexec_kill (bg, NULL, SIGKILL);
+    if (f) {
+        flux_future_wait_for (f, 5.);
+        flux_future_destroy (f);
+    }
+    flux_reactor_run (r, 0);
+    idset_destroy (target);
+    bgexec_destroy (bg);
+}
+
+/* Partial recovery: one prior process is present, one is missing.  The
+ * present rank recovers status; the missing rank surfaces cb_on_error.  Both
+ * count toward completion.
+ */
+static void test_recover_partial (flux_t *h)
+{
+    char *av[] = { "true", NULL };
+    struct scorecard sc;
+    struct bgexec *bg;
+    struct bgexec_task *t0, *t1;
+
+    /* Only rank 0 has a prior incarnation; rank 1 does not. */
+    prior_start (h, 0, av, ARRAY_SIZE (av) - 1);
+
+    bg = setup (h, &sc, 2, av, ARRAY_SIZE (av) - 1);
+    ok (bgexec_wait (h, bg) == 0,
+        "recover_partial: bgexec_wait works");
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
+        "recover_partial: reactor ran to completion");
+    ok (sc.errors == 1,
+        "recover_partial: one rank surfaced cb_on_error (got %d)", sc.errors);
+    ok (sc.last_error_rank == 1,
+        "recover_partial: error was for the missing rank 1 (got %d)",
+        sc.last_error_rank);
+    /* Rank 0 recovered a real (zero) status; rank 1 carries a wait error. */
+    t0 = bgexec_get_task (bg, 0);
+    t1 = bgexec_get_task (bg, 1);
+    ok (t0 != NULL && bgexec_task_status (t0) == 0,
+        "recover_partial: rank 0 recovered exit status 0");
+    ok (t1 != NULL && bgexec_task_errnum (t1) != 0,
+        "recover_partial: rank 1 carries a wait error (errno %d)",
+        t1 ? bgexec_task_errnum (t1) : 0);
+    ok (t1 != NULL && bgexec_task_errmsg (t1) != NULL,
+        "recover_partial: rank 1 carries a wait error string (got '%s')",
+        (t1 && bgexec_task_errmsg (t1)) ? bgexec_task_errmsg (t1) : "(null)");
+    ok (sc.cb_on_complete == 1,
+        "recover_partial: cb_on_complete fired");
+    ok (bgexec_complete (bg) == 2,
+        "recover_partial: both tasks complete (got %d)",
+        bgexec_complete (bg));
+    bgexec_destroy (bg);
+}
+
+/* Accessors: bgexec_service_name, bgexec_set_max_per_loop (including the
+ * EINVAL-on-0 guard), and bgexec_active_ranks (the idset of active ranks,
+ * which shrinks as ranks are killed and collected).
+ */
+static void test_accessors (flux_t *h)
+{
+    char *av[] = { "sleep", "30", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 3, av, ARRAY_SIZE (av) - 1);
+    flux_reactor_t *r = flux_get_reactor (h);
+    struct idset *active;
+    struct idset *target;
+    flux_future_t *f;
+
+    ok (streq (bgexec_service_name (bg), SERVER_NAME),
+        "accessors: bgexec_service_name returns the service name (got '%s')",
+        bgexec_service_name (bg));
+
+    /* set_max_per_loop: 0 is rejected, -1 (no max) and a positive value ok. */
+    ok (bgexec_set_max_per_loop (bg, 0) < 0 && errno == EINVAL,
+        "accessors: bgexec_set_max_per_loop (0) fails with EINVAL");
+    ok (bgexec_set_max_per_loop (bg, -1) == 0,
+        "accessors: bgexec_set_max_per_loop (-1) works");
+    ok (bgexec_set_max_per_loop (bg, 2) == 0,
+        "accessors: bgexec_set_max_per_loop (2) works");
+
+    ok (bgexec_start (h, bg) == 0,
+        "accessors: bgexec_start works");
+    while (sc.cb_on_start == 0)
+        flux_reactor_run (r, FLUX_REACTOR_ONCE);
+
+    /* All three ranks are active. */
+    active = bgexec_active_ranks (bg);
+    ok (active != NULL && idset_count (active) == 3
+        && idset_test (active, 0)
+        && idset_test (active, 1)
+        && idset_test (active, 2),
+        "accessors: active_ranks is {0,1,2} after start (count %d)",
+        active ? (int)idset_count (active) : -1);
+    idset_destroy (active);
+
+    /* Kill rank 1 and collect it; active_ranks drops to {0,2}. */
+    if (!(target = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        BAIL_OUT ("idset_create failed");
+    idset_set (target, 1);
+    f = bgexec_kill (bg, target, SIGTERM);
+    ok (f != NULL && flux_future_wait_for (f, 5.) == 0,
+        "accessors: targeted kill of rank 1 completed");
+    flux_future_destroy (f);
+    while (bgexec_complete (bg) < 1)
+        flux_reactor_run (r, FLUX_REACTOR_ONCE);
+
+    active = bgexec_active_ranks (bg);
+    ok (active != NULL && idset_count (active) == 2
+        && idset_test (active, 0)
+        && !idset_test (active, 1)
+        && idset_test (active, 2),
+        "accessors: active_ranks is {0,2} after rank 1 exits (count %d)",
+        active ? (int)idset_count (active) : -1);
+    idset_destroy (active);
+
+    /* Clean up the survivors. */
+    f = bgexec_kill (bg, NULL, SIGKILL);
+    if (f) {
+        flux_future_wait_for (f, 5.);
+        flux_future_destroy (f);
+    }
+    flux_reactor_run (r, 0);
+    idset_destroy (target);
+    bgexec_destroy (bg);
+}
+
+/* push_cmd validation (empty set, overlapping ranks) and the once-only
+ * start/wait guards.
+ */
+static void test_push_and_start_guards (flux_t *h)
+{
+    char *av[] = { "true", NULL };
+    struct scorecard sc;
+    struct bgexec *bg;
+    struct idset *ranks;
+    flux_cmd_t *cmd = NULL;
+
+    memset (&sc, 0, sizeof (sc));
+    if (!(bg = bgexec_create (&test_ops, SERVER_NAME, TEST_JOBID, "shell",
+                              &sc)))
+        BAIL_OUT ("bgexec_create failed");
+    if (!(ranks = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || !(cmd = flux_cmd_create (ARRAY_SIZE (av) - 1, av, environ)))
+        BAIL_OUT ("setup failed");
+
+    /* Empty rank set is rejected. */
+    ok (bgexec_push_cmd (bg, ranks, cmd) < 0 && errno == EINVAL,
+        "push_guards: empty rank set fails with EINVAL");
+
+    /* Push ranks [0-2], then a command overlapping rank 2 is rejected and
+     * the object is left unchanged (total stays 3).
+     */
+    idset_range_set (ranks, 0, 2);
+    ok (bgexec_push_cmd (bg, ranks, cmd) == 0,
+        "push_guards: push of ranks [0-2] works");
+    ok (bgexec_total (bg) == 3,
+        "push_guards: total is 3 (got %d)", bgexec_total (bg));
+    idset_range_clear (ranks, 0, INT_MAX);
+    idset_range_set (ranks, 2, 4);
+    ok (bgexec_push_cmd (bg, ranks, cmd) < 0 && errno == EEXIST,
+        "push_guards: overlapping rank push fails with EEXIST");
+    ok (bgexec_total (bg) == 3,
+        "push_guards: total unchanged after rejected push (got %d)",
+        bgexec_total (bg));
+
+    /* A disjoint push still works. */
+    idset_range_clear (ranks, 0, INT_MAX);
+    idset_range_set (ranks, 3, 4);
+    ok (bgexec_push_cmd (bg, ranks, cmd) == 0,
+        "push_guards: disjoint push of ranks [3-4] works");
+    ok (bgexec_total (bg) == 5,
+        "push_guards: total is 5 (got %d)", bgexec_total (bg));
+
+    /* Start once; a second start (or a wait) fails with EINVAL. */
+    ok (bgexec_start (h, bg) == 0,
+        "push_guards: first bgexec_start works");
+    ok (bgexec_start (h, bg) < 0 && errno == EINVAL,
+        "push_guards: second bgexec_start fails with EINVAL");
+    ok (bgexec_wait (h, bg) < 0 && errno == EINVAL,
+        "push_guards: bgexec_wait after start fails with EINVAL");
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
+        "push_guards: reactor ran to completion");
+
+    flux_cmd_destroy (cmd);
+    idset_destroy (ranks);
+    bgexec_destroy (bg);
+}
+
+/* aux_set/aux_get round-trip and EINVAL guards on NULL bgexec. */
+static void test_aux_and_guards (flux_t *h)
+{
+    char *av[] = { "true", NULL };
+    struct scorecard sc;
+    struct bgexec *bg = setup (h, &sc, 1, av, ARRAY_SIZE (av) - 1);
+    int val = 42;
+
+    ok (bgexec_aux_set (bg, "key", &val, NULL) == 0,
+        "aux: bgexec_aux_set works");
+    ok (bgexec_aux_get (bg, "key") == &val,
+        "aux: bgexec_aux_get returns the stored value");
+
+    /* NULL-bgexec guards. */
+    ok (bgexec_aux_set (NULL, "k", &val, NULL) < 0 && errno == EINVAL,
+        "guards: bgexec_aux_set (NULL) fails with EINVAL");
+    ok (bgexec_aux_get (NULL, "k") == NULL,
+        "guards: bgexec_aux_get (NULL) returns NULL");
+    ok (bgexec_start (h, NULL) < 0 && errno == EINVAL,
+        "guards: bgexec_start (NULL) fails with EINVAL");
+    ok (bgexec_wait (h, NULL) < 0 && errno == EINVAL,
+        "guards: bgexec_wait (NULL) fails with EINVAL");
+    ok (bgexec_cancel (NULL) < 0 && errno == EINVAL,
+        "guards: bgexec_cancel (NULL) fails with EINVAL");
+    ok (bgexec_kill (NULL, NULL, SIGTERM) == NULL && errno == EINVAL,
+        "guards: bgexec_kill (NULL) fails with EINVAL");
+    ok (bgexec_push_cmd (NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "guards: bgexec_push_cmd (NULL) fails with EINVAL");
+    ok (bgexec_get_task (bg, -1) == NULL && errno == EINVAL,
+        "guards: bgexec_get_task (rank<0) fails with EINVAL");
+    ok (bgexec_get_task (bg, 99) == NULL && errno == ENOENT,
+        "guards: bgexec_get_task (unknown rank) fails with ENOENT");
+    bgexec_destroy (bg);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+
+    plan (NO_PLAN);
+
+    signal (SIGPIPE, SIG_IGN);
+    h = rcmdsrv_create (SERVER_NAME);
+
+    diag ("test_basic");
+    test_basic (h);
+    diag ("test_nonzero");
+    test_nonzero (h);
+    diag ("test_launch_failure");
+    test_launch_failure (h);
+    diag ("test_mixed");
+    test_mixed (h);
+    diag ("test_output");
+    test_output (h);
+    diag ("test_kill");
+    test_kill (h);
+    diag ("test_recover_wait");
+    test_recover_wait (h);
+    diag ("test_recover_missing");
+    test_recover_missing (h);
+    diag ("test_recover_partial");
+    test_recover_partial (h);
+    diag ("test_cancel_before_start");
+    test_cancel_before_start (h);
+    diag ("test_cancel_after_start");
+    test_cancel_after_start (h);
+    diag ("test_cancel_then_exit");
+    test_cancel_then_exit (h);
+    diag ("test_exit_batching");
+    test_exit_batching (h);
+    diag ("test_kill_targeted");
+    test_kill_targeted (h);
+    diag ("test_accessors");
+    test_accessors (h);
+    diag ("test_push_and_start_guards");
+    test_push_and_start_guards (h);
+    diag ("test_aux_and_guards");
+    test_aux_and_guards (h);
+
+    test_server_stop (h);
+    flux_close (h);
+
+    done_testing ();
+    return 0;
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -30,7 +30,8 @@ libjob_exec_la_SOURCES = \
 	rset.c \
 	rset.h \
 	testexec.c \
-	bulkexec.c
+	bulkexec.c \
+	bgexec.c
 libjob_exec_la_LIBADD = \
 	$(top_builddir)/src/common/librlist/librlist.la
 

--- a/src/modules/job-exec/bgexec.c
+++ b/src/modules/job-exec/bgexec.c
@@ -13,15 +13,9 @@
  * DESCRIPTION
  *
  * A peer of the bulk-exec implementation (exec.c) that launches the job
- * shells using the libsubprocess bgexec abstraction (flux_rexec_bg(3) +
- * flux_rexec_wait(3)) rather than streaming flux_rexec_ex(3).  Selected by
- * setting the exec.method config key to "bgexec".
- *
- * The start and status-collection phases are decoupled so that a wait may
- * be re-issued after a job-exec restart, which is the property WARMSTART
- * requires.  Reattach to shells launched by a previous incarnation is not
- * yet wired up here (it needs command reconstruction from KVS); this
- * implementation drives the normal launch path only.
+ * shells using the libsubprocess bgexec abstraction and supports reattach.
+ * Selected by setting the exec.method config key to "bgexec" or loading
+ * job-exec with the method=bgexec module option.
  *
  * TEST CONFIGURATION
  *
@@ -56,14 +50,19 @@ struct bgexec_ctx {
     const char *mock_exception;   /* fake exception */
     const char *sdexec_test_expected_cpus; /* override for post-start check */
 
-    /*  Shells enter a sequence of barriers during startup.  Only the first
-     *  is timed (with first_barrier_timeout); on completion the current
+    /*  Shells enter a sequence of two barriers during startup: the first
+     *  after initialization, the second after tasks have started.  Only the
+     *  first is timed (with first_barrier_timeout); on completion the current
      *  barrier is destroyed and a fresh untimed one is created for the next.
-     *  first_barrier_done records that the first barrier has completed.
+     *  first_barrier_done and second_barrier_done record their completion.
+     *  The RFC 50 recoverable event is posted once the second barrier
+     *  completes, since barrier state cannot be reconstructed on reattach
+     *  and only then are all shells known to be past the startup sequence.
      */
     struct barrier *barrier;
     double first_barrier_timeout;
     bool first_barrier_done;
+    bool second_barrier_done;
 
     /*  Set to true if one shell terminates before the first barrier *and*
      *  the first exception.  This allows other ranks to be drained when they
@@ -140,7 +139,21 @@ static const char *bgexec_mock_exception (struct bgexec *bg)
 static void start_cb (struct bgexec *bg, void *arg)
 {
     struct jobinfo *job = arg;
-    jobinfo_started (job);
+    if (job->reattach)
+        jobinfo_reattached (job);
+    else {
+        jobinfo_started (job);
+        /*  The shells are launched WAITABLE and their status can be
+         *  recovered by re-issuing the wait by label.  A single-shell job
+         *  runs no barriers and has no barrier state to lose across a
+         *  restart, so post the RFC 50 recoverable event now.  A multi-shell
+         *  job defers this to second-barrier completion (see
+         *  bgexec_barrier_enter_op) because its barrier state is not
+         *  reconstructible on reattach.
+         */
+        if (bgexec_total (bg) == 1)
+            jobinfo_emit_event_pack_nowait (job, "recoverable", NULL);
+    }
 }
 
 static void complete_cb (struct bgexec *bg, void *arg)
@@ -577,24 +590,43 @@ static void bgexec_check_cb (flux_reactor_t *r,
     }
 }
 
+/*  Reattach to shells launched before a restart: the per-rank commands were
+ *  reconstructed by bgexec_impl_init() from job->R (which yields the same
+ *  deterministic per-rank labels as the original start), so recover status by
+ *  re-issuing the wait for every rank by label rather than launching a fresh
+ *  set of shells.  The processes survive because the rexec server retains
+ *  waitable exited shells across a client disconnect.  The exec eventlog is
+ *  not consulted: the label is reconstructible from the jobid and R alone.
+ */
+static int bgexec_impl_reattach (struct jobinfo *job, json_t *eventlog)
+{
+    struct bgexec *bg = job->data;
+    struct bgexec_ctx *ctx;
+
+    if (!bg || !(ctx = bgexec_aux_get (bg, "ctx"))) {
+        jobinfo_fatal_error (job, errno, "failed to get bgexec ctx");
+        return -1;
+    }
+
+    /*  Reattach is gated on the RFC 50 recoverable event, which is only
+     *  posted once all shells are past the startup barrier sequence (the
+     *  second barrier has completed).  The reattached shells will not
+     *  re-enter that sequence, so mark both barriers done: otherwise
+     *  exit_cb() would misread a normally-exiting shell as having terminated
+     *  before the first barrier and raise a spurious exception (draining
+     *  ranks under the IMP).
+     */
+    ctx->first_barrier_done = true;
+    ctx->second_barrier_done = true;
+    return bgexec_wait (job->h, bg);
+}
+
 static int bgexec_impl_start (struct jobinfo *job)
 {
     struct bgexec *bg = job->data;
 
     if (!bg || !bgexec_aux_get (bg, "ctx")) {
         jobinfo_fatal_error (job, errno, "failed to get bgexec ctx");
-        return -1;
-    }
-
-    /*  Reattach to shells launched before a restart is not yet implemented
-     *  for bgexec: rebuilding the per-rank commands from KVS to re-issue the
-     *  wait is a follow-on.  Fail the job explicitly rather than launching a
-     *  fresh set of shells for a job believed to be already running.
-     */
-    if (job->reattach) {
-        jobinfo_fatal_error (job,
-                             ENOSYS,
-                             "reattach to running job is not implemented");
         return -1;
     }
 
@@ -723,7 +755,16 @@ static int bgexec_barrier_enter_op (struct jobinfo *job, const flux_msg_t *msg)
      *  keeps barrier.c ignorant of the barrier sequence.
      */
     barrier_destroy (ctx->barrier);
-    ctx->first_barrier_done = true;
+    if (!ctx->first_barrier_done)
+        ctx->first_barrier_done = true;
+    else if (!ctx->second_barrier_done) {
+        ctx->second_barrier_done = true;
+        /*  All shells are past the startup barrier sequence, so their state
+         *  is now recoverable by re-issuing the wait by label: post the
+         *  RFC 50 recoverable event to permit a reattach after a restart.
+         */
+        jobinfo_emit_event_pack_nowait (job, "recoverable", NULL);
+    }
     if (!(ctx->barrier = barrier_create (job,
                                          resource_set_ranks (job->R),
                                          0.,
@@ -738,6 +779,7 @@ struct exec_implementation bgexec = {
     .init =     bgexec_impl_init,
     .exit =     bgexec_impl_exit,
     .start =    bgexec_impl_start,
+    .reattach = bgexec_impl_reattach,
     .kill =     bgexec_impl_kill,
     .cancel =   bgexec_impl_cancel,
     .stats =    bgexec_impl_stats,

--- a/src/modules/job-exec/bgexec.c
+++ b/src/modules/job-exec/bgexec.c
@@ -1,0 +1,749 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* bgexec - background/waitable exec implementation
+ *
+ * DESCRIPTION
+ *
+ * A peer of the bulk-exec implementation (exec.c) that launches the job
+ * shells using the libsubprocess bgexec abstraction (flux_rexec_bg(3) +
+ * flux_rexec_wait(3)) rather than streaming flux_rexec_ex(3).  Selected by
+ * setting the exec.method config key to "bgexec".
+ *
+ * The start and status-collection phases are decoupled so that a wait may
+ * be re-issued after a job-exec restart, which is the property WARMSTART
+ * requires.  Reattach to shells launched by a previous incarnation is not
+ * yet wired up here (it needs command reconstruction from KVS); this
+ * implementation drives the normal launch path only.
+ *
+ * TEST CONFIGURATION
+ *
+ * Like bulk-exec, this reads a per-implementation object from the jobspec,
+ * attributes.system.exec.bgexec, for "mock_exception", "barrier-timeout",
+ * and "sdexec-test-expected-cpus".
+ */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <unistd.h>
+#include <string.h>
+
+#include "src/common/libjob/idf58.h"
+#include "ccan/str/str.h"
+#include "src/common/libutil/basename.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libsubprocess/bgexec.h"
+
+#include "job-exec.h"
+#include "exec_config.h"
+#include "exec_cmd.h"
+#include "rset.h"
+#include "barrier.h"
+
+struct bgexec_ctx {
+    struct jobinfo *job;
+
+    const char *mock_exception;   /* fake exception */
+    const char *sdexec_test_expected_cpus; /* override for post-start check */
+
+    /*  Shells enter a sequence of barriers during startup.  Only the first
+     *  is timed (with first_barrier_timeout); on completion the current
+     *  barrier is destroyed and a fresh untimed one is created for the next.
+     *  first_barrier_done records that the first barrier has completed.
+     */
+    struct barrier *barrier;
+    double first_barrier_timeout;
+    bool first_barrier_done;
+
+    /*  Set to true if one shell terminates before the first barrier *and*
+     *  the first exception.  This allows other ranks to be drained when they
+     *  exit too.
+     */
+    bool terminated_before_first_barrier;
+};
+
+static void bgexec_ctx_destroy (struct bgexec_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        barrier_destroy (ctx->barrier);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct bgexec_ctx *bgexec_ctx_create (struct jobinfo *job,
+                                             const struct idset *ranks,
+                                             flux_error_t *errp)
+{
+    json_error_t error;
+    struct bgexec_ctx *ctx = NULL;
+
+    if (!(ctx = calloc (1, sizeof (*ctx)))) {
+        errprintf (errp, "%s", strerror (errno));
+        goto error;
+    }
+
+    ctx->job = job;
+    ctx->first_barrier_timeout = config_get_default_barrier_timeout ();
+
+    if (json_unpack_ex (job->jobspec,
+                        &error,
+                        0,
+                        "{s?{s?{s?{s?{s?s s?s s?F !}}}}}",
+                        "attributes",
+                          "system",
+                            "exec",
+                              "bgexec",
+                                "mock_exception", &ctx->mock_exception,
+                                "sdexec-test-expected-cpus",
+                                    &ctx->sdexec_test_expected_cpus,
+                                "barrier-timeout",
+                                    &ctx->first_barrier_timeout) < 0) {
+        errprintf (errp,
+                   "failed to unpack system.exec.bgexec for %s: %s",
+                    idf58 (job->id),
+                    error.text);
+        goto error;
+    }
+
+    if (!(ctx->barrier = barrier_create (job,
+                                         ranks,
+                                         ctx->first_barrier_timeout,
+                                         errp)))
+        goto error;
+
+    return ctx;
+error:
+    bgexec_ctx_destroy (ctx);
+    return NULL;
+}
+
+static const char *bgexec_mock_exception (struct bgexec *bg)
+{
+    struct bgexec_ctx *ctx = bgexec_aux_get (bg, "ctx");
+    if (!ctx || !ctx->mock_exception)
+        return "none";
+    return ctx->mock_exception;
+}
+
+static void start_cb (struct bgexec *bg, void *arg)
+{
+    struct jobinfo *job = arg;
+    jobinfo_started (job);
+}
+
+static void complete_cb (struct bgexec *bg, void *arg)
+{
+    struct jobinfo *job = arg;
+    jobinfo_tasks_complete (job,
+                            resource_set_ranks (job->R),
+                            bgexec_rc (bg));
+}
+
+static void output_cb (struct bgexec *bg,
+                       struct bgexec_task *task,
+                       const char *stream,
+                       const char *data,
+                       int len,
+                       void *arg)
+{
+    struct jobinfo *job = arg;
+    const char *cmd = flux_cmd_arg (bgexec_task_cmd (task), 0);
+
+    jobinfo_log_output (job,
+                        bgexec_task_rank (task),
+                        basename_simple (cmd),
+                        stream,
+                        data,
+                        len);
+}
+
+static void error_cb (struct bgexec *bg, struct bgexec_task *task, void *arg)
+{
+    struct jobinfo *job = arg;
+    flux_cmd_t *cmd;
+    int errnum;
+    int rank;
+    int shell_rank;
+    const char *hostname;
+    const char *errmsg;
+
+    /*  A NULL task signals a whole-object launch-pacing failure that is not
+     *  tied to any one rank.  Raise a fatal error directly rather than
+     *  deriving a bogus rank/host from the absent task.
+     */
+    if (!task) {
+        jobinfo_fatal_error (job, 0, "job shell exec error");
+        return;
+    }
+
+    cmd = bgexec_task_cmd (task);
+    errnum = bgexec_task_errnum (task);
+    rank = bgexec_task_rank (task);
+    shell_rank = resource_set_rank_index (job->R, rank);
+    hostname = flux_get_hostbyrank (job->h, rank);
+    errmsg = bgexec_task_errmsg (task);
+
+    /*  cmd may be NULL here if exec implementation failed to
+     *   create flux_cmd_t
+     */
+    if (cmd) {
+        if (errnum == EDEADLK) {
+            /*  EDEADLK from sdexec means that unkillable processes were left
+             *   on the node and it must be drained.  A "finished" response
+             *   will not have been received, so after draining, treat this
+             *   like EHOSTUNREACH.
+             */
+            char ranks[16];
+            snprintf (ranks, sizeof (ranks), "%d", rank);
+            (void) jobinfo_drain_ranks (job,
+                                        ranks,
+                                        "sdexec reports %s for job %s",
+                                        errmsg,
+                                        idf58 (job->id));
+            bool critical = jobinfo_is_critical_rank (job, shell_rank);
+
+            /*  Always notify rank 0 shell of a lost shell.
+             */
+            jobinfo_lost_shell (job,
+                                critical,
+                                shell_rank,
+                                "shell exited with unkillable processes"
+                                " on %s (shell rank %d)",
+                                hostname,
+                                shell_rank);
+
+            /*  Raise a fatal error and terminate job immediately if
+             *  the lost shell was critical.
+             */
+            if (critical)
+                jobinfo_fatal_error (job,
+                                     0,
+                                     "shell exited with unkillable processes"
+                                     " on %s (rank %d)",
+                                     hostname,
+                                     rank);
+        }
+        else if (errnum == EHOSTUNREACH) {
+            bool critical = jobinfo_is_critical_rank (job, shell_rank);
+
+            /*  Always notify rank 0 shell of a lost shell.
+             */
+            jobinfo_lost_shell (job,
+                                critical,
+                                shell_rank,
+                                "node failure on %s (shell rank %d)",
+                                hostname,
+                                shell_rank);
+
+            /*  Raise a fatal error and terminate job immediately if
+             *  the lost shell was critical.
+             */
+            if (critical)
+                jobinfo_fatal_error (job,
+                                     0,
+                                     "node failure on %s (rank %d)",
+                                     hostname,
+                                     rank);
+        }
+        else if (errnum == EIO) {
+            /*  EIO from sdexec indicates a post-start constraint check failed
+             *  (e.g. AllowedCPUs not enforced by the kernel).  Drain the rank
+             *  since the node is likely misconfigured and all subsequent jobs
+             *  would also run unconstrained.
+             */
+            char ranks[16];
+            snprintf (ranks, sizeof (ranks), "%d", rank);
+            (void) jobinfo_drain_ranks (job,
+                                        ranks,
+                                        "sdexec constraint check failed "
+                                        "on %s for job %s: %s",
+                                        hostname,
+                                        idf58 (job->id),
+                                        errmsg);
+            jobinfo_fatal_error (job,
+                                 0,
+                                 "sdexec constraint check failed "
+                                 "on %s (rank %d): %s",
+                                 hostname,
+                                 rank,
+                                 errmsg);
+        }
+        else if (errnum == ENOSYS) {
+            jobinfo_fatal_error (job,
+                                 0,
+                                 "%s service is not loaded on %s (rank %d)",
+                                 bgexec_service_name (bg),
+                                 hostname,
+                                 rank);
+        }
+        else {
+            jobinfo_fatal_error (job,
+                                 0,
+                                 "%s on broker %s (rank %d): %s",
+                                 "job shell exec error",
+                                 hostname,
+                                 rank,
+                                 errmsg ? errmsg : strerror (errnum));
+        }
+    }
+    else
+        jobinfo_fatal_error (job,
+                             errnum,
+                             "job shell exec error on %s (rank %d)",
+                             hostname,
+                             rank);
+}
+
+static void exit_cb (struct bgexec *bg,
+                     void *arg,
+                     const struct idset *ranks)
+{
+    struct jobinfo *job = arg;
+    struct bgexec_ctx *ctx;
+
+    /*  Post shell-exit event if the leader shell (shell rank 0) is in the
+     *  set of exiting ranks.  This must be done before the single-shell
+     *  early-return so the event is posted for single-shell jobs too.
+     *  jobinfo_post_shell_exit() is a no-op after the first call.
+     */
+    {
+        unsigned int leader_rank = resource_set_nth_rank (job->R, 0);
+        if (idset_test (ranks, leader_rank)) {
+            struct bgexec_task *task = bgexec_get_task (bg, leader_rank);
+            int wait_status = task ? bgexec_task_status (task) : 0;
+            jobinfo_post_shell_exit (job, leader_rank, wait_status);
+        }
+    }
+
+    /*  Nothing more to do here if the job consists of only one shell.
+     *  (or, if we fail to get ctx object (highly unlikely))
+     */
+    if (bgexec_total (bg) == 1
+        || !(ctx = bgexec_aux_get (bg, "ctx")))
+        return;
+
+    /*  Check if a shell is exiting before the first barrier, in which
+     *   case we raise a job exception because the shell or IMP may not
+     *   have had a chance to do so.
+     */
+    if (!ctx->first_barrier_done
+        && (!job->exception_in_progress
+            || ctx->terminated_before_first_barrier)) {
+        char *ids = idset_encode (ranks, IDSET_FLAG_RANGE);
+        char *hosts = flux_hostmap_lookup (job->h, ids, NULL);
+        jobinfo_fatal_error (job, 0,
+                             "%s (rank%s %s) terminated before first barrier",
+                              hosts ? hosts : "(unknown)",
+                              idset_count (ranks) > 1 ? "s" : "",
+                              ids ? ids : "(unknown)");
+
+        /* Set the terminated-before-first-barrier flag. This will allow
+         * other terminating tasks to also raise their own exception and
+         * possibly drain affected ranks, even though exception_in_progress
+         * is now true.
+         */
+        ctx->terminated_before_first_barrier = true;
+
+        /* If this job was run under the IMP, drain the affected ranks since
+         * this could indicate an unrecoverable node issue (like missing
+         * or incorrect MUNGE key)
+         */
+        if (job->multiuser
+            && barrier_drain_pending (ctx->barrier, ranks) < 0)
+            flux_log_error (job->h,
+                            "failed to drain %s (rank%s %s) for job %s",
+                            hosts ? hosts : "(unknown)",
+                            idset_count (ranks) > 1 ? "s" : "",
+                            ids ? ids : "(unknown)",
+                            idf58 (job->id));
+        free (ids);
+        free (hosts);
+    }
+
+    /*  Notify the barrier that shells have exited: terminates any barrier in
+     *   progress with error (releasing waiting shells so they exit rather
+     *   than being killed) and causes later barrier-enter requests to be
+     *   rejected.
+     */
+    barrier_notify_shell_exit (ctx->barrier);
+
+    /*  If a shell exits due to signal report the shell as lost to
+     *  the leader shell. This avoids potential hangs in the leader
+     *  shell if it is waiting for data from job shells that did not
+     *  exit cleanly.
+     */
+    unsigned int rank = idset_first (ranks);
+    while (rank != IDSET_INVALID_ID) {
+        struct bgexec_task *task = bgexec_get_task (bg, rank);
+        int signo = task ? bgexec_task_signaled (task) : 0;
+        int shell_rank = resource_set_rank_index (job->R, rank);
+        if (task && signo > 0) {
+            if (shell_rank != 0)
+                jobinfo_lost_shell (job,
+                                    jobinfo_is_critical_rank (job, shell_rank),
+                                    shell_rank,
+                                    "shell rank %d (on %s): %s",
+                                    shell_rank,
+                                    flux_get_hostbyrank (job->h, rank),
+                                    strsignal (signo));
+            else {
+                /*  Job can't continue without the leader shell, which has
+                 *  terminated unexpectedly. Cancel the job now to avoid
+                 *  a potential hang.
+                 */
+                jobinfo_fatal_error (job,
+                                     0,
+                                     "shell rank 0 (on %s): %s",
+                                     flux_get_hostbyrank (job->h, rank),
+                                     strsignal (signo));
+            }
+        }
+        rank = idset_next (ranks, rank);
+    }
+}
+
+static int get_exec_service (const char **service, flux_error_t *error)
+{
+    const char *s = config_get_exec_service ();
+
+    if (!streq (s, "rexec") && !streq (s, "sdexec")) {
+        errprintf (error, "unsupported exec.service value: %s", s);
+        errno = EINVAL;
+        return -1;
+    }
+    *service = s;
+    return 0;
+}
+
+static struct bgexec_ops bgexec_ops = {
+    .on_start =     start_cb,
+    .on_exit =      exit_cb,
+    .on_complete =  complete_cb,
+    .on_output =    output_cb,
+    .on_error =     error_cb
+};
+
+/* Push one bgexec cmd per rank, each with rank-specific sdexec options.
+ * Returns 0 on success, -1 on error.
+ */
+static int sdexec_push_per_rank_cmds (struct bgexec *bg,
+                                      const struct idset *ranks,
+                                      flux_cmd_t *cmd)
+{
+    struct bgexec_ctx *ctx = bgexec_aux_get (bg, "ctx");
+    unsigned int r = idset_first (ranks);
+
+    if (!ctx)
+        return -1;
+    while (r != IDSET_INVALID_ID) {
+        flux_cmd_t *rcmd = NULL;
+        struct idset *rset = NULL;
+        int rc;
+
+        if (!(rcmd = flux_cmd_copy (cmd))
+            || !(rset = idset_create (0, IDSET_FLAG_AUTOGROW))
+            || idset_set (rset, r) < 0
+            || job_shell_cmd_set_rank_opts (ctx->job,
+                                            rcmd,
+                                            r,
+                                            ctx->sdexec_test_expected_cpus)
+               < 0) {
+            flux_cmd_destroy (rcmd);
+            idset_destroy (rset);
+            return -1;
+        }
+        rc = bgexec_push_cmd (bg, rset, rcmd);
+        flux_cmd_destroy (rcmd);
+        idset_destroy (rset);
+        if (rc < 0)
+            return -1;
+        r = idset_next (ranks, r);
+    }
+    return 0;
+}
+
+static int bgexec_impl_init (struct jobinfo *job)
+{
+    flux_cmd_t *cmd = NULL;
+    struct bgexec_ctx *ctx = NULL;
+    struct bgexec *bg = NULL;
+    const struct idset *ranks = NULL;
+    const char *service;
+    flux_error_t error;
+
+    if (job->multiuser && !config_get_imp_path ()) {
+        flux_log (job->h,
+                  LOG_ERR,
+                  "unable run multiuser job with no IMP configured!");
+        goto err;
+    }
+
+    if (!(ranks = resource_set_ranks (job->R))) {
+        flux_log_error (job->h, "bgexec_init: resource_set_ranks");
+        goto err;
+    }
+    if (get_exec_service (&service, &error) < 0) {
+        flux_log (job->h, LOG_ERR, "bgexec_init: %s" , error.text);
+        goto err;
+    }
+    /* The sdexec service is not yet supported with this backend (per-rank
+     * unit setup and reattach are unimplemented for it).  Reject it here
+     * rather than proceeding to a partially-wired sdexec launch below.
+     */
+    if (streq (service, "sdexec")) {
+        flux_log (job->h,
+                  LOG_ERR,
+                  "bgexec_init: exec.service=sdexec is not supported with"
+                  " method=bgexec");
+        errno = ENOTSUP;
+        goto err;
+    }
+    if (!(bg = bgexec_create (&bgexec_ops,
+                              service,
+                              job->id,
+                              job->multiuser ? "imp-shell" : "shell",
+                              job))) {
+        flux_log_error (job->h, "bgexec_init: bgexec_create");
+        goto err;
+    }
+    if (!(ctx = bgexec_ctx_create (job, ranks, &error))) {
+        flux_log (job->h, LOG_ERR, "bgexec_ctx_create: %s", error.text);
+        goto err;
+    }
+    if (bgexec_aux_set (bg, "ctx", ctx,
+                        (flux_free_f) bgexec_ctx_destroy) < 0) {
+        bgexec_ctx_destroy (ctx);
+        flux_log_error (job->h, "bgexec_init: bgexec_aux_set");
+        goto err;
+    }
+    /* ctx is now owned by bg (freed via bgexec_destroy in the err: path and
+     * on normal teardown); the local pointer is borrowed from here on.
+     */
+    if (!(cmd = job_shell_cmd_create (job, service)))
+        goto err;
+    /* When per-rank sdexec options are needed, push one cmd per rank so
+     * each transient unit can be configured for its own allocation.
+     * Otherwise push a single command covering all ranks (the common case).
+     */
+    if (streq (service, "sdexec")
+        && job_shell_needs_per_rank_cmds (ctx->sdexec_test_expected_cpus)) {
+        if (sdexec_push_per_rank_cmds (bg, ranks, cmd) < 0) {
+            flux_log_error (job->h, "bgexec_init: sdexec per-rank cmd setup");
+            goto err;
+        }
+    }
+    else {
+        if (bgexec_push_cmd (bg, ranks, cmd) < 0) {
+            flux_log_error (job->h, "bgexec_init: bgexec_push_cmd");
+            goto err;
+        }
+    }
+    flux_cmd_destroy (cmd);
+    job->data = bg;
+    return 1;
+err:
+    flux_cmd_destroy (cmd);
+    bgexec_destroy (bg);
+    return -1;
+}
+
+static void bgexec_check_cb (flux_reactor_t *r,
+                             flux_watcher_t *w,
+                             int revents,
+                             void *arg)
+{
+    struct jobinfo *job = arg;
+    struct bgexec *bg = job->data;
+    if (bgexec_started_count (bg) >= 1) {
+        jobinfo_fatal_error (job, 0, "mock starting exception generated");
+        flux_log (job->h,
+                  LOG_DEBUG,
+                  "mock exception for starting job total=%d, current=%d",
+                  bgexec_total (bg),
+                  bgexec_started_count (bg));
+        flux_watcher_destroy (w);
+    }
+}
+
+static int bgexec_impl_start (struct jobinfo *job)
+{
+    struct bgexec *bg = job->data;
+
+    if (!bg || !bgexec_aux_get (bg, "ctx")) {
+        jobinfo_fatal_error (job, errno, "failed to get bgexec ctx");
+        return -1;
+    }
+
+    /*  Reattach to shells launched before a restart is not yet implemented
+     *  for bgexec: rebuilding the per-rank commands from KVS to re-issue the
+     *  wait is a follow-on.  Fail the job explicitly rather than launching a
+     *  fresh set of shells for a job believed to be already running.
+     */
+    if (job->reattach) {
+        jobinfo_fatal_error (job,
+                             ENOSYS,
+                             "reattach to running job is not implemented");
+        return -1;
+    }
+
+    if (streq (bgexec_mock_exception (bg), "init")) {
+        /* If creating an "init" mock exception, generate it and
+         *  then return to simulate an exception that came in before
+         *  we could actually start the job
+         */
+        jobinfo_fatal_error (job, 0, "mock init exception generated");
+        return 0;
+    }
+    else if (streq (bgexec_mock_exception (bg), "starting")) {
+        /*  If we're going to mock an exception in "starting" phase, then
+         *   set up a check watcher to cancel the job when some shells have
+         *   started but (potentially) not all.
+         */
+        flux_reactor_t *r = flux_get_reactor (job->h);
+        flux_watcher_t *w = flux_check_watcher_create (r, bgexec_check_cb, job);
+        if (w)
+            flux_watcher_start (w);
+    }
+
+    return bgexec_start (job->h, bg);
+}
+
+static void bgexec_kill_cb (flux_future_t *f, void *arg)
+{
+    struct jobinfo *job = arg;
+    if (flux_future_get (f, NULL) < 0 && errno != ENOENT)
+        bgexec_kill_log_error (f, job->id);
+    jobinfo_decref (job);
+    flux_future_destroy (f);
+}
+
+static int bgexec_impl_kill (struct jobinfo *job, int signum)
+{
+    struct bgexec *bg = job->data;
+    flux_future_t *f;
+
+    if (!bg)
+        return 0;
+    if (!(f = bgexec_kill (bg, NULL, signum))) {
+        if (errno != ENOENT)
+            flux_log_error (job->h, "%s: bgexec_kill", idf58 (job->id));
+        return 0;
+    }
+
+    jobinfo_incref (job);
+    if (flux_future_then (f, 3., bgexec_kill_cb, job) < 0) {
+        flux_log_error (job->h,
+                        "%s: bgexec_kill: flux_future_then",
+                        idf58 (job->id));
+        flux_future_destroy (f);
+        return -1;
+    }
+    return 0;
+}
+
+static int bgexec_impl_cancel (struct jobinfo *job)
+{
+    struct bgexec *bg = job->data;
+    if (!bg)
+        return 0;
+    return bgexec_cancel (bg);
+}
+
+static void bgexec_impl_exit (struct jobinfo *job)
+{
+    struct bgexec *bg = job->data;
+    bgexec_destroy (bg);
+    job->data = NULL;
+}
+
+static json_t *bgexec_impl_stats (struct jobinfo *job)
+{
+    struct bgexec *bg;
+    struct idset *active_ranks;
+    char *s = NULL;
+    json_t *o;
+    int total, active;
+
+    /*  Config stats are reported once, by the bulk-exec implementation
+     *  (both implementations share exec_config).  Report per-job stats only.
+     */
+    if (!job)
+        return NULL;
+
+    bg = job->data;
+    total = bgexec_total (bg);
+    active = bgexec_active_count (bg);
+
+    if ((active_ranks = bgexec_active_ranks (bg)))
+        s = idset_encode (active_ranks, IDSET_FLAG_RANGE);
+
+    o = json_pack ("{s:i s:i s:s}",
+                   "total_shells", total,
+                   "active_shells", active,
+                   "active_ranks", s ? s : "");
+    free (s);
+    idset_destroy (active_ranks);
+    return o;
+}
+
+static struct idset *bgexec_impl_active_ranks (struct jobinfo *job)
+{
+    if (job)
+        return bgexec_active_ranks ((struct bgexec *) job->data);
+    return NULL;
+}
+
+static int bgexec_barrier_enter_op (struct jobinfo *job, const flux_msg_t *msg)
+{
+    struct bgexec *bg = job->data;
+    struct bgexec_ctx *ctx = bgexec_aux_get (bg, "ctx");
+    flux_error_t error;
+    int rc;
+
+    if (!ctx || !ctx->barrier)
+        return -1;
+    if ((rc = barrier_enter (ctx->barrier, msg)) != BARRIER_COMPLETE)
+        return rc == BARRIER_ERROR ? -1 : 0;
+
+    /*  This barrier is done and its shells have been released.  Replace it
+     *  with a fresh untimed barrier for the next one in the sequence: only
+     *  the first barrier is timed (a hung node at initialization), and this
+     *  keeps barrier.c ignorant of the barrier sequence.
+     */
+    barrier_destroy (ctx->barrier);
+    ctx->first_barrier_done = true;
+    if (!(ctx->barrier = barrier_create (job,
+                                         resource_set_ranks (job->R),
+                                         0.,
+                                         &error)))
+        jobinfo_fatal_error (job, errno, "barrier: %s", error.text);
+    return 0;
+}
+
+struct exec_implementation bgexec = {
+    .name =     "bgexec",
+    .select =   EXEC_SELECT_CONFIG,
+    .init =     bgexec_impl_init,
+    .exit =     bgexec_impl_exit,
+    .start =    bgexec_impl_start,
+    .kill =     bgexec_impl_kill,
+    .cancel =   bgexec_impl_cancel,
+    .stats =    bgexec_impl_stats,
+    .active_ranks = bgexec_impl_active_ranks,
+    .barrier_enter = bgexec_barrier_enter_op,
+};
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/bulkexec.c
+++ b/src/modules/job-exec/bulkexec.c
@@ -329,7 +329,7 @@ static void exit_cb (struct bulk_exec *exec,
         jobinfo_fatal_error (job, 0,
                              "%s (rank%s %s) terminated before first barrier",
                               hosts ? hosts : "(unknown)",
-                              idset_count (ranks) ? "s" : "",
+                              idset_count (ranks) > 1 ? "s" : "",
                               ids ? ids : "(unknown)");
 
         /* Set the terminated-before-first-barrier flag. This will allow
@@ -348,7 +348,7 @@ static void exit_cb (struct bulk_exec *exec,
             flux_log_error (job->h,
                             "failed to drain %s (rank%s %s) for job %s",
                             hosts ? hosts : "(unknown)",
-                            idset_count (ranks) ? "s" : "",
+                            idset_count (ranks) > 1 ? "s" : "",
                             ids ? ids : "(unknown)",
                             idf58 (job->id));
         free (ids);

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1270,9 +1270,7 @@ static int exec_eventlog_has_event (json_t *eventlog, const char *name)
  */
 static int jobinfo_start_execution (struct jobinfo *job, json_t *eventlog)
 {
-    if (job->reattach)
-        jobinfo_emit_event_pack_nowait (job, "re-starting", NULL);
-    else
+    if (!job->reattach)
         jobinfo_emit_event_pack_nowait (job, "starting", NULL);
     /* Set started flag before calling start/reattach method because we want
      *  to be sure to clean up properly if an exception occurs

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -119,9 +119,11 @@ static int kill_signal;
 
 extern struct exec_implementation testexec;
 extern struct exec_implementation bulkexec;
+extern struct exec_implementation bgexec;
 
 static struct exec_implementation * implementations[] = {
     &testexec,
+    &bgexec,
     &bulkexec,
     NULL
 };

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -234,6 +234,7 @@ TESTSCRIPTS = \
 	t2415-sdexec-device.t \
 	t2416-sdexec-constrain-resources.t \
 	t2417-job-exec-shell-exit.t \
+	t2418-job-exec-bgexec.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \
 	t2600-job-shell-rcalc.t \

--- a/t/t2418-job-exec-bgexec.t
+++ b/t/t2418-job-exec-bgexec.t
@@ -188,11 +188,73 @@ test_expect_success 'cancel of running job reaches clean' '
 '
 
 # ---------------------------------------------------------------------------
-# reattach is not implemented (matches bulk-exec)
+# recoverable event (RFC 50)
+#
+# A multi-node job's barrier state cannot be reconstructed on reattach, so the
+# recoverable event is posted only after the second (post-task-start) barrier
+# completes -- not when the shells are merely launched.  A job that fails
+# before that point (e.g. shells start and pass the init barrier, but the user
+# executable does not exist) must therefore NOT be marked recoverable.
 # ---------------------------------------------------------------------------
 
-# TODO: exercise the reattach=ENOSYS path once an instance-restart harness
-# for bgexec exists (cf. t3202-instance-restart-testexec.t).
+test_expect_success 'multi-node job posts recoverable after second barrier' '
+	id=$(flux submit -N2 -n2 sleep 30) &&
+	flux job wait-event -p exec -t 30 $id recoverable &&
+	flux cancel $id &&
+	flux job wait-event -t 30 $id clean
+'
+test_expect_success 'job that fails before second barrier is not recoverable' '
+	id=$(flux submit -N2 -n2 /nonexistent-executable) &&
+	flux job wait-event -t 30 $id clean &&
+	flux job wait-event -t 5 $id exception &&
+	test_must_fail flux job wait-event -p exec -t 5 $id recoverable
+'
+
+# ---------------------------------------------------------------------------
+# reattach across a module reload
+#
+# bgexec launches shells via the real rexec service, so they live in the
+# broker and survive a job-exec module reload (unlike a full instance restart,
+# which is the sdexec follow-on).  On reload the job manager re-issues the
+# start request with reattach set; bgexec recovers status by re-issuing the
+# wait for each rank by its deterministic label rather than relaunching.  This
+# mirrors the testexec reattach path in t3204.
+# ---------------------------------------------------------------------------
+
+test_expect_success 'submit long-running job under bgexec and wait for start' '
+	id=$(flux submit --flags=debug -N2 -n2 sleep 300) &&
+	flux job wait-event -t 60 $id start &&
+	flux job wait-event -p exec -t 60 $id recoverable
+'
+test_expect_success 'job is reattached rather than relaunched on reload' '
+	flux module reload job-exec method=bgexec &&
+	flux job wait-event -t 60 $id debug.exec-reattach-finish &&
+	flux job eventlog $id >reattach.out &&
+	test_debug "cat reattach.out" &&
+	grep "debug.start-lost" reattach.out &&
+	grep "debug.exec-reattach-finish" reattach.out
+'
+test_expect_success 'reattached job remains in RUN state' '
+	test $(flux jobs -no "{state}" $id) = RUN
+'
+test_expect_success 'reattached job can be canceled and cleaned up' '
+	flux cancel $id &&
+	flux job wait-event -t 60 $id clean
+'
+
+# A reattached multi-node job that exits normally (rather than being
+# canceled) must not be misread as having terminated before the first
+# barrier.  The reattach path marks both barriers done since the recoverable
+# event gate guarantees they completed in the prior incarnation.
+test_expect_success 'multi-node reattached job exits cleanly without exception' '
+	id=$(flux submit --flags=debug -N2 -n2 sleep 10) &&
+	flux job wait-event -p exec -t 60 $id recoverable &&
+	flux module reload job-exec method=bgexec &&
+	flux job wait-event -t 60 $id debug.exec-reattach-finish &&
+	flux job wait-event -t 60 $id clean &&
+	flux job status $id &&
+	test_must_fail flux job wait-event -t 5 $id exception
+'
 
 test_expect_success 'reload job-exec to defaults' '
 	flux module reload job-exec

--- a/t/t2418-job-exec-bgexec.t
+++ b/t/t2418-job-exec-bgexec.t
@@ -1,0 +1,201 @@
+#!/bin/sh
+
+test_description='Test job-exec bgexec implementation'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2 job
+
+FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
+
+# ---------------------------------------------------------------------------
+# Config: exec.method selection
+# ---------------------------------------------------------------------------
+
+test_expect_success 'default exec.method is bulk-exec' '
+	flux module reload job-exec &&
+	flux module stats job-exec \
+	    | jq -e ".method == \"bulk-exec\""
+'
+test_expect_success 'invalid exec.method fails config load' '
+	test_expect_code 1 flux config load <<-EOF
+	[exec]
+	method = "notreal"
+	EOF
+'
+test_expect_success 'exec.method=bgexec loads successfully' '
+	flux config load <<-EOF &&
+	[exec]
+	method = "bgexec"
+	EOF
+	flux module reload job-exec &&
+	flux module stats job-exec \
+	    | jq -e ".method == \"bgexec\""
+'
+test_expect_success 'reload job-exec with method=bgexec via cmdline' '
+	flux config load </dev/null &&
+	flux module reload job-exec method=bgexec &&
+	flux module stats job-exec \
+	    | jq -e ".method == \"bgexec\""
+'
+# The sdexec service is not yet supported with method=bgexec.  The
+# combination must fail the job cleanly at init rather than crash job-exec
+# (see PR #7767 review).  Restore the default config afterward so later
+# tests run under rexec.
+test_expect_success 'method=bgexec with exec.service=sdexec fails job cleanly' '
+	flux config load <<-EOF &&
+	[exec]
+	method = "bgexec"
+	service = "sdexec"
+	EOF
+	flux module reload job-exec &&
+	test_when_finished "flux config load </dev/null && \
+	    flux module reload job-exec method=bgexec" &&
+	id=$(flux submit -N1 true) &&
+	flux job wait-event -t 30 $id clean &&
+	test_must_fail flux job status $id &&
+	flux job wait-event -Ht 30 $id exception \
+	    | grep "failed to initialize implementation"
+'
+
+# ---------------------------------------------------------------------------
+# Normal execution under bgexec
+# ---------------------------------------------------------------------------
+
+test_expect_success 'single-node job runs to completion under bgexec' '
+	id=$(flux submit -N1 true) &&
+	flux job wait-event -t 30 $id clean &&
+	flux job status $id
+'
+test_expect_success 'multi-node job runs to completion under bgexec' '
+	id=$(flux submit -N2 -n2 true) &&
+	flux job wait-event -t 30 $id clean &&
+	flux job status $id
+'
+test_expect_success 'job exit status is propagated' '
+	test_expect_code 1 flux run -N1 false
+'
+test_expect_success 'job stdout is captured' '
+	flux run -N1 echo hello >bgexec-stdout.out &&
+	grep hello bgexec-stdout.out
+'
+test_expect_success 'shell stderr is captured to exec.eventlog' '
+	cat >stderr.lua <<-EOT &&
+	for i = 1,10,1
+	do
+	    io.stderr:write("foo bar\n")
+	end
+	EOT
+	id=$(flux submit -o userrc=stderr.lua -N1 true) &&
+	flux job wait-event -t 30 $id clean &&
+	flux job eventlog -f json -p exec $id \
+	    | jq -c ". | select(.name==\"log\" and .context.stream==\"stderr\")" \
+	      >bgexec-stderr.out &&
+	test $(grep -c "foo bar" bgexec-stderr.out) -eq 10
+'
+test_expect_success 'shell stdout is captured to exec.eventlog' '
+	cat >stdout.lua <<-EOT &&
+	for i = 1,10,1
+	do
+	    io.stdout:write("hello out\n")
+	end
+	EOT
+	id=$(flux submit -o userrc=stdout.lua -N1 true) &&
+	flux job wait-event -t 30 $id clean &&
+	flux job eventlog -f json -p exec $id \
+	    | jq -c ". | select(.name==\"log\" and .context.stream==\"stdout\")" \
+	      >bgexec-stdout-log.out &&
+	test $(grep -c "hello out" bgexec-stdout-log.out) -eq 10
+'
+test_expect_success 'per-job stats report active shells' '
+	id=$(flux submit -N2 -n2 sleep 30) &&
+	flux job wait-event -t 30 $id start &&
+	flux module stats job-exec \
+	    | jq -e ".jobs.\"$id\".active_shells == 2" &&
+	flux cancel $id &&
+	flux job wait-event -t 30 $id clean
+'
+
+# ---------------------------------------------------------------------------
+# Test configuration: attributes.system.exec.bgexec object
+#
+# bgexec reads its test knobs from its own per-implementation namespace
+# (attributes.system.exec.bgexec), not the bulk-exec one.
+# ---------------------------------------------------------------------------
+
+test_expect_success 'invalid bgexec key in jobspec raises error' '
+	flux dmesg -C &&
+	test_must_fail flux run --setattr=exec.bgexec.foo=bar true &&
+	flux dmesg -H | grep "failed to unpack system.exec.bgexec"
+'
+test_expect_success 'mock_exception during init terminates job' '
+	id=$(flux run --dry-run -N2 -n2 sleep 30 \
+	    | jq ".attributes.system.exec.bgexec.mock_exception = \"init\"" \
+	    | flux job submit) &&
+	flux job wait-event -t 30 $id clean &&
+	test_must_fail flux job status $id
+'
+test_expect_success 'mock_exception while starting terminates job' '
+	id=$(flux run --dry-run -N2 -n2 sleep 30 \
+	    | jq ".attributes.system.exec.bgexec.mock_exception = \"starting\"" \
+	    | flux job submit) &&
+	flux job wait-event -t 30 $id clean &&
+	test_must_fail flux job status $id
+'
+test_expect_success 'barrier-timeout drains rank stuck at first barrier' '
+	cat >barrier-hang.lua <<-EOT &&
+	if shell.info.rank == 1 then
+	    os.execute("sleep 30")
+	end
+	EOT
+	id=$(flux run --dry-run -N2 -n2 -o userrc=barrier-hang.lua sleep 60 \
+	    | jq ".attributes.system.exec.bgexec.\"barrier-timeout\" = 0.5" \
+	    | flux job submit) &&
+	flux job wait-event -Ht 60 $id exception &&
+	drained=$(flux resource drain -no "{ranks}") &&
+	test -n "$drained" &&
+	flux resource drain -no "{reason}" | grep "start timeout" &&
+	flux resource undrain "$drained" &&
+	flux job wait-event -t 30 $id clean
+'
+
+# ---------------------------------------------------------------------------
+# shell-exit event (shared jobinfo path exercised via bgexec)
+# ---------------------------------------------------------------------------
+
+test_expect_success 'single-node job posts shell-exit event' '
+	id=$(flux submit -N1 true) &&
+	flux job wait-event -p exec -t 30 $id shell-exit &&
+	flux job wait-event -p exec --format=json -t 10 $id shell-exit \
+	    | jq -e ".context.wait_status == 0"
+'
+test_expect_success 'shell-exit wait_status is nonzero when leader killed' '
+	id=$(flux submit -N1 sh -c "kill -9 \$\$") &&
+	flux job wait-event -t 30 $id clean &&
+	flux job wait-event -p exec --format=json -t 10 $id shell-exit \
+	    | jq -e ".context.wait_status != 0"
+'
+
+# ---------------------------------------------------------------------------
+# cancel and signal delivery
+# ---------------------------------------------------------------------------
+
+test_expect_success 'cancel of running job reaches clean' '
+	id=$(flux submit -N2 -n2 sleep 60) &&
+	flux job wait-event -t 30 $id start &&
+	flux cancel $id &&
+	flux job wait-event -t 30 $id clean
+'
+
+# ---------------------------------------------------------------------------
+# reattach is not implemented (matches bulk-exec)
+# ---------------------------------------------------------------------------
+
+# TODO: exercise the reattach=ENOSYS path once an instance-restart harness
+# for bgexec exists (cf. t3202-instance-restart-testexec.t).
+
+test_expect_success 'reload job-exec to defaults' '
+	flux module reload job-exec
+'
+
+test_done


### PR DESCRIPTION
Problem: job-exec doesn't take advantage of the new `flux_rexec_bg()` and `flux_rexec_wait()` calls to enable reattachment to running jobs.
  
This PR adds a new job-exec back end implementation called _bgexec_ that uses the background calls and fully supports the reattach protocol specified in RFC 50, where
  - the exec.eventlog `recoverable` event is posted once the job gets past the two barriers
  - when job-exec is unloaded, the job's private namespace is grafted into the primary KVS namespace so that it survives a full instance restart (on a plain module reload the live namespace persists and is adopted directly - see below)
  - when job-exec is loaded, the job-manager sends a `job-exec.start` request for running jobs with `reattach=true`
  - if the `recoverable` event was not posted, a fatal exception is raised, otherwise:
  - the private namespace is recreated from the graft if it doesn't exist (full instance restart); if it does (only a job-exec module reload) it is adopted
  - the bgexec `reattach()` method is called, which calls `flux_rexec_wait()` on the running job shells
  
With this in place, recovery can be simulated in test by reloading the job-exec module with running jobs.
  
This PR also drops the unused `re-starting` exec.eventlog event, per the corresponding (merged) RFC 50 change.
  
This PR does not alter the default exec back end - it is still bulkexec. That was intentional to avoid disruption.
  
Coming soon: sdexec (systemd) support for reattaching to running units.