### PR TITLE
libfluxutil: normalize vqueue parent error message

### DIFF
--- a/src/common/libfluxutil/conf_policy.c
+++ b/src/common/libfluxutil/conf_policy.c
@@ -364,12 +364,12 @@ static int validate_queues_config (const flux_conf_t *conf,
             json_error_t jerror;
             json_t *policy = NULL;
             json_t *requires = NULL;
-            const char *parent = NULL;
+            json_t *parent = NULL;
 
             if (json_unpack_ex (entry,
                                 &jerror,
                                 0,
-                                "{s?o s?o s?s !}",
+                                "{s?o s?o s?o !}",
                                 "policy", &policy,
                                 "requires", &requires,
                                 "parent", &parent) < 0) {
@@ -377,6 +377,13 @@ static int validate_queues_config (const flux_conf_t *conf,
                            "error parsing [queues.%s] config table: %s",
                            name,
                            jerror.text);
+                goto inval;
+            }
+            if (parent && !json_is_string (parent)) {
+                errprintf (error,
+                           "error parsing [queues.%s] config table:"
+                           " 'parent' must be a string",
+                           name);
                 goto inval;
             }
             if (policy) {

--- a/t/t2246-queue-virtual.t
+++ b/t/t2246-queue-virtual.t
@@ -114,7 +114,7 @@ test_expect_success 'invalid config: vqueue parent is not a string is rejected' 
 	[queues.expedite]
 	parent = 42
 	EOT
-	grep -i "expected string" parenttype.err
+	grep -i "must be a string" parenttype.err
 '
 
 test_expect_success 'invalid vqueue config fails the instance at startup' '


### PR DESCRIPTION
Problem: Several components validate that a queue parent key is a string, but validate_queues_config() in libfluxutil emits a different error message. On config reload, whichever error is returned first wins, so the message is indeterminate and a test in t2246-queue-virtual.t intermittently fails.

Update the error message in validate_queues_config() to match the other components, and update the expected error in the test.

Fixes #7768