### PR TITLE
normalize non-string vqueue parent error message

### DIFF
--- a/src/modules/job-list/match.c
+++ b/src/modules/job-list/match.c
@@ -969,19 +969,19 @@ static int config_parse_queue_parents (struct match_ctx *mctx,
 
     if (queues) {
         json_object_foreach (queues, name, entry) {
-            json_t *parent;
+            json_error_t jerror;
+            const char *parent = NULL;
 
-            if (!(parent = json_object_get (entry, "parent")))
-                continue;
-            if (!json_is_string (parent)) {
-                errprintf (errp,
-                           "queues.%s: 'parent' must be a string",
-                           name);
+            if (json_unpack_ex (entry, &jerror, 0,
+                                "{s?s}", "parent", &parent) < 0) {
+                errprintf (errp, "queues.%s: %s", name, jerror.text);
                 goto error;
             }
+            if (!parent)
+                continue;
             if (zhashx_insert (queue_parents,
                                name,
-                               (void *)json_string_value (parent)) < 0) {
+                               (void *)parent) < 0) {
                 errprintf (errp,
                           "error building queue parent map entry for '%s'",
                           name);

--- a/src/modules/job-list/test/match.c
+++ b/src/modules/job-list/test/match.c
@@ -643,8 +643,8 @@ static void test_virtual_queue_config_reload (void)
     ok (job_match_config_reload (&mctx, conf, &error) < 0,
         "config reload with non-string parent fails");
     diag ("%s", error.text);
-    ok (strstr (error.text, "must be a string") != NULL,
-        "error message says parent must be a string");
+    ok (strstr (error.text, "Expected string") != NULL,
+        "error message says parent should be a string");
     flux_conf_decref (conf);
     ok (mctx.queue_parents
         && zhashx_lookup (mctx.queue_parents, "expedite") != NULL,

--- a/src/modules/job-manager/plugins/limit-duration.c
+++ b/src/modules/job-manager/plugins/limit-duration.c
@@ -173,7 +173,8 @@ static int queues_parse (zhashx_t **zhp,
         json_object_foreach (queues, name, entry) {
             double duration = DURATION_INVALID;
             double own;
-            json_t *parent = json_object_get (entry, "parent");
+            json_error_t jerror;
+            const char *parent_name = NULL;
 
             /* RFC 33 virtual queues: a vqueue with no own duration
              * limit inherits its parent queue's limit. Read the
@@ -187,17 +188,14 @@ static int queues_parse (zhashx_t **zhp,
              * conf_policy_validate() rejects this config up front, so
              * reaching here means validation was bypassed.
              */
-            if (parent) {
-                const char *parent_name;
+            if (json_unpack_ex (entry, &jerror, 0,
+                                "{s?s}", "parent", &parent_name) < 0) {
+                errprintf (error, "queues.%s: %s", name, jerror.text);
+                goto error;
+            }
+            if (parent_name) {
                 json_t *parent_entry;
 
-                if (!json_is_string (parent)) {
-                    errprintf (error,
-                               "queues.%s: 'parent' must be a string",
-                               name);
-                    goto error;
-                }
-                parent_name = json_string_value (parent);
                 if (!(parent_entry = json_object_get (queues,
                                                       parent_name))) {
                     errprintf (error,

--- a/src/modules/job-manager/plugins/limit-job-size.c
+++ b/src/modules/job-manager/plugins/limit-job-size.c
@@ -284,7 +284,8 @@ static int queues_parse (zhashx_t **zhp,
         flux_error_t e;
 
         json_object_foreach (queues, name, entry) {
-            json_t *parent = json_object_get (entry, "parent");
+            json_error_t jerror;
+            const char *parent_name = NULL;
 
             limits_clear (&limits);
 
@@ -300,17 +301,14 @@ static int queues_parse (zhashx_t **zhp,
              * conf_policy_validate() rejects this config up front, so
              * reaching here means validation was bypassed.
              */
-            if (parent) {
-                const char *parent_name;
+            if (json_unpack_ex (entry, &jerror, 0,
+                                "{s?s}", "parent", &parent_name) < 0) {
+                errprintf (error, "queues.%s: %s", name, jerror.text);
+                goto error;
+            }
+            if (parent_name) {
                 json_t *parent_entry;
 
-                if (!json_is_string (parent)) {
-                    errprintf (error,
-                               "queues.%s: 'parent' must be a string",
-                               name);
-                    goto error;
-                }
-                parent_name = json_string_value (parent);
                 if (!(parent_entry = json_object_get (queues,
                                                       parent_name))) {
                     errprintf (error,

--- a/src/modules/job-manager/queues.c
+++ b/src/modules/job-manager/queues.c
@@ -103,14 +103,17 @@ static void queue_destructor (void **item)
 /* Extract the "parent" key from a queue's own config entry 'entry' (may
  * be NULL). On success, '*namep' is set to the borrowed name string,
  * or NULL if 'entry' has no "parent" key. Returns -1 if "parent" is
- * present but not a string.
+ * present but not a string, filling in 'jerror' (which may be NULL) with
+ * jansson's diagnostic ("expected string").
  */
-static int entry_parent_name (json_t *entry, const char **namep)
+static int entry_parent_name (json_t *entry,
+                              const char **namep,
+                              json_error_t *jerror)
 {
     *namep = NULL;
     if (!entry)
         return 0;
-    return json_unpack (entry, "{s?s}", "parent", namep);
+    return json_unpack_ex (entry, jerror, 0, "{s?s}", "parent", namep);
 }
 
 /* True if 'name's config entry in 'table' (the full desired [queues]
@@ -127,7 +130,8 @@ static bool entry_is_virtual (json_t *table, const char *name)
 
     return table
         && entry_parent_name (json_object_get (table, name),
-                              &parent_name) == 0
+                              &parent_name,
+                              NULL) == 0
         && parent_name != NULL;
 }
 
@@ -148,7 +152,7 @@ static int resolve_parent (struct queue *q, json_t *entry)
     const char *parent_name;
 
     q->parent = NULL;
-    if (entry_parent_name (entry, &parent_name) < 0) {
+    if (entry_parent_name (entry, &parent_name, NULL) < 0) {
         errno = EPROTO;
         return -1;
     }
@@ -186,12 +190,14 @@ static int lookup_parent (struct queues *queues,
 {
     struct queue *parent;
     const char *parent_name;
+    json_error_t jerror;
 
     *parentp = NULL;
-    if (entry_parent_name (entry, &parent_name) < 0) {
+    if (entry_parent_name (entry, &parent_name, &jerror) < 0) {
         errprintf (error,
-                  "queue '%s': 'parent' must be a string",
-                  name ? name : "(anon)");
+                  "queue '%s': %s",
+                  name ? name : "(anon)",
+                  jerror.text);
         errno = EINVAL;
         return -1;
     }
@@ -697,9 +703,10 @@ static int queues_config_validate (json_t *config, flux_error_t *error)
     }
     json_object_foreach (config, name, value) {
         const char *parent_name;
+        json_error_t jerror;
 
-        if (entry_parent_name (value, &parent_name) < 0) {
-            errprintf (error, "queue '%s': 'parent' must be a string", name);
+        if (entry_parent_name (value, &parent_name, &jerror) < 0) {
+            errprintf (error, "queue '%s': %s", name, jerror.text);
             errno = EINVAL;
             return -1;
         }


### PR DESCRIPTION
Problem: a test that sets a vqueue parent config to a non-string value (42) integer and checks for a specific error message fails intermittently.

The parse error always occurs but the error message is nondeterministic. Several independent config-reload validators reject it, with inconsistent error wording, and apparently it is not always the same validator that fails first.

Parse 'parent' with a strict s:s json_unpack_ex at every site and let jansson's "Expected string" diagnostic flow through, dropping the explicit json_is_string() check and custom message. All validators now agree on the wording regardless of dispatch order.

Fixes #7768

Assisted-by: Claude:opus-4.8