### PR TITLE
testsuite: add cocci check for double-free json_pack() style functions

### DIFF
--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -49,9 +49,10 @@ flux_future_t *flux_job_raise (flux_t *h,
                              "job-manager.raise",
                              FLUX_NODEID_ANY,
                              0,
-                             "o",
+                             "O",
                              o)))
         goto error;
+    json_decref (o);
     return f;
 nomem:
     errno = ENOMEM;

--- a/src/common/libjob/jobspec1.c
+++ b/src/common/libjob/jobspec1.c
@@ -704,7 +704,6 @@ static json_t *tasks_create (int argc, char **argv)
                              "count",
                              "per_slot",
                              1))) {
-        json_decref (argv_json);
         errno = ENOMEM;
         return NULL;
     }
@@ -760,7 +759,6 @@ static json_t *resources_create (int ntasks,
                                 "count", nnodes,
                                 "with",
                                 slot))) {
-            json_decref (slot);
             goto nomem;
         }
         return node;
@@ -806,8 +804,6 @@ flux_jobspec1_t *flux_jobspec1_from_command (int argc,
                                "duration", duration,
                              "environment",
                            "version", 1))) {
-        json_decref (tasks);
-        json_decref (resources);
         errno = ENOMEM;
         return NULL;
     }

--- a/src/common/libjob/list.c
+++ b/src/common/libjob/list.c
@@ -52,7 +52,7 @@ flux_future_t *flux_job_list (flux_t *h,
                              "job-list.list",
                              FLUX_NODEID_ANY,
                              0,
-                             "{s:i s:o s:o}",
+                             "{s:i s:O s:O}",
                              "max_entries", max_entries,
                              "attrs", o,
                              "constraint", c))) {
@@ -62,6 +62,8 @@ flux_future_t *flux_job_list (flux_t *h,
         errno = saved_errno;
         return NULL;
     }
+    json_decref (o);
+    json_decref (c);
     return f;
 }
 
@@ -92,7 +94,7 @@ flux_future_t *flux_job_list_inactive (flux_t *h,
                              "job-list.list",
                              FLUX_NODEID_ANY,
                              0,
-                             "{s:i s:f s:o s:o}",
+                             "{s:i s:f s:O s:O}",
                              "max_entries", max_entries,
                              "since", since,
                              "attrs", o,
@@ -103,6 +105,8 @@ flux_future_t *flux_job_list_inactive (flux_t *h,
         errno = saved_errno;
         return NULL;
     }
+    json_decref (o);
+    json_decref (c);
     return f;
 }
 

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -509,7 +509,6 @@ json_t *treeobj_create_symlink (const char *ns, const char *target)
                            "ver", treeobj_version,
                            "type", "symlink",
                            "data", data))) {
-        json_decref (data);
         errno = ENOMEM;
         return NULL;
     }

--- a/src/common/librlist/rnode.c
+++ b/src/common/librlist/rnode.c
@@ -889,10 +889,10 @@ json_t *rnode_encode (const struct rnode *n, const struct idset *ids)
         return NULL;
     if (!(children = children_encode (n)))
         goto done;
-    if (!(o = json_pack ("{s:s s:o}",
-                         "rank", ranks,
-                         "children", children)))
-        goto done;
+    /* json_pack() steals the reference to 'children' on success and failure. */
+    o = json_pack ("{s:s s:o}",
+                   "rank", ranks,
+                   "children", children);
     children = NULL;
 done:
     json_decref (children);

--- a/src/common/libtaskmap/taskmap.c
+++ b/src/common/libtaskmap/taskmap.c
@@ -787,9 +787,12 @@ json_t *taskmap_encode_json (const struct taskmap *map, int flags)
     }
     if (!(flags & TASKMAP_ENCODE_WRAPPED))
         return blocks;
-    if (!(taskmap = json_pack ("{s:i s:o}",
-                               "version", 1,
-                               "map", blocks)))
+    /* json_pack() steals the reference to 'blocks' on success and failure */
+    taskmap = json_pack ("{s:i s:o}",
+                         "version", 1,
+                         "map", blocks);
+    blocks = NULL;
+    if (!taskmap)
         goto error;
     return taskmap;
 error:

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -703,7 +703,6 @@ static json_t *stats_checkpoints (struct content_sqlite *ctx,
                              "id", id,
                              "value", value))
             || json_array_append_new (checkpts, o) < 0) {
-            json_decref (value);
             // jansson decrefs the new object on failure
             errprintf (errp, "checkpt_get_all: out of memory");
             errno = ENOMEM;

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -263,7 +263,10 @@ static int legacy_list_rpc (flux_t *h,
         }
     }
 
-    if (!((*legacy_constraint) = json_pack ("{s:o}", "and", a)))
+    /* json_pack() steals the reference to 'a' on success and failure */
+    *legacy_constraint = json_pack ("{s:o}", "and", a);
+    a = NULL;
+    if (!*legacy_constraint)
         goto error;
 
     return 0;

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -293,13 +293,14 @@ static void handle_load_response (flux_future_t *f, struct watcher *w)
             errprintf (&err, "failed to create treeobj value");
             goto error_respond;
         }
-        if (flux_respond_pack (h, w->request, "{ s:o }", "val", val) < 0) {
+        if (flux_respond_pack (h, w->request, "{ s:O }", "val", val) < 0) {
             flux_log_error (h,
                             "%s: failed to respond to kvs-watch.lookup",
                             __FUNCTION__);
             json_decref (val);
             goto finished;
         }
+        json_decref (val);
         w->loaded_blob_count++;
         w->responded = true;
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -411,7 +411,8 @@ EXTRA_DIST= \
 	scheduler/sched_tree_amender.py \
 	scheduler/sched-tree-subclass.py \
 	cocci/json_set_new_decref.cocci \
-	cocci/json_pack_o_decref.cocci
+	cocci/json_pack_o_decref.cocci \
+	cocci/json_pack_mixed_oO.cocci
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -410,7 +410,8 @@ EXTRA_DIST= \
 	scheduler/sched-slowgen.py \
 	scheduler/sched_tree_amender.py \
 	scheduler/sched-tree-subclass.py \
-	cocci/json_set_new_decref.cocci
+	cocci/json_set_new_decref.cocci \
+	cocci/json_pack_o_decref.cocci
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/cocci/json_pack_mixed_oO.cocci
+++ b/t/cocci/json_pack_mixed_oO.cocci
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: LGPL-3.0
+//
+// Forbid mixing 'o' and 'O' specifiers in a single jansson pack format.
+//
+// In the jansson pack family (json_pack() and the flux *_pack() wrappers
+// built on it), 'o' STEALS the reference to its json_t argument while 'O'
+// INCREMENTS it.  A format that uses both in one call therefore mixes two
+// opposite ownership conventions: some passed values are consumed and some
+// are borrowed, and which is which depends on reading the format positions
+// against the argument list.  This is error prone for humans and defeats
+// json_pack_o_decref.cocci, whose steal-vs-decref analysis deliberately
+// gives up on such formats (it can only reason about a call when every
+// json_t argument is handled the same way).  Requiring a single convention
+// per call -- all 'o' or all 'O' -- keeps both the code and that check
+// tractable.  Rewrite a mixed call to use 'O' throughout (incref) and
+// json_decref() each retained value on all paths.
+//
+// The format string is matched by regex: a rule fires when the format
+// literal contains both a lowercase 'o' and an uppercase 'O', in either
+// order.  The Str-syntax alternation "o.*O\|O.*o" covers both.
+//
+// The format metavariable is pinned to its argument position in each
+// function so that the regex tests the format string itself and not a key
+// string (object keys are separate 's' arguments and may contain the
+// letters 'o' and 'O', e.g. "coordO").  Functions are grouped below by how
+// many arguments precede the format.  The set matches json_pack_o_decref.cocci;
+// the va_list vpack variants take their values through a va_list and are
+// likewise out of scope here.
+
+// ---- format is the 1st argument ----
+
+@@
+constant char []fmt =~ "o.*O\|O.*o";
+identifier packfn = { json_pack, flux_conf_pack };
+@@
+* packfn(fmt, ...)
+
+// ---- format is the 2nd argument ----
+
+@@
+constant char []fmt =~ "o.*O\|O.*o";
+identifier packfn =
+  { flux_msg_pack, flux_event_pack, flux_jobtap_jobspec_update_pack };
+expression a1;
+@@
+* packfn(a1, fmt, ...)
+
+// ---- format is the 3rd argument ----
+
+@@
+constant char []fmt =~ "o.*O\|O.*o";
+identifier packfn =
+  { json_pack_ex, flux_respond_pack, flux_plugin_arg_pack,
+    flux_shell_setopt_pack, flux_jobtap_jobspec_update_id_pack };
+expression a1, a2;
+@@
+* packfn(a1, a2, fmt, ...)
+
+// ---- format is the 4th argument ----
+
+@@
+constant char []fmt =~ "o.*O\|O.*o";
+identifier packfn =
+  { flux_event_publish_pack, flux_kvs_txn_pack, flux_jobtap_event_post_pack };
+expression a1, a2, a3;
+@@
+* packfn(a1, a2, a3, fmt, ...)
+
+// ---- format is the 5th argument ----
+
+@@
+constant char []fmt =~ "o.*O\|O.*o";
+identifier packfn = { flux_rpc_pack, flux_shell_rpc_pack };
+expression a1, a2, a3, a4;
+@@
+* packfn(a1, a2, a3, a4, fmt, ...)

--- a/t/cocci/json_pack_o_decref.cocci
+++ b/t/cocci/json_pack_o_decref.cocci
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: LGPL-3.0
+//
+// Detect double-free of a json_t value stolen by a bare 'o' pack specifier.
+//
+// In the jansson pack family (json_pack() and the flux *_pack() wrappers
+// built on it), the 'o' specifier STEALS the reference to its json_t
+// argument, whether the pack succeeds or fails.  On failure jansson still
+// consumes (decref's) the value, so a subsequent json_decref() of that same
+// value is a double-free on the error path (or a premature free of a
+// now-container-owned reference on the success path).  Once a value has
+// been handed to a pack function via 'o', the caller must not decref it
+// again unless it first reassigns or re-increfs it.  ('O', by contrast,
+// increments the refcount, so the caller retains and must free its own
+// reference -- that decref is correct and is NOT flagged.)
+//
+// The format string is matched by regex: a rule fires only when the format
+// literal contains a lowercase 'o' and no uppercase 'O'.  With no 'O'
+// present, every json_t passed is stolen, so a decref of any passed value
+// is unambiguously wrong -- there is no borrowed 'O' value to confuse it
+// with.  Formats mixing 'o' and 'O', and non-literal (computed) formats,
+// are intentionally not handled here.  ('o'/'O' are the only two specifiers
+// that consume a json_t; scalar args like 's'/'i'/'f' are never decref'd,
+// so their presence in the format is harmless.)
+//
+// The format metavariable is pinned to its argument position in each
+// function so that the regex tests the format string itself and not a key
+// string (object keys are separate 's' arguments and may contain the
+// letter 'o', e.g. "mods").  Functions are grouped below by how many
+// arguments precede the format.
+//
+// Like json_set_new_decref.cocci, this matches on data flow, so it catches
+// the decref regardless of how control reaches it (direct, via goto to a
+// shared error label, or via ERRNO_SAFE_WRAP() at such a label).  The
+// "when !=" constraints suppress the match when the value is reassigned or
+// re-increfed between the steal and the decref.
+
+// ---- format is the 1st argument ----
+
+@@
+constant char []fmt =~ "^[^O]*o[^O]*$";
+identifier packfn = { json_pack, flux_conf_pack };
+identifier decref = json_decref;
+expression val, E;
+@@
+  packfn(fmt, ..., val, ...)
+  ... when != val = E
+      when != json_incref(val)
+(
+* decref(val)
+|
+* ERRNO_SAFE_WRAP(decref, val)
+)
+
+// ---- format is the 2nd argument ----
+
+@@
+constant char []fmt =~ "^[^O]*o[^O]*$";
+identifier packfn =
+  { flux_msg_pack, flux_event_pack, flux_jobtap_jobspec_update_pack };
+identifier decref = json_decref;
+expression a1, val, E;
+@@
+  packfn(a1, fmt, ..., val, ...)
+  ... when != val = E
+      when != json_incref(val)
+(
+* decref(val)
+|
+* ERRNO_SAFE_WRAP(decref, val)
+)
+
+// ---- format is the 3rd argument ----
+
+@@
+constant char []fmt =~ "^[^O]*o[^O]*$";
+identifier packfn =
+  { json_pack_ex, flux_respond_pack, flux_plugin_arg_pack,
+    flux_shell_setopt_pack, flux_jobtap_jobspec_update_id_pack };
+identifier decref = json_decref;
+expression a1, a2, val, E;
+@@
+  packfn(a1, a2, fmt, ..., val, ...)
+  ... when != val = E
+      when != json_incref(val)
+(
+* decref(val)
+|
+* ERRNO_SAFE_WRAP(decref, val)
+)
+
+// ---- format is the 4th argument ----
+
+@@
+constant char []fmt =~ "^[^O]*o[^O]*$";
+identifier packfn =
+  { flux_event_publish_pack, flux_kvs_txn_pack, flux_jobtap_event_post_pack };
+identifier decref = json_decref;
+expression a1, a2, a3, val, E;
+@@
+  packfn(a1, a2, a3, fmt, ..., val, ...)
+  ... when != val = E
+      when != json_incref(val)
+(
+* decref(val)
+|
+* ERRNO_SAFE_WRAP(decref, val)
+)
+
+// ---- format is the 5th argument ----
+
+@@
+constant char []fmt =~ "^[^O]*o[^O]*$";
+identifier packfn = { flux_rpc_pack, flux_shell_rpc_pack };
+identifier decref = json_decref;
+expression a1, a2, a3, a4, val, E;
+@@
+  packfn(a1, a2, a3, a4, fmt, ..., val, ...)
+  ... when != val = E
+      when != json_incref(val)
+(
+* decref(val)
+|
+* ERRNO_SAFE_WRAP(decref, val)
+)


### PR DESCRIPTION
Problem: as touched on yesterday in #7772, it's easy to forget that jansson functions like the ones ending in `_new()` and the `json_pack()` variants with the `o` (little o) specifier steal their json object arguments on failure as well as success.

We have a coccinelle rule for the `_new()` case.  Add one for the `json_pack()` case, and fix some (very unlikely) code paths that would double free.

Caveat: mixed `o` and `O` in a pack function could not be checked with the rule proposed here.  Apparently we don't do that anywhere in the code base, so I just added another rule to forbid mixing, which might be considered a bad practice since these refcounts are tricky? :shrug:.  That bit could be dropped if it's too draconian.