### PR TITLE
fix segfault in `flux job eventlog --follow`

### DIFF
--- a/src/cmd/job/eventlog.c
+++ b/src/cmd/job/eventlog.c
@@ -304,6 +304,9 @@ static bool wait_event_test (struct wait_event_ctx *ctx, json_t *event)
     json_t *context = NULL;
     bool match = false;
 
+    if (!ctx->wait_event)
+        return false;
+
     if (eventlog_entry_parse (event, &timestamp, &name, &context) < 0)
         log_err_exit ("eventlog_entry_parse");
 
@@ -347,7 +350,7 @@ static void wait_event_continuation (flux_future_t *f, void *arg)
                           ctx->wait_event);
         } else if (errno == ENODATA) {
             flux_future_destroy (f);
-            if (!ctx->got_event)
+            if (ctx->wait_event && !ctx->got_event)
                 log_msg_exit ("event '%s' never received",
                               ctx->wait_event);
             return;

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -256,6 +256,23 @@ test_expect_success NO_CHAIN_LINT 'flux job eventlog -F, --follow works' '
 	test_debug "cat eventlog-follow.out" &&
 	grep clean eventlog-follow.out
 '
+test_expect_success 'submit job for chain-lint allowed eventlog follow tests' '
+	jobid=$(flux submit -n1 hostname)
+'
+test_expect_success 'flux job eventlog -F, --follow works with guest.output' '
+	run_timeout 30 \
+	  flux job eventlog -p guest.output -HF $jobid \
+		> eventlog-follow-output.out &&
+	test_debug "cat eventlog-follow-output.out" &&
+	grep $(hostname) eventlog-follow-output.out
+'
+test_expect_success 'flux job eventlog -F, --follow works with exec eventlog' '
+	run_timeout 30 \
+	  flux job eventlog -p exec -HF $jobid \
+		> eventlog-follow-exec.out &&
+	test_debug "cat eventlog-follow-exec.out" &&
+	grep done eventlog-follow-exec.out
+'
 #
 #  Color and human-readable output tests for flux job eventlog/wait-event
 #

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -405,8 +405,8 @@ test_expect_success NO_CHAIN_LINT 'attach: --tail works without arg (live job)' 
 	kill -INT ${pidB} &&
 	sleep 0.2 &&
 	kill -INT ${pidB} &&
-	! wait ${pidA} &&
-	! wait ${pidB} &&
+	wait ${pidA} &&
+	test_must_fail_or_be_terminated wait ${pidB} &&
 	test_must_fail grep "START" tail4B.out &&
 	tail -n 1 tail4B.out | grep "BAR" &&
 	count=`grep FOO tail4B.out | wc -l` &&
@@ -425,8 +425,8 @@ test_expect_success NO_CHAIN_LINT 'attach: --tail works with arg > 0 (live job)'
 	kill -INT ${pidB} &&
 	sleep 0.2 &&
 	kill -INT ${pidB} &&
-	! wait ${pidA} &&
-	! wait ${pidB} &&
+	wait ${pidA} &&
+	test_must_fail_or_be_terminated wait ${pidB} &&
 	test_must_fail grep "START" tail5B.out &&
 	tail -n 1 tail5B.out | grep "BAR" &&
 	count=`grep FOO tail4B.out | wc -l` &&
@@ -445,8 +445,8 @@ test_expect_success NO_CHAIN_LINT 'attach: --tail works with arg == 0 (live job)
 	kill -INT ${pidB} &&
 	sleep 0.2 &&
 	kill -INT ${pidB} &&
-	! wait ${pidA} &&
-	! wait ${pidB} &&
+	wait ${pidA} &&
+	test_must_fail_or_be_terminated wait ${pidB} &&
 	test_must_fail grep "START" tail6B.out &&
 	tail -n 1 tail6B.out | grep "BAR" &&
 	test_must_fail grep "FOO" tail6B.out


### PR DESCRIPTION
This PR fixes a potential segfault in `flux job eventlog --follow`, fixes a couple instances of test fallout from that change, and finally adds a couple tests to get coverage of `flux job eventlog --follow` with alternate named eventlogs.