### PR TITLE
return effective queue config in `job-manager.queue-list` and use it in `flux resource` and frobnicator

### DIFF
--- a/src/bindings/python/flux/job/frobnicator/frobnicator.py
+++ b/src/bindings/python/flux/job/frobnicator/frobnicator.py
@@ -15,10 +15,22 @@ import flux
 from flux.cli.argparse import FluxArgumentParser
 from flux.importer import import_path, import_plugins
 from flux.job import Jobspec
+from flux.queue import queue_config_fetch
 
 
 class FrobnicatorPlugin:
-    """Base class for plugins which modify jobspec in place"""
+    """Base class for plugins which modify jobspec in place
+
+    The following base class attributes are used to pass optional, extensible
+    context to plugins without perturbing plugin callback method signatures,
+    and will be available from within all callbacks unless otherwise noted:
+
+    Attrs:
+        queue_conf (:obj:`flux.queue.QueueConf`): The instance's queue
+            configuration, as fetched from the job-manager.queue-list RPC.
+    """
+
+    queue_conf = None
 
     def __init__(self, parser):
         """Initialize a FrobnicatorPlugin"""
@@ -103,7 +115,16 @@ class JobFrobnicator:
     def start(self):
         """Read broker config, select and configure frobnicator plugins"""
 
-        self.config = flux.Flux().rpc("config.get").get()
+        # Fetch the full broker config (passed to every plugin) and the
+        # job-manager's queue configuration (for queue-aware plugins). Send
+        # both requests before draining either, so they overlap. The queue
+        # config comes from the queue-list RPC, falling back to the broker
+        # config for an older job-manager (see queue_config_fetch()).
+        handle = flux.Flux()
+        config_rpc = handle.rpc("config.get")
+        queue_conf_rpc = queue_config_fetch(handle)
+        self.config = config_rpc.get()
+        queue_conf = queue_conf_rpc.get()
 
         for name in self.args.plugins:
             if name not in self.plugins:
@@ -114,9 +135,13 @@ class JobFrobnicator:
             plugin = self.plugins[name].Frobnicator(parser=self.plugins_group)
             self.frobnicators.append(plugin)
 
-        # Parse remaining args and pass result to loaded plugins
+        # Parse remaining args and pass result to loaded plugins. Share
+        # queue_conf by attribute rather than as a configure() argument, so
+        # the configure(args, config) signature stays stable for plugins
+        # (including third-party plugins) as new context is added.
         args = self.parser.parse_args(self.remaining_args)
         for frobnicator in self.frobnicators:
+            frobnicator.queue_conf = queue_conf
             frobnicator.configure(args, config=self.config)
 
     def frob(self, jobspec, user=None, flags=None, urgency=16):

--- a/src/bindings/python/flux/job/frobnicator/plugins/constraints.py
+++ b/src/bindings/python/flux/job/frobnicator/plugins/constraints.py
@@ -8,78 +8,54 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-"""Apply constraints to incoming jobspec based on broker config."""
+"""Apply queue constraints to incoming jobspec from the job-manager."""
 
 from flux.job.frobnicator import FrobnicatorPlugin
+from flux.queue import QueueConf
 
 
-class QueueConfig:
-    """Convenience class for handling jobspec queues configuration"""
+def apply_constraints(queue_conf, jobspec):
+    """Apply a jobspec's queue's required properties as a constraint.
 
-    def __init__(self, config={}):
-        self.queues = {}
-        try:
-            self.queues = config["queues"]
-        except KeyError:
-            pass
+    'queue_conf' is a flux.queue.QueueConf: the job-manager's authoritative
+    queue configuration, with RFC 33 virtual-queue inheritance already
+    resolved.
+    """
+    if not jobspec.queue:
+        return
+    if jobspec.queue not in queue_conf:
+        raise ValueError(f"Invalid queue '{jobspec.queue}' specified")
+    # The queue's effective required properties. For a virtual queue (RFC
+    # 33) this is the parent's, resolved by the job-manager - so applying it
+    # schedules the job as part of the parent's job list.
+    queue_properties = queue_conf.requires(jobspec.queue)
+    if queue_properties is None:
+        return
 
-    def queue_properties(self, name):
-        try:
-            entry = self.queues[name]
-        except KeyError:
-            return None
-        # A virtual queue (RFC 33) has no 'requires' of its own -
-        # inject the parent's instead, since that is what makes the
-        # job schedule as part of the parent's job list. Inheritance
-        # is one level (validated by conf_policy.c), so no chain to
-        # walk. An unresolvable parent is a fatal error (fail closed):
-        # silently dropping the parent's constraint would place the
-        # job outside the parent's resource slice.
-        parent = entry.get("parent")
-        if parent is not None:
-            try:
-                entry = self.queues[parent]
-            except KeyError:
-                raise ValueError(
-                    f"queue '{name}': parent queue '{parent}' is not configured"
-                )
-        return entry.get("requires")
-
-    def apply_constraints(self, jobspec):
-        """Apply queue-specific constraints to jobspec"""
-
-        if jobspec.queue:
-            if jobspec.queue not in self.queues:
-                raise ValueError(f"Invalid queue '{jobspec.queue}' specified")
-            queue_properties = self.queue_properties(jobspec.queue)
-            if queue_properties is None:
-                return
-
-            # First try appending to existing constraints
-            try:
-                spec = jobspec.attributes["system"]["constraints"]["properties"]
-                for prop in queue_properties:
-                    if prop not in spec:
-                        spec.append(prop)
-                return
-            except KeyError:
-                #  No "properties" operator at top level, try combining
-                #  existing constraints with logical AND
-                pass
-            try:
-                jobspec.setattr(
-                    "system.constraints",
-                    {
-                        "and": [
-                            jobspec.attributes["system"]["constraints"],
-                            {"properties": queue_properties},
-                        ]
-                    },
-                )
-            except KeyError:
-                #  No existing "constraints" - set constraints to queue
-                #  constraints
-                jobspec.setattr("system.constraints", {"properties": queue_properties})
+    # First try appending to existing constraints
+    try:
+        spec = jobspec.attributes["system"]["constraints"]["properties"]
+        for prop in queue_properties:
+            if prop not in spec:
+                spec.append(prop)
+        return
+    except KeyError:
+        #  No "properties" operator at top level, try combining
+        #  existing constraints with logical AND
+        pass
+    try:
+        jobspec.setattr(
+            "system.constraints",
+            {
+                "and": [
+                    jobspec.attributes["system"]["constraints"],
+                    {"properties": queue_properties},
+                ]
+            },
+        )
+    except KeyError:
+        #  No existing "constraints" - set constraints to queue constraints
+        jobspec.setattr("system.constraints", {"properties": queue_properties})
 
 
 class Frobnicator(FrobnicatorPlugin):
@@ -87,7 +63,9 @@ class Frobnicator(FrobnicatorPlugin):
         super().__init__(parser)
 
     def configure(self, args, config):
-        self.config = QueueConfig(config)
+        # queue_conf is injected by the framework as an attribute (see
+        # FrobnicatorPlugin) before configure() is called.
+        self.queue_conf = self.queue_conf or QueueConf({})
 
     def frob(self, jobspec, user, urgency, flags):
-        self.config.apply_constraints(jobspec)
+        apply_constraints(self.queue_conf, jobspec)

--- a/src/bindings/python/flux/queue.py
+++ b/src/bindings/python/flux/queue.py
@@ -15,6 +15,7 @@ except ModuleNotFoundError:
     from flux.utils.dataclasses import dataclass
 
 from flux.resource import resource_list
+from flux.rpc import RPC
 from flux.util import parse_fsd
 
 """Simple access to information about Flux queues from Python.
@@ -174,6 +175,146 @@ class QueueResources:
 
     def __getattr__(self, attr):
         return getattr(self._resource_list, attr)
+
+
+def queue_conf_from_config(config):
+    """Build the job-manager.queue-list "conf" object from a raw broker config.
+
+    This helper creates a job-manager.queue-list response ``conf`` object
+    directly from broker config. For use in testing and as a fallback when
+    the job-manager is from an older version of Flux that does not provide
+    the queue config directly.
+
+    Returns ``{"queues": [{"name": str, "requires"?: list, "parent"?: str},
+    ...]}``. A virtual queue (RFC 33) has no "requires" of its own, so its
+    effective "requires" is resolved from its parent.
+
+    Args:
+        config (dict): a broker config, e.g. from the ``config.get`` RPC.
+
+    Raises:
+        ValueError: a virtual queue names a parent that is not configured.
+    """
+    queues = config.get("queues", {})
+    entries = []
+    for name, entry in queues.items():
+        conf = {"name": name}
+        parent = entry.get("parent")
+        if parent is not None:
+            # Virtual queue: inherit the parent's requires. An unresolvable
+            # parent is fatal (fail closed) - falling through would report
+            # the vqueue as covering the full instance resource set.
+            if parent not in queues:
+                raise ValueError(
+                    f"queue '{name}': parent queue '{parent}' is not configured"
+                )
+            conf["parent"] = parent
+            requires = queues[parent].get("requires")
+        else:
+            requires = entry.get("requires")
+        if requires is not None:
+            conf["requires"] = requires
+        entries.append(conf)
+    return {"queues": entries}
+
+
+class QueueConf:
+    """The job-manager's authoritative queue configuration.
+
+    Wraps a job-manager.queue-list "conf" object (``{"queues": [...]}``) and
+    exposes per-queue effective configuration. RFC 33 virtual-queue
+    inheritance is already resolved by the job-manager, so a queue's
+    ``requires`` is an effective value.
+
+    Fetch from a live instance with :func:`queue_config_fetch`. Build from a
+    raw broker config with :meth:`from_config` (the ``--config-file`` /
+    stdin / test path). The empty (anonymous-queue) case is a QueueConf with
+    no entries.
+    """
+
+    def __init__(self, conf):
+        self._entries = {entry["name"]: entry for entry in conf.get("queues", [])}
+
+    @classmethod
+    def from_config(cls, config):
+        """Return a QueueConf built from a raw broker config (the config-file
+        test path). See :func:`queue_conf_from_config`.
+        """
+        return cls(queue_conf_from_config(config))
+
+    def __contains__(self, name):
+        return name in self._entries
+
+    def __iter__(self):
+        return iter(self._entries)
+
+    def __len__(self):
+        # Number of named queues (0 in the anonymous-queue case), so a
+        # QueueConf is falsy when no named queues are configured.
+        return len(self._entries)
+
+    @property
+    def entries(self):
+        """The raw name -> conf-entry dict.
+
+        A low-level escape hatch for bulk/iteration consumers whose access
+        pattern does not fit the per-queue accessors (requires/parent) --
+        e.g. flux-resource's dict-oriented rendering. Prefer the accessors
+        for per-queue lookups.
+        """
+        return self._entries
+
+    def requires(self, name):
+        """The queue's effective required-properties list, or None.
+
+        Already vqueue-resolved by the job-manager (a virtual queue reports
+        its parent's requires). ``name`` may be None or an unconfigured queue
+        (the anonymous-queue case) -> None.
+        """
+        return (self._entries.get(name) or {}).get("requires")
+
+    def parent(self, name):
+        """The queue's resolved parent name (RFC 33 virtual queue), or "".
+
+        The job-manager's authoritative view of the resolved parent.
+        """
+        return (self._entries.get(name) or {}).get("parent", "")
+
+
+class QueueConfRPC(RPC):
+    """A pending queue configuration fetch from a Flux instance.
+
+    Sends the ``job-manager.queue-list`` RPC on construction (so it can
+    overlap with other work) and returns a :obj:`QueueConf` from
+    :meth:`get`. An older job-manager omits the "conf" object, so
+    :meth:`get` then falls back to deriving the config from the broker
+    config via a synchronous ``config.get`` RPC.
+    """
+
+    def __init__(self, flux_handle):
+        super().__init__(flux_handle, "job-manager.queue-list")
+
+    def get(self):
+        """Return the :obj:`QueueConf`. Blocks until the request completes."""
+        conf = super().get().get("conf")
+        if conf is None:
+            #  Older job-manager without "conf": fall back to config.
+            conf = queue_conf_from_config(self._handle.rpc("config.get").get())
+        return QueueConf(conf)
+
+
+def queue_config_fetch(handle):
+    """Send a request for the instance's queue configuration.
+
+    Args:
+        handle (:obj:`flux.Flux`): a Flux handle
+
+    Returns:
+        QueueConfRPC: a pending fetch; :meth:`~QueueConfRPC.get` returns a
+        :obj:`QueueConf`. The request is sent immediately, so the fetch can
+        overlap with other RPCs before :meth:`~QueueConfRPC.get` is called.
+    """
+    return QueueConfRPC(handle)
 
 
 class QueueInfo:

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -24,6 +24,7 @@ from flux.cli.argparse import FluxArgumentParser
 from flux.eventlog import EventLogFormatter
 from flux.hostlist import Hostlist
 from flux.idset import IDset
+from flux.queue import QueueConf, queue_config_fetch
 from flux.resource import (
     ResourceJournalConsumer,
     ResourceSet,
@@ -196,27 +197,30 @@ def undrain(args):
     RPC(flux.Flux(), "resource.undrain", payload, nodeid=0).get()
 
 
-def queue_effective_entry(queues, name):
+def queue_conf(args, queue_conf_rpc):
     """
-    Return the effective [queues] config entry for queue ``name``: its own
-    entry, or its parent's entry if it is an RFC 33 virtual queue.
+    Return the effective queue configuration as a name->entry dict, where
+    each entry has its effective "requires" (an RFC 33 virtual queue's is
+    resolved from its parent) and, for a virtual queue, its "parent". This
+    is the job-manager's authoritative view.
 
-    A virtual queue has no "requires" of its own, so resolving to the
-    parent's entry is what maps it to the parent's resource slice rather
-    than wrongly matching every node as an unconstrained queue would. An
-    unresolvable parent raises ValueError (defense in depth: config
-    validation rejects it in a live instance, but --config-file and
-    --from-stdin input is not validated).
+    'queue_conf_rpc' is a queue_config_fetch() request the caller has
+    already sent (so it can overlap with other RPCs). It is required on the
+    online path and must be non-None unless ``--config-file`` is set. The
+    hidden --config-file/--from-stdin test options derive the config from a
+    file instead. Returns an empty dict when there is no source.
     """
-    entry = queues[name]
-    if "parent" in entry:
-        parent = entry["parent"]
-        if parent not in queues:
-            raise ValueError(
-                f"queue '{name}': parent queue '{parent}' is not configured"
-            )
-        entry = queues[parent]
-    return entry
+    if args.config_file:
+        with open(args.config_file) as fp:
+            conf = QueueConf.from_config(json.load(fp))
+    elif queue_conf_rpc is None:
+        return {}
+    else:
+        conf = queue_conf_rpc.get()
+    #  Return the raw name->entry dict: the resource rendering below iterates
+    #  entries (filtering hidden/virtual queues, testing membership) rather
+    #  than doing per-queue lookups, so QueueConf.entries fits it directly.
+    return conf.entries
 
 
 class QueueResources:
@@ -224,17 +228,14 @@ class QueueResources:
     Convenience class to map queues to resource sets
     """
 
-    def __init__(self, resource_set, config):
+    def __init__(self, resource_set, queues):
         self._queues = {}
-        if "queues" not in config:
-            return
-        for queue in config["queues"]:
-            entry = queue_effective_entry(config["queues"], queue)
+        for name, entry in queues.items():
             if "requires" in entry:
                 result = resource_set.copy_constraint({"properties": entry["requires"]})
             else:
                 result = resource_set.copy()
-            self._queues[queue] = result
+            self._queues[name] = result
 
     def queue(self, queue):
         if queue not in self._queues:
@@ -242,15 +243,16 @@ class QueueResources:
         return self._queues[queue]
 
 
-def ranks_by_queue(resource_set, config, queues):
+def ranks_by_queue(resource_set, queue_config, queues):
     """
     Return all ranks associated with a list of queues
     Args:
         resource_set: The resource set to query
-        config: a Flux config object including queue configuration, if any.
+        queue_config: effective queue config as a name->entry dict (see
+            queue_conf())
         queues: one or more queues specified as a comma-separated string
     """
-    queue_resources = QueueResources(resource_set, config)
+    queue_resources = QueueResources(resource_set, queue_config)
     ranks = IDset()
     for queue in queues:
         ranks.add(queue_resources.queue(queue).ranks)
@@ -452,6 +454,7 @@ def status(args):
     fmt = FluxResourceConfig("status").load().get_format_string(args.format)
 
     handle = None
+    queue_conf_rpc = None
 
     #  Get payload from stdin or from resource.status RPC:
     if args.from_stdin:
@@ -459,18 +462,21 @@ def status(args):
         rstatus = ResourceStatus(json.loads(input_str) if input_str else None)
     else:
         handle = flux.Flux()
+        #  Send the queue config request (only needed for --queue) before
+        #  resource.status .get(), so the two overlap:
+        if args.queue:
+            queue_conf_rpc = queue_config_fetch(handle)
         rstatus = resource_status(handle).get()
 
     if args.queue:
-        if args.config_file:
-            with open(args.config_file) as fp:
-                config = json.load(fp)
-        else:
-            config = {}
-            if handle is not None:
-                config = handle.rpc("config.get").get()
         try:
-            rstatus.filter(ranks_by_queue(rstatus.rset, config, args.queue))
+            rstatus.filter(
+                ranks_by_queue(
+                    rstatus.rset,
+                    queue_conf(args, queue_conf_rpc),
+                    args.queue,
+                )
+            )
         except ValueError as exc:
             raise ValueError(f"--queue: {exc}") from None
 
@@ -534,12 +540,12 @@ class ResourceSetExtra(ResourceSet):
         self,
         arg=None,
         version=1,
-        flux_config=None,
+        queue_config=None,
         queue=None,
         queue_filter=None,
         hidden_queues=None,
     ):
-        self.flux_config = flux_config
+        self.queue_config = queue_config or {}
         self._queue = queue
         self._queue_filter = queue_filter
         self._hidden_queues = hidden_queues or set()
@@ -558,9 +564,8 @@ class ResourceSetExtra(ResourceSet):
         properties = json.loads(self.get_properties())
         #  Strip all configured queue names from properties, so that
         #  properties used only for queue membership are not displayed.
-        if self.flux_config and "queues" in self.flux_config:
-            for q in self.flux_config["queues"]:
-                properties.pop(q, None)
+        for q in self.queue_config:
+            properties.pop(q, None)
         return ",".join(properties.keys())
 
     @property
@@ -573,11 +578,11 @@ class ResourceSetExtra(ResourceSet):
         #  If self._queue is not set, then build list of queues from
         #  set properties and queue configuration:
         queues = ""
-        if self.flux_config and "queues" in self.flux_config:
+        if self.queue_config:
             if not self.ranks:
                 return ""
             properties = json.loads(self.get_properties())
-            for key, value in self.flux_config["queues"].items():
+            for key, entry in self.queue_config.items():
                 if self._queue_filter:
                     if key not in self._queue_filter:
                         continue
@@ -587,9 +592,8 @@ class ResourceSetExtra(ResourceSet):
                 # was explicitly requested via -q (i.e. is in the filter),
                 # otherwise it would match every node in the default QUEUE
                 # column via its resolved parent's requires:
-                if "parent" in value and not self._queue_filter:
+                if "parent" in entry and not self._queue_filter:
                     continue
-                entry = queue_effective_entry(self.flux_config["queues"], key)
                 if "requires" not in entry or set(entry["requires"]).issubset(
                     set(properties)
                 ):
@@ -626,7 +630,7 @@ def split_by_property_combinations(rset):
 
 
 def resources_uniq_lines(
-    resources, states, formatter, config, queues=None, hidden_queues=None
+    resources, states, formatter, queue_config, queues=None, hidden_queues=None
 ):
     """
     Generate a set of resource sets that would produce unique lines given
@@ -670,10 +674,10 @@ def resources_uniq_lines(
     #  If no queues are configured then one "anonymous" queue is simulated
     #  with [None].
     if not queues:
-        if config and "queues" in config:
+        if queue_config:
             queues = [
                 q
-                for q, entry in config["queues"].items()
+                for q, entry in queue_config.items()
                 if q not in hidden_queues and "parent" not in entry
             ]
             if not queues:
@@ -691,7 +695,7 @@ def resources_uniq_lines(
             #   state would be suppressed.
             #
             for queue in queues:
-                rset = ResourceSetExtra(flux_config=config, queue=queue)
+                rset = ResourceSetExtra(queue_config=queue_config, queue=queue)
                 rset.state = state
                 key = fmt.format(rset)
                 if key not in lines:
@@ -706,7 +710,7 @@ def resources_uniq_lines(
             rset.state = state
             rset = ResourceSetExtra(
                 rset,
-                flux_config=config,
+                queue_config=queue_config,
                 queue_filter=queue_filter,
                 hidden_queues=hidden_queues,
             )
@@ -725,7 +729,7 @@ def get_resource_list(args):
     Common function for list_handler() and emit_R()
     """
     valid_states = ["up", "down", "allocated", "free", "all"]
-    config = None
+    handle = None
 
     args.states = args.states.split(",")
     for state in args.states:
@@ -733,23 +737,27 @@ def get_resource_list(args):
             LOGGER.error("Invalid resource state %s specified", state)
             sys.exit(1)
 
+    queue_conf_rpc = None
     if args.from_stdin:
         resources = SchedResourceList(json.load(sys.stdin))
-        if args.config_file:
-            with open(args.config_file) as fp:
-                config = json.load(fp)
     else:
         handle = flux.Flux()
-        rpcs = [resource_list(handle), handle.rpc("config.get")]
-        resources = rpcs[0].get()
-        try:
-            config = rpcs[1].get()
-        except Exception as e:
-            LOGGER.warning("Could not get flux config: " + str(e))
+        queue_conf_rpc = queue_config_fetch(handle)
+        resources = resource_list(handle).get()
+
+    #  The job-manager may be unavailable (e.g. not loaded); still list
+    #  resources, just without queue annotation.
+    try:
+        queue_config_dict = queue_conf(args, queue_conf_rpc)
+    except OSError as e:
+        LOGGER.warning("Could not get queue configuration: " + str(e))
+        queue_config_dict = {}
 
     if args.queue:
         try:
-            resources.filter(ranks_by_queue(resources.all, config, args.queue))
+            resources.filter(
+                ranks_by_queue(resources.all, queue_config_dict, args.queue)
+            )
         except ValueError as exc:
             raise ValueError(f"--queue: {exc}") from None
 
@@ -759,7 +767,7 @@ def get_resource_list(args):
         except (ValueError, TypeError) as exc:
             raise ValueError(f"--include: {exc}") from None
 
-    return resources, config
+    return resources, queue_config_dict
 
 
 def sort_output(args, items):
@@ -783,7 +791,7 @@ def list_handler(args):
         "nodelist": "NODELIST",
         "rlist": "LIST",
     }
-    resources, config = get_resource_list(args)
+    resources, queue_config_dict = get_resource_list(args)
 
     list_config = FluxResourceConfig("list").load()
     fmt = list_config.get_format_string(args.format)
@@ -794,7 +802,7 @@ def list_handler(args):
         resources,
         args.states,
         formatter,
-        config,
+        queue_config_dict,
         queues=args.queue,
         hidden_queues=hidden_queues,
     )
@@ -815,7 +823,7 @@ def info(args):
 
 def emit_R(args):
     """Emit R in JSON on stdout for requested set of resources"""
-    resources, config = get_resource_list(args)
+    resources, _ = get_resource_list(args)
 
     rset = ResourceSet()
     rset.starttime = resources["all"].starttime

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -144,20 +144,20 @@ static void queue_list_cb (flux_t *h,
                            void *arg)
 {
     struct queue_ctx *qctx = arg;
-    json_t *a = NULL;
+    json_t *resp = NULL;
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
-    if (!(a = queues_list_encode (qctx->queues)))
+    if (!(resp = queues_list_response (qctx->queues)))
         goto error;
-    if (flux_respond_pack (h, msg, "{s:O}", "queues", a) < 0)
+    if (flux_respond_pack (h, msg, "O", resp) < 0)
         flux_log_error (h, "error responding to job-manager.queue-list");
-    json_decref (a);
+    json_decref (resp);
     return;
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "error responding to job-manager.queue-list");
-    json_decref (a);
+    json_decref (resp);
 }
 
 static void queue_status_cb (flux_t *h,

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -144,20 +144,21 @@ static void queue_list_cb (flux_t *h,
                            void *arg)
 {
     struct queue_ctx *qctx = arg;
-    json_t *resp = NULL;
+    json_t *resp;
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
+    /* resp is a borrowed reference owned by the queues cache; "O"
+     * increfs it for the response, so it is not decref'd here.
+     */
     if (!(resp = queues_list_response (qctx->queues)))
         goto error;
     if (flux_respond_pack (h, msg, "O", resp) < 0)
         flux_log_error (h, "error responding to job-manager.queue-list");
-    json_decref (resp);
     return;
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "error responding to job-manager.queue-list");
-    json_decref (resp);
 }
 
 static void queue_status_cb (flux_t *h,

--- a/src/modules/job-manager/queues.c
+++ b/src/modules/job-manager/queues.c
@@ -45,16 +45,16 @@ struct queue {
     bool is_started_sticky;     /* tracks is_started unless --nocheckpoint */
     char *stop_reason;          /* reason if stopped (optionally set) */
     json_t *requires;           /* required properties array (own; a
-                                  * virtual queue's is always NULL - see
-                                  * queue_root() for the effective value)
-                                  */
+                                 * virtual queue's is always NULL - see
+                                 * queue_root() for the effective value)
+                                 */
     struct queue *parent;       /* resolved parent queue (RFC 33 virtual
-                                  * queues), or NULL if not virtual. Not
-                                  * owned; borrowed from the same queues
-                                  * table. Inheritance is one level
-                                  * (validated elsewhere) so this is
-                                  * never itself virtual.
-                                  */
+                                 * queues), or NULL if not virtual. Not
+                                 * owned; borrowed from the same queues
+                                 * table. Inheritance is one level
+                                 * (validated elsewhere) so this is
+                                 * never itself virtual.
+                                 */
     struct queues *queues;      /* back-pointer for notify */
 };
 

--- a/src/modules/job-manager/queues.c
+++ b/src/modules/job-manager/queues.c
@@ -61,19 +61,38 @@ struct queue {
 struct queues {
     struct queue *anon;         /* live when named == NULL */
     zhashx_t *named;            /* non-NULL selects named mode */
+    json_t *list_cache;         /* cached queue-list response, built
+                                 * lazily by queues_list_response() and
+                                 * invalidated by notify() on any
+                                 * mutation. NULL when not yet built.
+                                 */
     bool restoring;             /* suppress notify during queues_restore */
     queues_change_f notify_cb;
     void *notify_arg;
 };
 
+/* Invalidate any cached queue-list response.
+ */
+static void cache_invalidate (struct queues *queues)
+{
+    json_decref (queues->list_cache);
+    queues->list_cache = NULL;
+}
+
 /* Internal: fire change notification if callback is registered.
  * Suppressed during queues_restore: restore reconstructs state that
  * was already notified when it originally changed.
+ *
+ * The response cache is invalidated unconditionally (even during restore,
+ * which is not a notify consumer) since any mutation may change it. The
+ * cache depends only on config-derived fields, so enable/start/stop
+ * events over-invalidate harmlessly.
  */
 static void notify (struct queues *queues,
                     struct queue *q,
                     const char *event)
 {
+    cache_invalidate (queues);
     if (queues->notify_cb && !queues->restoring)
         queues->notify_cb (queues, q, event, queues->notify_arg);
 }
@@ -296,6 +315,7 @@ void queues_destroy (struct queues *queues)
             zhashx_destroy (&queues->named);
         else
             queue_free (queues->anon);
+        json_decref (queues->list_cache);
         free (queues);
         errno = saved_errno;
     }
@@ -999,13 +1019,10 @@ nomem:
     return NULL;
 }
 
-/* Assemble the full queue-list RPC response:
+/* Build the full queue-list RPC response (a new reference):
  *   {"queues":[names...], "conf":{"queues":[{name,requires?,parent?}...]}}
- * The "queues" name array is retained for backwards compatibility; "conf"
- * carries the effective per-queue configuration. Returns a new reference
- * the caller must decref.
  */
-json_t *queues_list_response (struct queues *queues)
+static json_t *list_response_build (struct queues *queues)
 {
     json_t *names = NULL;
     json_t *conf = NULL;
@@ -1025,6 +1042,13 @@ error:
     ERRNO_SAFE_WRAP (json_decref, names);
     ERRNO_SAFE_WRAP (json_decref, conf);
     return NULL;
+}
+
+json_t *queues_list_response (struct queues *queues)
+{
+    if (!queues->list_cache)
+        queues->list_cache = list_response_build (queues);
+    return queues->list_cache;
 }
 
 static int save_one (json_t *a, struct queue *q)

--- a/src/modules/job-manager/queues.c
+++ b/src/modules/job-manager/queues.c
@@ -935,6 +935,98 @@ error:
     return NULL;
 }
 
+/* Encode one queue's effective configuration for the conf object:
+ * {"name":s, "requires"?:[...], "parent"?:s}. 'requires' is the
+ * effective required-properties array (a virtual queue inherits its
+ * parent's - see queue_requires()), omitted when the queue has none.
+ * 'parent' is present only for a virtual queue (RFC 33).
+ */
+static json_t *queue_conf_encode (struct queue *q)
+{
+    json_t *o;
+    json_t *requires;
+
+    if (!(o = json_pack ("{s:s}", "name", q->name)))
+        goto nomem;
+    if ((requires = queue_requires (q))) {
+        if (json_object_set (o, "requires", requires) < 0)
+            goto nomem;
+    }
+    if (queue_is_virtual (q)) {
+        if (set_string (o, "parent", queue_name (queue_parent (q))) < 0)
+            goto error;
+    }
+    return o;
+nomem:
+    errno = ENOMEM;
+error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return NULL;
+}
+
+/* Encode the effective queue configuration object returned by the
+ * queue-list RPC: {"queues":[{name,requires?,parent?}, ...]}. The
+ * anonymous queue is omitted (empty array in anon mode). Future global
+ * fields (default queue, merged policy) attach here as siblings of
+ * "queues".
+ */
+static json_t *queues_conf_encode (struct queues *queues)
+{
+    json_t *conf;
+    json_t *a;
+
+    if (!(a = json_array ()))
+        goto nomem;
+    if (queues->named) {
+        struct queue *q = zhashx_first (queues->named);
+        while (q) {
+            json_t *o;
+            if (!(o = queue_conf_encode (q))
+                || json_array_append_new (a, o) < 0) {
+                /* jansson decrefs `o` on failure */
+                goto nomem;
+            }
+            q = zhashx_next (queues->named);
+        }
+    }
+    if (!(conf = json_pack ("{s:O}", "queues", a)))
+        goto nomem;
+    json_decref (a);
+    return conf;
+nomem:
+    errno = ENOMEM;
+    ERRNO_SAFE_WRAP (json_decref, a);
+    return NULL;
+}
+
+/* Assemble the full queue-list RPC response:
+ *   {"queues":[names...], "conf":{"queues":[{name,requires?,parent?}...]}}
+ * The "queues" name array is retained for backwards compatibility; "conf"
+ * carries the effective per-queue configuration. Returns a new reference
+ * the caller must decref.
+ */
+json_t *queues_list_response (struct queues *queues)
+{
+    json_t *names = NULL;
+    json_t *conf = NULL;
+    json_t *resp;
+
+    if (!(names = queues_list_encode (queues))
+        || !(conf = queues_conf_encode (queues)))
+        goto error;
+    if (!(resp = json_pack ("{s:O s:O}", "queues", names, "conf", conf)))
+        goto nomem;
+    json_decref (names);
+    json_decref (conf);
+    return resp;
+nomem:
+    errno = ENOMEM;
+error:
+    ERRNO_SAFE_WRAP (json_decref, names);
+    ERRNO_SAFE_WRAP (json_decref, conf);
+    return NULL;
+}
+
 static int save_one (json_t *a, struct queue *q)
 {
     json_t *entry;

--- a/src/modules/job-manager/queues.h
+++ b/src/modules/job-manager/queues.h
@@ -124,6 +124,17 @@ int queues_restore (struct queues *queues, int version, json_t *o);
 json_t *queue_status_encode (struct queue *q, bool sched_ready);
 json_t *queues_list_encode (struct queues *queues);
 
+/* Assemble the full job-manager.queue-list RPC response:
+ *   {"queues":[names...],
+ *    "conf":{"queues":[{"name":s,"requires"?:[...],"parent"?:s}, ...]}}
+ * The "queues" name array is retained for backwards compatibility; "conf"
+ * carries the effective per-queue configuration (a virtual queue's
+ * 'requires' is inherited from its parent). Queue order is unspecified.
+ * Returns a new reference the caller must destroy, or NULL with errno set
+ * on error.
+ */
+json_t *queues_list_response (struct queues *queues);
+
 /* Per-queue accessors
  * If q == NULL, assume anonymous queue.
  */

--- a/src/modules/job-manager/queues.h
+++ b/src/modules/job-manager/queues.h
@@ -130,8 +130,11 @@ json_t *queues_list_encode (struct queues *queues);
  * The "queues" name array is retained for backwards compatibility; "conf"
  * carries the effective per-queue configuration (a virtual queue's
  * 'requires' is inherited from its parent). Queue order is unspecified.
- * Returns a new reference the caller must destroy, or NULL with errno set
- * on error.
+ *
+ * The response is cached and rebuilt lazily; any queue mutation
+ * invalidates the cache. Returns a BORROWED reference owned by the queues
+ * object (do not destroy it; incref if it must outlive the next
+ * mutation), or NULL with errno set on error.
  */
 json_t *queues_list_response (struct queues *queues);
 

--- a/src/modules/job-manager/test/queues.c
+++ b/src/modules/job-manager/test/queues.c
@@ -1606,6 +1606,114 @@ static void test_list_encode (void)
     queues_destroy (qs);
 }
 
+/* Look up the conf.queues entry named 'name' in array 'cq', or NULL.
+ * Queue order in the array is not guaranteed, so entries are found by
+ * name rather than by position.
+ */
+static json_t *conf_entry (json_t *cq, const char *name)
+{
+    size_t index;
+    json_t *entry;
+
+    json_array_foreach (cq, index, entry) {
+        const char *n;
+        if (json_unpack (entry, "{s:s}", "name", &n) == 0 && streq (n, name))
+            return entry;
+    }
+    return NULL;
+}
+
+/* The queue-list response carries both the "queues" name array and a
+ * "conf" object with each queue's effective config. Effective
+ * 'requires'/'parent' are checked on a virtual queue.
+ */
+static void test_list_response (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+    json_t *resp;
+    json_t *names;
+    json_t *cq;
+    const char *name;
+    json_t *req0;
+    const char *parent2 = NULL;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* anon mode: names empty and conf.queues empty */
+    resp = queues_list_response (qs);
+    ok (resp != NULL
+        && json_unpack (resp,
+                        "{s:o s:{s:o}}",
+                        "queues", &names,
+                        "conf",
+                          "queues", &cq) == 0
+        && json_array_size (names) == 0
+        && json_array_size (cq) == 0,
+        "response in anon mode: empty queues and empty conf.queues");
+    json_decref (resp);
+
+    /* batch (real, requires=batch), then expedite (virtual, parent
+     * batch, no own requires). Queue order in the response is not
+     * guaranteed, so entries are checked by name.
+     */
+    config = json_pack ("{s:{s:[s]} s:{s:[s]} s:{s:s}}",
+                        "debug",
+                          "requires", "debug",
+                        "batch",
+                          "requires", "batch",
+                        "expedite",
+                          "parent", "batch");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed: %s", error.text);
+    json_decref (config);
+
+    resp = queues_list_response (qs);
+    ok (resp != NULL, "queues_list_response works in named mode");
+    ok (resp
+        && json_unpack (resp,
+                        "{s:o s:{s:o}}",
+                        "queues", &names,
+                        "conf",
+                          "queues", &cq) == 0,
+        "response has queues array and conf.queues array");
+
+    /* conf.queues carries an entry for each configured queue */
+    ok (cq && json_array_size (cq) == 3
+        && conf_entry (cq, "debug") != NULL
+        && conf_entry (cq, "batch") != NULL
+        && conf_entry (cq, "expedite") != NULL,
+        "conf.queues has an entry for each configured queue");
+
+    /* real queue carries its own requires, no parent key */
+    ok (json_unpack (conf_entry (cq, "batch"),
+                     "{s:s s:o !}",
+                     "name", &name,
+                     "requires", &req0) == 0
+        && json_array_size (req0) == 1
+        && streq (json_string_value (json_array_get (req0, 0)), "batch"),
+        "real queue conf carries own requires and no parent key");
+
+    /* virtual queue inherits parent's requires and reports parent */
+    ok (json_unpack (conf_entry (cq, "expedite"),
+                     "{s:s s:o s:s !}",
+                     "name", &name,
+                     "requires", &req0,
+                     "parent", &parent2) == 0
+        && streq (parent2, "batch")
+        && json_array_size (req0) == 1
+        && streq (json_string_value (json_array_get (req0, 0)), "batch"),
+        "virtual queue conf inherits parent requires and reports parent");
+
+    json_decref (resp);
+    queues_destroy (qs);
+}
+
 /* ---------- virtual queue (RFC 33) tests -------------------------------- */
 
 static void test_vqueue_configure (void)
@@ -2324,6 +2432,7 @@ int main (int argc, char *argv[])
     test_list_names ();
     test_status_encode ();
     test_list_encode ();
+    test_list_response ();
 
     test_vqueue_configure ();
     test_vqueue_reparent_on_reload ();

--- a/src/modules/job-manager/test/queues.c
+++ b/src/modules/job-manager/test/queues.c
@@ -1606,6 +1606,82 @@ static void test_list_encode (void)
     queues_destroy (qs);
 }
 
+/* Return the number of named queues currently configured. */
+static size_t named_queue_count (struct queues *qs)
+{
+    zlistx_t *names = queues_list_names (qs);
+    size_t n = zlistx_size (names);
+    zlistx_destroy (&names);
+    return n;
+}
+
+/* A failed queues_configure() must be rejected whole, leaving the
+ * previous configuration intact.
+ */
+static void test_configure_failure_preserves_state (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *good;
+    json_t *bad;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    good = json_pack ("{s:{} s:{} s:{}}", "a", "b", "c");
+    if (!good)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, good, &error) < 0)
+        BAIL_OUT ("queues_configure failed: %s", error.text);
+    json_decref (good);
+    ok (named_queue_count (qs) == 3, "initial configuration established");
+
+    /* A new config with an invalid (non-object) entry must be rejected
+     * whole, leaving the old configuration untouched.
+     */
+    bad = json_pack ("{s:{} s:{} s:i s:{}}",
+                     "c",
+                     "a",
+                     "bad", 5,
+                     "b");
+    if (!bad)
+        BAIL_OUT ("json_pack failed");
+    errno = 0;
+    ok (queues_configure (qs, bad, &error) < 0 && errno == EINVAL,
+        "configure with an invalid entry fails with EINVAL");
+    json_decref (bad);
+
+    ok (named_queue_count (qs) == 3
+        && queues_lookup (qs, "a", NULL) != NULL
+        && queues_lookup (qs, "b", NULL) != NULL
+        && queues_lookup (qs, "c", NULL) != NULL
+        && queues_lookup (qs, "bad", NULL) == NULL,
+        "failed configure leaves the previous configuration intact");
+
+    queues_destroy (qs);
+
+    /* Same, but starting from the anonymous queue: a failed configure
+     * must not partially transition to named mode.
+     */
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    bad = json_pack ("{s:{} s:i}", "a", "bad", 5);
+    if (!bad)
+        BAIL_OUT ("json_pack failed");
+    errno = 0;
+    ok (queues_configure (qs, bad, &error) < 0 && errno == EINVAL,
+        "configure from anon with an invalid entry fails with EINVAL");
+    json_decref (bad);
+
+    ok (!queues_have_named (qs) && queues_lookup (qs, NULL, NULL) != NULL,
+        "failed configure from anon leaves the anonymous queue intact");
+
+    queues_destroy (qs);
+}
+
 /* Look up the conf.queues entry named 'name' in array 'cq', or NULL.
  * Queue order in the array is not guaranteed, so entries are found by
  * name rather than by position.
@@ -2448,6 +2524,7 @@ int main (int argc, char *argv[])
     test_list_names ();
     test_status_encode ();
     test_list_encode ();
+    test_configure_failure_preserves_state ();
     test_list_response ();
 
     test_vqueue_configure ();

--- a/src/modules/job-manager/test/queues.c
+++ b/src/modules/job-manager/test/queues.c
@@ -1643,7 +1643,9 @@ static void test_list_response (void)
     if (!qs)
         BAIL_OUT ("queues_create failed");
 
-    /* anon mode: names empty and conf.queues empty */
+    /* anon mode: names empty and conf.queues empty. The returned
+     * reference is borrowed (owned by the cache), so it is not decref'd.
+     */
     resp = queues_list_response (qs);
     ok (resp != NULL
         && json_unpack (resp,
@@ -1654,7 +1656,6 @@ static void test_list_response (void)
         && json_array_size (names) == 0
         && json_array_size (cq) == 0,
         "response in anon mode: empty queues and empty conf.queues");
-    json_decref (resp);
 
     /* batch (real, requires=batch), then expedite (virtual, parent
      * batch, no own requires). Queue order in the response is not
@@ -1710,7 +1711,6 @@ static void test_list_response (void)
         && streq (json_string_value (json_array_get (req0, 0)), "batch"),
         "virtual queue conf inherits parent requires and reports parent");
 
-    json_decref (resp);
     queues_destroy (qs);
 }
 

--- a/src/modules/job-manager/test/queues.c
+++ b/src/modules/job-manager/test/queues.c
@@ -1711,6 +1711,22 @@ static void test_list_response (void)
         && streq (json_string_value (json_array_get (req0, 0)), "batch"),
         "virtual queue conf inherits parent requires and reports parent");
 
+    /* cache: a second call with no mutation returns the same object */
+    ok (queues_list_response (qs) == resp,
+        "queues_list_response returns cached object when unchanged");
+
+    /* cache: a mutation invalidates, so a fresh object is built. Hold a
+     * reference across the mutation: the borrowed 'resp' is owned by the
+     * cache, which decrefs (frees) it on invalidation, and comparing the
+     * rebuilt response against freed memory is undefined - the allocator
+     * may hand the same address back.
+     */
+    json_incref (resp);
+    queue_stop (queues_lookup (qs, "batch", NULL), NULL, false);
+    ok (queues_list_response (qs) != resp,
+        "a queue mutation invalidates the cached response");
+    json_decref (resp);
+
     queues_destroy (qs);
 }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -366,6 +366,7 @@ TESTSCRIPTS = \
 	python/t0046-job-watcher.py \
 	python/t0047-flux-argument-parser.py \
 	python/t0048-frobnicator-vqueue.py \
+	python/t0049-queue-conf.py \
 	python/t0100-modprobe.py \
 	python/t1000-service-add-remove.py \
 	python/t6010-fake-resources.py

--- a/t/python/t0034-queuelist.py
+++ b/t/python/t0034-queuelist.py
@@ -102,7 +102,54 @@ class TestQueueList(unittest.TestCase):
         self.assertEqual(qlist.debug.limits.duration, 3600.0)
         self.assertEqual(qlist.debug.limits.timelimit, 3600.0)
 
-    def test_003_vqueue_stale_parent(self):
+    def test_003_queue_list_conf(self):
+        # Exercise the queue-list RPC response directly: the conf object
+        # carries each queue's effective config, with a virtual queue
+        # inheriting its parent's requires. Queue order is not guaranteed,
+        # so compare by set / by name.
+        testconf = """
+        [queues.debug]
+        requires = ["debug"]
+
+        [queues.batch]
+        requires = ["batch"]
+
+        [queues.expedite]
+        parent = "batch"
+        """
+        self.fh.rpc("config.load", tomllib.loads(testconf)).get()
+
+        resp = self.fh.rpc("job-manager.queue-list").get()
+        self.assertEqual(set(resp["queues"]), {"debug", "batch", "expedite"})
+        conf = resp["conf"]["queues"]
+        self.assertEqual({q["name"] for q in conf}, {"debug", "batch", "expedite"})
+
+        by_name = {q["name"]: q for q in conf}
+        # real queue: own requires, no parent key
+        self.assertEqual(by_name["batch"]["requires"], ["batch"])
+        self.assertNotIn("parent", by_name["batch"])
+        # virtual queue: inherits parent's requires and reports parent
+        self.assertEqual(by_name["expedite"]["requires"], ["batch"])
+        self.assertEqual(by_name["expedite"]["parent"], "batch")
+
+        # A reconfigure is reflected in the response: drop 'debug' and
+        # confirm the remaining queues are those configured.
+        reconfig = """
+        [queues.expedite]
+        parent = "batch"
+
+        [queues.batch]
+        requires = ["batch"]
+        """
+        self.fh.rpc("config.load", tomllib.loads(reconfig)).get()
+        resp = self.fh.rpc("job-manager.queue-list").get()
+        self.assertEqual(set(resp["queues"]), {"expedite", "batch"})
+        self.assertEqual(
+            {q["name"] for q in resp["conf"]["queues"]},
+            {"expedite", "batch"},
+        )
+
+    def test_004_vqueue_stale_parent(self):
         # A QueueInfo parent (sourced from the queue-status RPC) missing
         # from the config (a separate RPC, so a config reload can race
         # the two) must raise, not fall back to the full instance

--- a/t/python/t0034-queuelist.py
+++ b/t/python/t0034-queuelist.py
@@ -18,7 +18,13 @@ except ModuleNotFoundError:
     from flux.utils import tomli as tomllib
 
 import flux
-from flux.queue import QueueInfo, QueueList
+from flux.queue import (
+    QueueConf,
+    QueueInfo,
+    QueueList,
+    queue_conf_from_config,
+    queue_config_fetch,
+)
 from flux.resource import resource_list
 from subflux import rerun_under_flux
 
@@ -148,6 +154,54 @@ class TestQueueList(unittest.TestCase):
             {q["name"] for q in resp["conf"]["queues"]},
             {"expedite", "batch"},
         )
+
+    def test_0035_conf_matches_helper(self):
+        # The queue_conf_from_config() helper (used as the fallback for
+        # older brokers and by the hidden --config-file/--from-stdin
+        # options) must reproduce the live job-manager 'conf' object
+        # exactly, so the two implementations do not drift. Queue order is
+        # not guaranteed, so compare with the queues list sorted by name.
+        testconf = """
+        [queues.debug]
+        requires = ["debug"]
+
+        [queues.batch]
+        requires = ["batch"]
+
+        [queues.expedite]
+        parent = "batch"
+        """
+        config = tomllib.loads(testconf)
+        self.fh.rpc("config.load", config).get()
+
+        def by_name(conf):
+            return sorted(conf["queues"], key=lambda q: q["name"])
+
+        resp = self.fh.rpc("job-manager.queue-list").get()
+        self.assertEqual(by_name(resp["conf"]), by_name(queue_conf_from_config(config)))
+
+    def test_0036_queue_config_fetch(self):
+        # queue_config_fetch() sends the request and its get() returns a
+        # QueueConf built from the live job-manager.
+        testconf = """
+        [queues.batch]
+        requires = ["batch"]
+        [queues.expedite]
+        parent = "batch"
+        """
+        self.fh.rpc("config.load", tomllib.loads(testconf)).get()
+
+        conf = queue_config_fetch(self.fh).get()
+        self.assertIsInstance(conf, QueueConf)
+        self.assertEqual(sorted(conf), ["batch", "expedite"])
+        # vqueue-resolved effective config from the live job-manager:
+        self.assertEqual(conf.requires("expedite"), ["batch"])
+        self.assertEqual(conf.parent("expedite"), "batch")
+
+        # a second fetch reflects the same configuration:
+        conf2 = queue_config_fetch(self.fh).get()
+        self.assertEqual(sorted(conf2), sorted(conf))
+        self.assertEqual(conf2.entries, conf.entries)
 
     def test_004_vqueue_stale_parent(self):
         # A QueueInfo parent (sourced from the queue-status RPC) missing

--- a/t/python/t0048-frobnicator-vqueue.py
+++ b/t/python/t0048-frobnicator-vqueue.py
@@ -13,8 +13,10 @@
 import unittest
 
 import subflux  # noqa: F401 - To set up PYTHONPATH
-from flux.job.frobnicator.plugins.constraints import QueueConfig
+from flux.job import JobspecV1
+from flux.job.frobnicator.plugins.constraints import apply_constraints
 from flux.job.frobnicator.plugins.defaults import DefaultsConfig
+from flux.queue import QueueConf
 from pycotap import TAPTestRunner
 
 
@@ -22,37 +24,63 @@ def defaults_config(system):
     return {"policy": {"jobspec": {"defaults": {"system": system}}}}
 
 
+def queue_conf(queues):
+    """A QueueConf from a raw [queues] table (as the job-manager resolves it)."""
+    return QueueConf.from_config({"queues": queues})
+
+
+def jobspec(queue=None):
+    js = JobspecV1.from_command(["hostname"])
+    if queue is not None:
+        js.queue = queue
+    return js
+
+
+def properties(js):
+    return js.attributes["system"].get("constraints", {}).get("properties")
+
+
 class TestConstraintsVQueue(unittest.TestCase):
-    """RFC 33 virtual queue constraint inheritance in the frobnicator."""
+    """The constraints frobnicator applies a queue's effective requires.
+
+    RFC 33 virtual-queue inheritance is resolved by the job-manager, so the
+    QueueConf entries already carry a vqueue's effective (parent's) requires.
+    """
 
     def test_vqueue_inherits_parent_requires(self):
-        qc = QueueConfig(
+        qc = queue_conf(
             {
-                "queues": {
-                    "batch": {"requires": ["batch"]},
-                    "expedite": {"parent": "batch"},
-                }
+                "batch": {"requires": ["batch"]},
+                "expedite": {"parent": "batch"},
             }
         )
-        # The vqueue's effective properties are the parent's.
-        self.assertEqual(qc.queue_properties("expedite"), ["batch"])
-        self.assertEqual(qc.queue_properties("expedite"), qc.queue_properties("batch"))
+        # The vqueue is constrained to the parent's required properties.
+        js = jobspec("expedite")
+        apply_constraints(qc, js)
+        self.assertEqual(properties(js), ["batch"])
 
     def test_nonvirtual_queue_uses_own_requires(self):
-        qc = QueueConfig({"queues": {"batch": {"requires": ["batch"]}}})
-        self.assertEqual(qc.queue_properties("batch"), ["batch"])
+        qc = queue_conf({"batch": {"requires": ["batch"]}})
+        js = jobspec("batch")
+        apply_constraints(qc, js)
+        self.assertEqual(properties(js), ["batch"])
 
-    def test_unknown_queue_returns_none(self):
-        qc = QueueConfig({"queues": {"batch": {"requires": ["batch"]}}})
-        self.assertIsNone(qc.queue_properties("nosuchqueue"))
+    def test_queue_without_requires_adds_no_constraint(self):
+        qc = queue_conf({"batch": {}})
+        js = jobspec("batch")
+        apply_constraints(qc, js)
+        self.assertIsNone(properties(js))
 
-    def test_vqueue_missing_parent_fails_closed(self):
-        # A vqueue whose parent is not configured must raise, not
-        # silently drop the parent's constraint (which would place the
-        # job outside the parent's resource slice).
-        qc = QueueConfig({"queues": {"expedite": {"parent": "nosuchqueue"}}})
+    def test_invalid_queue_fails(self):
+        qc = queue_conf({"batch": {"requires": ["batch"]}})
         with self.assertRaises(ValueError):
-            qc.queue_properties("expedite")
+            apply_constraints(qc, jobspec("nosuchqueue"))
+
+    def test_no_queue_is_noop(self):
+        qc = queue_conf({"batch": {"requires": ["batch"]}})
+        js = jobspec()
+        apply_constraints(qc, js)
+        self.assertIsNone(properties(js))
 
 
 class TestDefaultsVQueue(unittest.TestCase):

--- a/t/python/t0049-queue-conf.py
+++ b/t/python/t0049-queue-conf.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+
+import subflux  # noqa: F401 - To set up PYTHONPATH
+from flux.queue import QueueConf, queue_conf_from_config
+from pycotap import TAPTestRunner
+
+
+class TestQueueConfFromConfig(unittest.TestCase):
+    """queue_conf_from_config() builds the queue-list 'conf' object."""
+
+    def test_empty_config(self):
+        self.assertEqual(queue_conf_from_config({}), {"queues": []})
+        self.assertEqual(queue_conf_from_config({"queues": {}}), {"queues": []})
+
+    def test_all_queues_present(self):
+        config = {
+            "queues": {
+                "debug": {"requires": ["debug"]},
+                "batch": {"requires": ["batch"]},
+                "expedite": {"parent": "batch"},
+            }
+        }
+        conf = queue_conf_from_config(config)
+        self.assertEqual(
+            {q["name"] for q in conf["queues"]}, {"debug", "batch", "expedite"}
+        )
+
+    def test_real_queue_own_requires(self):
+        conf = queue_conf_from_config({"queues": {"batch": {"requires": ["batch"]}}})
+        entry = conf["queues"][0]
+        self.assertEqual(entry, {"name": "batch", "requires": ["batch"]})
+        self.assertNotIn("parent", entry)
+
+    def test_queue_without_requires_omits_key(self):
+        conf = queue_conf_from_config({"queues": {"plain": {}}})
+        self.assertEqual(conf["queues"], [{"name": "plain"}])
+
+    def test_vqueue_inherits_parent_requires(self):
+        config = {
+            "queues": {
+                "batch": {"requires": ["batch"]},
+                "expedite": {"parent": "batch"},
+            }
+        }
+        by_name = {q["name"]: q for q in queue_conf_from_config(config)["queues"]}
+        # The vqueue reports its parent and inherits the parent's requires.
+        self.assertEqual(by_name["expedite"]["parent"], "batch")
+        self.assertEqual(by_name["expedite"]["requires"], ["batch"])
+
+    def test_vqueue_parent_without_requires_omits_key(self):
+        config = {
+            "queues": {
+                "batch": {},
+                "expedite": {"parent": "batch"},
+            }
+        }
+        by_name = {q["name"]: q for q in queue_conf_from_config(config)["queues"]}
+        self.assertNotIn("requires", by_name["expedite"])
+        self.assertEqual(by_name["expedite"]["parent"], "batch")
+
+    def test_missing_parent_fails_closed(self):
+        # An unresolvable parent must raise (fail closed) rather than fall
+        # through to reporting the vqueue as unconstrained.
+        with self.assertRaises(ValueError) as ctx:
+            queue_conf_from_config({"queues": {"expedite": {"parent": "nosuchqueue"}}})
+        self.assertIn(
+            "parent queue 'nosuchqueue' is not configured", str(ctx.exception)
+        )
+
+
+class TestQueueConf(unittest.TestCase):
+    """QueueConf exposes effective per-queue configuration."""
+
+    # A representative config: a real queue with its own requires, a virtual
+    # queue inheriting its parent, and a queue with no requires.
+    # QueueConf.from_config runs it through queue_conf_from_config, so the
+    # per-queue requires entries are already vqueue-resolved.
+    CONFIG = {
+        "queues": {
+            "batch": {"requires": ["batch"]},
+            "expedite": {"parent": "batch"},
+            "plain": {},
+        },
+    }
+
+    def setUp(self):
+        self.qc = QueueConf.from_config(self.CONFIG)
+
+    def test_empty(self):
+        qc = QueueConf({"queues": []})
+        self.assertEqual(list(qc), [])
+
+    def test_empty_conf_object(self):
+        # An empty conf object (no "queues" key) is the anonymous-queue case.
+        qc = QueueConf({})
+        self.assertEqual(list(qc), [])
+        self.assertEqual(len(qc), 0)
+        self.assertFalse(qc)
+
+    def test_len_and_truthiness(self):
+        self.assertEqual(len(self.qc), 3)
+        self.assertTrue(self.qc)
+
+    def test_membership_and_iteration(self):
+        self.assertIn("expedite", self.qc)
+        self.assertNotIn("nosuchqueue", self.qc)
+        self.assertEqual(set(self.qc), {"batch", "expedite", "plain"})
+
+    def test_requires_vqueue_resolved(self):
+        # A virtual queue reports its parent's requires (resolved server-side).
+        self.assertEqual(self.qc.requires("expedite"), ["batch"])
+        self.assertEqual(self.qc.requires("batch"), ["batch"])
+        self.assertIsNone(self.qc.requires("plain"))
+
+    def test_requires_anonymous_or_unknown(self):
+        # name None (anonymous queue) or an unconfigured queue -> None.
+        self.assertIsNone(self.qc.requires(None))
+        self.assertIsNone(self.qc.requires("nosuchqueue"))
+
+    def test_parent(self):
+        self.assertEqual(self.qc.parent("expedite"), "batch")
+        # A non-virtual or unconfigured queue has no parent.
+        self.assertEqual(self.qc.parent("batch"), "")
+        self.assertEqual(self.qc.parent("nosuchqueue"), "")
+
+    def test_entries(self):
+        # The raw name -> entry escape hatch.
+        self.assertEqual(sorted(self.qc.entries), ["batch", "expedite", "plain"])
+        self.assertEqual(
+            self.qc.entries["batch"], {"name": "batch", "requires": ["batch"]}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -518,6 +518,19 @@ test_expect_success 'flux resource list -q strips all queue names from propertie
 	test_debug "cat listpropx_multi_q.out" &&
 	grep "free 2 $" listpropx_multi_q.out
 '
+# Exercise the online status -q path (queue config from the queue-list RPC,
+# not --from-stdin/--config-file): batch is configured on 2 of the 4 nodes.
+test_expect_success 'flux resource status -q filters to the requested queue' '
+	flux resource status -q batch -s all -o "{state} {nnodes}" \
+		>statusqueue_q.out &&
+	test_debug "cat statusqueue_q.out" &&
+	grep "avail 2" statusqueue_q.out
+'
+test_expect_success 'flux resource status -q rejects an invalid queue' '
+	test_must_fail flux resource status -q notaqueue 2>statusqueue_bad.err &&
+	test_debug "cat statusqueue_bad.err" &&
+	grep -i "no such queue\|not a valid queue\|notaqueue" statusqueue_bad.err
+'
 test_expect_success 'configure queues and resource with extra property' '
 	flux R encode -r 0-3 -p batch:0-1 -p debug:2-3 -p foo:0-3\
 	   | tr -d "\n" \

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -598,15 +598,15 @@ test_expect_success 'flux resource list --queue works for a queue with no constr
 	test_must_fail grep debug queue-every.out
 '
 test_expect_success 'flux resource list includes queue names for empty sets' '
-	# There are no nodes in 'down' state in this test, so use that:
+	# There are no nodes in 'down' state in this test, so use that.
+	# Queue order is not guaranteed, so grep for each expected line.
 	flux resource list -s down -no "{queue} {state} {nnodes}" \
 		>queue-empty1.out &&
-	cat <<-EOF >queue-empty1.expected &&
-	every down 0
-	batch down 0
-	debug down 0
-	EOF
-	test_cmp queue-empty1.expected queue-empty1.out
+	test_debug "cat queue-empty1.out" &&
+	test $(grep -c "^every down 0$" queue-empty1.out) -eq 1 &&
+	test $(grep -c "^batch down 0$" queue-empty1.out) -eq 1 &&
+	test $(grep -c "^debug down 0$" queue-empty1.out) -eq 1 &&
+	test $(wc -l <queue-empty1.out) -eq 3
 '
 test_expect_success 'flux resource list includes queue names for empty sets (single)' '
 	flux resource list -q batch -s down -no "{queue} {state} {nnodes}" \


### PR DESCRIPTION
This PR updates the `job-manager.queue-list` RPC to include the effective queue configuration in a new `conf` object, as a first step in making the job-manager the authoritative source for current queue configuration. Adding queue policy to the response is deferred to keep the PR reviewable, so only one consumer - `flux-resource.py` - is updated to use `conf`, which drops its need to read the `[queues]` table directly.

The updated response includes a new `conf` object next to the existing `queues` object. The `conf` object currently contains a single `queues` key - an array of queue configuration objects, e.g.:
```json
{"queues": [{"name:s", "requires?s", "parent?s"},  ...}.
```
 
Other details of interest:
- _"Effective" config_ means a vqueue's `requires` is copied from its parent, so clients stop re-deriving inherited fields from `[queues]`. Policy inheritance will follow.
- _Ordering:_ `conf` preserves config declaration order, matching the ordering clients got when reading `[queues]` directly.
- _Caching:_ the response is cached and rebuilt lazily, since it only changes on reconfig
- _Backward compatibility:_ `flux resource` falls back to reading `[queues]` from config directly if it is talking to an older job-manager that doesn't supply the `conf` object in its response.
