### PR TITLE
libsubprocess: fix potential hang in buffered read watcher

### DIFF
--- a/src/common/libsubprocess/fbuf_watcher.c
+++ b/src/common/libsubprocess/fbuf_watcher.c
@@ -196,22 +196,25 @@ static void rbwatcher_fd_cb (flux_reactor_t *r,
         if ((space = fbuf_space (rbw->fbuf)) < 0)
             return;
 
+        bool read_error = false;
         if ((ret = fbuf_write_from_fd (rbw->fbuf, rbw->fd, space)) < 0) {
-            /* EAGAIN and EWOULDBLOCK are transient errors: return and
-             * try again. Otherwise, stop the watcher and return
-             * FLUX_POLLERR to catch permanent errors like EBADF.
+            /* EAGAIN and EWOULDBLOCK are transient errors: return and try
+             * again. Otherwise, set EOF and raise POLLERR on a permanent
+             * read error.
              */
             if (errno == EAGAIN || errno == EWOULDBLOCK)
                 return;
-            flux_watcher_stop (fd_w);
-            watcher_call (w, FLUX_POLLERR);
-            return;
+            read_error = true;
+            ret = 0;
         }
 
         if (!ret) {
             fbuf_read_watcher_decref (w);
             (void)fbuf_readonly (rbw->fbuf);
             flux_watcher_stop (fd_w);
+            /* N.B. call last: the callback may destroy the watcher */
+            if (read_error)
+                watcher_call (w, FLUX_POLLERR);
         }
         else if (ret == space) {
             /* buffer full, rbwatcher_notify_cb will be called

--- a/src/common/libsubprocess/fbuf_watcher.c
+++ b/src/common/libsubprocess/fbuf_watcher.c
@@ -104,7 +104,14 @@ static void rbwatcher_start (flux_watcher_t *w)
     if (!rbw->start) {
         flux_watcher_start (rbw->prepare_w);
         flux_watcher_start (rbw->check_w);
-        if (fbuf_space (rbw->fbuf) > 0)
+        /* Do not (re)start the fd watcher after EOF: the buffer is read-only
+         * and a further read fails with EROFS. This can occur when the
+         * watcher is stopped and restarted after EOF, for example the
+         * flux_subprocess_stream_stop()/_start() calls used for output flow
+         * control. The prepare/check watchers still deliver any buffered data
+         * and the final EOF to the user.
+         */
+        if (!rbw->eof_read && fbuf_space (rbw->fbuf) > 0)
             flux_watcher_start (rbw->fd_w);
         /* else: buffer full, buffer_notify_cb will be called
          * to re-enable io reactor when space is available */
@@ -221,9 +228,13 @@ static void rbwatcher_notify_cb (struct fbuf *fb, void *arg)
 {
     struct rbwatcher *rbw = arg;
 
-    /* space is available, start ev io watcher again, assuming watcher
-     * is not stopped by user */
-    if (rbw->start && fbuf_space (fb) > 0)
+    /* Space is available, start ev io watcher again, assuming watcher is not
+     * stopped by user. Do not re-arm after EOF: the buffer is read-only, so
+     * a further read fails with EROFS. Draining buffered data triggers this
+     * callback, and a re-armed fd watcher would fire again on the readable
+     * (EOF) fd, stranding the read side. See flux-framework/flux-core#7406.
+     */
+    if (rbw->start && !rbw->eof_read && fbuf_space (fb) > 0)
         flux_watcher_start (rbw->fd_w);
 }
 

--- a/src/common/libsubprocess/test/fbuf_watcher.c
+++ b/src/common/libsubprocess/test/fbuf_watcher.c
@@ -1169,16 +1169,21 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
     close (fd[1]);
 }
 
-/* Regression test for issue #7774.
+/* Regression test for issues #7774 and #7406.
  *
  * A read buffer watcher on a fd that polls ready but returns a persistent
- * error on read() (e.g. EBADF) must stop the watcher and notify the user
- * with FLUX_POLLERR, rather than spinning at 100% CPU re-reading the fd.
+ * error on read() (e.g. EBADF) must not spin at 100% CPU re-reading the fd
+ * (#7774). The permanent error is delivered to the user as FLUX_POLLERR - so
+ * a client may report it - and then also as EOF (an empty-buffer FLUX_POLLIN)
+ * so the stream still completes rather than being stranded (#7406). The error
+ * callback is delivered first, the EOF callback second.
  */
 
 struct buffer_read_error {
     int count;
-    int revents;
+    int err_revents;   /* revents on the first (error) callback */
+    int eof_revents;   /* revents on the second (EOF) callback */
+    int eof_len;       /* length returned by the read on the EOF callback */
 };
 
 static void buffer_read_error_cb (flux_reactor_t *r,
@@ -1187,10 +1192,22 @@ static void buffer_read_error_cb (flux_reactor_t *r,
                                    void *arg)
 {
     struct buffer_read_error *err = arg;
+
+    if (err->count == 0)
+        err->err_revents = revents;
+    else {
+        err->eof_revents = revents;
+        if (revents & FLUX_POLLIN) {
+            struct fbuf *fb = fbuf_read_watcher_get_buffer (w);
+            const void *ptr;
+            int len = -1;
+            if (fb && (ptr = fbuf_read (fb, -1, &len)))
+                err->eof_len = len;
+        }
+        flux_watcher_stop (w);
+        flux_reactor_stop (r);
+    }
     err->count++;
-    err->revents = revents;
-    flux_watcher_stop (w);
-    flux_reactor_stop (r);
 }
 
 /* Watchdog: if the watcher busy loops, the reactor never returns on its
@@ -1212,7 +1229,10 @@ static void test_buffer_read_error (flux_reactor_t *reactor)
     int fd;
     flux_watcher_t *w;
     flux_watcher_t *timer;
-    struct buffer_read_error err = { .count = 0, .revents = 0 };
+    struct buffer_read_error err = { .count = 0,
+                                     .err_revents = 0,
+                                     .eof_revents = 0,
+                                     .eof_len = -1 };
     int timed_out = 0;
 
     /* Open /dev/null write-only: the fd is valid and can be made
@@ -1248,10 +1268,14 @@ static void test_buffer_read_error (flux_reactor_t *reactor)
 
     ok (!timed_out,
         "buffer read error: watcher stopped instead of busy looping");
-    ok (err.count == 1,
-        "buffer read error: user callback called exactly once");
-    ok ((err.revents & FLUX_POLLERR),
-        "buffer read error: user callback got FLUX_POLLERR");
+    ok (err.count == 2,
+        "buffer read error: user callback called twice (error, then EOF)");
+    ok ((err.err_revents & FLUX_POLLERR),
+        "buffer read error: first callback got FLUX_POLLERR");
+    ok ((err.eof_revents & FLUX_POLLIN),
+        "buffer read error: second callback got EOF (FLUX_POLLIN)");
+    ok (err.eof_len == 0,
+        "buffer read error: EOF callback read returned 0 bytes");
 
     flux_watcher_stop (timer);
     flux_watcher_destroy (timer);


### PR DESCRIPTION
This PR addresses the cause of the hangs observed in #7778. When a permanent read error is returned in a buffered read watcher, set EOF on the target fd (no more data will be forthcoming) in addition to raising `FLUX_POLLER`. This ensures that the rbwatcher doesn't wait forever for an EOF that isn't coming.

Also, fix a couple spots where the fdwatcher was re-armed after EOF is set: resulting in an unnecessary callback that immediately returns `EROFS` since the buffer has been marked read-only.