### PR TITLE
job-manager: add effective queue policy to the queue-list RPC

### DIFF
--- a/src/bindings/python/flux/job/frobnicator/plugins/defaults.py
+++ b/src/bindings/python/flux/job/frobnicator/plugins/defaults.py
@@ -8,84 +8,36 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-"""Apply defaults to incoming jobspec based on broker config."""
-
-import copy
+"""Apply queue job defaults to incoming jobspec from the job-manager."""
 
 from flux.job.frobnicator import FrobnicatorPlugin
+from flux.queue import QueueConf
 
 
 class DefaultsConfig:
     """Convenience class for handling jobspec defaults configuration"""
 
-    def __init__(self, config={}):
-        self.defaults = {}
-        self.queues = {}
-        self.default_queue = None
-
-        try:
-            self.defaults = config["policy"]["jobspec"]["defaults"]["system"]
-            self.default_queue = self.defaults["queue"]
-        except KeyError:
-            pass
-
-        try:
-            self.queues = config["queues"]
-        except KeyError:
-            pass
-
-        self.validate_config()
-
-    def validate_config(self):
-        if self.queues and not isinstance(self.queues, dict):
-            raise ValueError("queues must be a table")
-
-        if self.default_queue and self.default_queue not in self.queues:
-            raise ValueError(
-                f"default queue '{self.default_queue}' must be in [queues]"
-            )
-
-        for queue in self.queues:
-            self.queue_defaults(queue)
+    def __init__(self, queue_conf=None):
+        # 'queue_conf' is a flux.queue.QueueConf, with each queue's effective
+        # defaults (the global defaults overlaid by the queue's own, RFC 33
+        # virtual-queue inheritance resolved) already computed.
+        self.queue_conf = queue_conf if queue_conf is not None else QueueConf({})
+        # The broker will have rejected a config with a default queue that
+        # is not also in [queues]. However, protect against it here anyway
+        # and raise a sensible error:
+        default = self.queue_conf.default_queue
+        if default and default not in self.queue_conf:
+            raise ValueError(f"default queue '{default}' must be in [queues]")
 
     def queue_defaults(self, name):
-        """Create a copy of self.defaults updated with queue-specific values
+        """Return the effective job defaults for a queue (None = anonymous).
 
-        Effective defaults are layered: global defaults, then (if 'name'
-        is a virtual queue, RFC 33) the parent queue's own defaults,
-        then this queue's own defaults - each layer overlaid per-key
-        over the last. Inheritance is one level (validated by
-        conf_policy.c), so there is no chain to walk beyond the parent.
+        The job-manager resolves RFC 33 virtual-queue inheritance, so this is
+        just the queue's effective ``jobspec.defaults.system``.
         """
-
-        def queue_system_defaults(qconf):
-            try:
-                return qconf["policy"]["jobspec"]["defaults"]["system"]
-            except KeyError:
-                return None
-
-        defaults = copy.deepcopy(self.defaults)
-        if name and self.queues:
-            if name not in self.queues:
-                raise ValueError(f"Invalid queue '{name}' specified")
-            qconf = self.queues[name]
-            # A virtual queue (RFC 33) inherits the parent's defaults
-            # beneath its own. An unresolvable parent is a fatal error
-            # (fail closed): silently skipping the parent layer would
-            # give the vqueue the wrong effective defaults.
-            parent = qconf.get("parent")
-            if parent is not None:
-                if parent not in self.queues:
-                    raise ValueError(
-                        f"queue '{name}': parent queue '{parent}' is not configured"
-                    )
-                pdefaults = queue_system_defaults(self.queues[parent])
-                if pdefaults is not None:
-                    defaults.update(pdefaults)
-            qdefaults = queue_system_defaults(qconf)
-            if qdefaults is not None:
-                defaults.update(qdefaults)
-        return defaults
+        if name is not None and name not in self.queue_conf:
+            raise ValueError(f"Invalid queue '{name}' specified")
+        return self.queue_conf.defaults(name)
 
     def setattr_default(self, jobspec, attr, value):
         if attr == "duration" and jobspec.duration == 0:
@@ -96,8 +48,10 @@ class DefaultsConfig:
     def apply_defaults(self, jobspec):
         """Apply general defaults then queue-specific defaults to jobspec"""
 
-        queue = jobspec.queue or self.defaults.get("queue")
-        if queue is None and self.queues:
+        queue = jobspec.queue or self.queue_conf.default_queue or None
+        # A falsy QueueConf means no named queues are configured, so the
+        # anonymous queue is valid; otherwise a queue is required.
+        if queue is None and self.queue_conf:
             raise ValueError("no queue specified")
 
         for attr, value in self.queue_defaults(queue).items():
@@ -110,7 +64,9 @@ class Frobnicator(FrobnicatorPlugin):
         super().__init__(parser)
 
     def configure(self, args, config):
-        self.config = DefaultsConfig(config)
+        # queue_conf is injected by the framework as an attribute (see
+        # FrobnicatorPlugin) before configure() is called.
+        self.config = DefaultsConfig(self.queue_conf)
 
     def frob(self, jobspec, user, urgency, flags):
         self.config.apply_defaults(jobspec)

--- a/src/bindings/python/flux/queue.py
+++ b/src/bindings/python/flux/queue.py
@@ -150,25 +150,11 @@ class QueueResources:
             allocated to jobs
     """
 
-    def __init__(self, name, resources, config, parent=""):
-        # A virtual queue (RFC 33) has no "requires" of its own (enforced
-        # at config validation), so it takes its parent's resource slice
-        # instead of the full instance resource set. 'parent' comes from
-        # the queue-status RPC while 'config' comes from a separate
-        # config.get RPC, so a config reload can race the two: a parent
-        # that is no longer in config is an error (fail closed), since
-        # falling through would silently report the vqueue as covering
-        # the full instance resource set.
-        requires = None
-        queues = config.get("queues", {})
-        if name and name in queues:
-            requires = queues[name].get("requires")
-        if requires is None and parent:
-            if parent not in queues:
-                raise ValueError(
-                    f"queue '{name}': parent queue '{parent}' is not configured"
-                )
-            requires = queues[parent].get("requires")
+    def __init__(self, resources, requires):
+        # 'requires' is the queue's effective required-properties array (an
+        # RFC 33 virtual queue's is resolved from its parent by the
+        # job-manager), or None. A queue with no requires covers the full
+        # instance resource set.
         if requires is not None:
             self._resource_list = resources.copy_constraint({"properties": requires})
         else:
@@ -408,26 +394,27 @@ class QueueInfo:
     def __init__(
         self,
         name,
-        config,
+        queue_conf,
         resources,
         enabled,
         started,
         default,
-        parent="",
         blocked=None,
     ):
+        # 'queue_conf' is a QueueConf (the job-manager's authoritative queue
+        # configuration). It provides this queue's effective requires, its
+        # resolved parent, and its effective policy (the global policy and
+        # RFC 33 virtual-queue inheritance already merged in). 'name' is
+        # None for the anonymous queue.
         self.name = name or ""
-        self.config = config
         self.is_default = default
         self.enabled = enabled
         self.started = started
-        # RFC 33 virtual queues: parent is sourced from the queue-status
-        # RPC response rather than config, since that is the job-manager's
-        # authoritative view of the resolved parent (config is also in
-        # hand here, but a single source avoids the two ever disagreeing).
-        self.parent = parent or ""
+        # RFC 33 virtual queues: parent is the job-manager's resolved parent.
+        self.parent = queue_conf.parent(name)
         self.blocked = blocked
-        self.resources = QueueResources(name, resources, config, self.parent)
+        self.resources = QueueResources(resources, queue_conf.requires(name))
+        self._policy = queue_conf.policy(name)
         self.defaults = QueueDefaults(
             duration=parse_fsd(self._policy_default("duration"))
         )
@@ -445,57 +432,25 @@ class QueueInfo:
             duration=parse_fsd(self._policy_system_limit("duration")),
         )
 
-    def _config_entries(self):
-        """
-        Yield config entries to search for a policy/limit/default key, in
-        RFC 33 virtual queue inheritance order: this queue's own config
-        entry, its parent's config entry (if this is a virtual queue),
-        then the global config. Each key is looked up independently in
-        this order (per-key inheritance), so a vqueue setting only one
-        key still inherits its parent's other keys. A parent missing
-        from config (a config reload racing the queue-status RPC, see
-        QueueResources) is an error: silently skipping the parent layer
-        would report the wrong effective limits and defaults.
-        """
-        queues = self.config.get("queues", {})
-        if self.name in queues:
-            yield queues[self.name]
-        if self.parent:
-            if self.parent not in queues:
-                raise ValueError(
-                    f"queue '{self.name}': parent queue '{self.parent}'"
-                    " is not configured"
-                )
-            yield queues[self.parent]
-        yield self.config
-
     def _size_limit(self, key, maximum=True):
-        limit = maximum and "max" or "min"
-        for entry in self._config_entries():
-            try:
-                val = entry["policy"]["limits"]["job-size"][limit][key]
-            except KeyError:
-                continue
-            if val < 0:
-                val = math.inf
-            return val
-        return math.inf if maximum else 0
+        limit = "max" if maximum else "min"
+        try:
+            val = self._policy["limits"]["job-size"][limit][key]
+        except KeyError:
+            return math.inf if maximum else 0
+        return math.inf if val < 0 else val
 
     def _policy_default(self, key, default="inf"):
-        for entry in self._config_entries():
-            try:
-                return entry["policy"]["jobspec"]["defaults"]["system"][key]
-            except KeyError:
-                continue
-        return default
+        try:
+            return self._policy["jobspec"]["defaults"]["system"][key]
+        except KeyError:
+            return default
 
     def _policy_system_limit(self, key, default="inf"):
-        for entry in self._config_entries():
-            try:
-                return entry["policy"]["limits"][key]
-            except KeyError:
-                continue
-        return default
+        try:
+            return self._policy["limits"][key]
+        except KeyError:
+            return default
 
 
 class QueueList:
@@ -510,46 +465,44 @@ class QueueList:
 
     def __init__(self, handle, queues=None):
 
-        # Gather resource list and current full config in parallel:
-        resources, config = map(
+        # Gather the resource list and the queue configuration in parallel:
+        resources, conf = map(
             lambda x: x.get(),
-            [resource_list(handle), handle.rpc("config.get")],
+            [resource_list(handle), queue_config_fetch(handle)],
         )
 
-        self.default_queue = self.__default_queue(config)
-        queue_config = self.__queue_config(config, queues)
-        status = self.__fetch_queue_status(handle, queue_config.keys())
+        self.default_queue = conf.default_queue
+        selected = self.__select_queues(conf, queues)
+        status = self.__fetch_queue_status(handle, selected)
 
         # If there's a single anonymous queue, self.__queue will not be None
         self.__queue = None
 
-        if not queue_config:
-            # single anonymous queue:
+        if not selected:
+            # single anonymous queue (no named queues configured):
             self.__queue = QueueInfo(
                 None,
-                config,
+                conf,
                 resources,
                 status["enable"],
                 status["start"],
                 True,
-                status.get("parent", ""),
                 status.get("blocked"),
             )
             self.__queues = {"": self.__queue}
         else:
             # multiple configured queues, keyed by name
             self.__queues = {
-                x: QueueInfo(
-                    x,
-                    config,
+                name: QueueInfo(
+                    name,
+                    conf,
                     resources,
-                    status[x]["enable"],
-                    status[x]["start"],
-                    x == self.default_queue,
-                    status[x].get("parent", ""),
-                    status[x].get("blocked"),
+                    status[name]["enable"],
+                    status[name]["start"],
+                    name == self.default_queue,
+                    status[name].get("blocked"),
                 )
-                for x in queue_config.keys()
+                for name in selected
             }
 
     def __getattr__(self, attr):
@@ -568,33 +521,21 @@ class QueueList:
         return iter([None])
 
     @staticmethod
-    def __default_queue(config):
+    def __select_queues(conf, queues):
         """
-        Return configured default queue name or an empty string if
-        there's a single anonymous queue
-        """
-        try:
-            return config["policy"]["jobspec"]["defaults"]["system"]["queue"]
-        except KeyError:
-            return ""
-
-    @staticmethod
-    def __queue_config(config, queues):
-        """
-        Return a subset of the queue config in ``config`` given ``queues``.
-        If ``queues`` is None or an empty list or set, return the whole config,
-        which may be empty if there are no configured queues.
+        Return the list of queue names in ``conf`` (a QueueConf) selected by
+        ``queues``. If ``queues`` is None or an empty list or set, return all
+        configured queue names, which may be empty if there are none.
         """
         if not queues:
-            return config.get("queues", {})
+            return list(conf)
 
-        # Otherwise, return subset of queue config only for selected queues:
-        result = {}
+        # Otherwise, return the selected queues only:
+        result = []
         for queue in queues:
-            try:
-                result[queue] = config["queues"][queue]
-            except KeyError:
+            if queue not in conf:
                 raise ValueError(f"No such queue: {queue}")
+            result.append(queue)
         return result
 
     @staticmethod

--- a/src/bindings/python/flux/queue.py
+++ b/src/bindings/python/flux/queue.py
@@ -254,10 +254,11 @@ def queue_conf_from_config(config):
 class QueueConf:
     """The job-manager's authoritative queue configuration.
 
-    Wraps a job-manager.queue-list "conf" object (``{"queues": [...]}``) and
-    exposes per-queue effective configuration. RFC 33 virtual-queue
-    inheritance is already resolved by the job-manager, so a queue's
-    ``requires`` is an effective value.
+    Wraps a job-manager.queue-list "conf" object (``{"queues": [...],
+    "policy"?: {...}, "default_queue"?: str}``) and exposes per-queue
+    effective configuration. The job-manager resolves everything, so a
+    queue's ``requires`` and ``policy`` are effective values (RFC 33
+    virtual-queue inheritance and the global policy are already merged in).
 
     Fetch from a live instance with :func:`queue_config_fetch`. Build from a
     raw broker config with :meth:`from_config` (the ``--config-file`` /
@@ -267,6 +268,11 @@ class QueueConf:
 
     def __init__(self, conf):
         self._entries = {entry["name"]: entry for entry in conf.get("queues", [])}
+        # The global policy is the effective policy for the anonymous queue
+        # or a job with no queue (a named queue's effective policy is in its
+        # own entry).
+        self._global_policy = conf.get("policy") or {}
+        self._default_queue = conf.get("default_queue", "")
 
     @classmethod
     def from_config(cls, config):
@@ -312,6 +318,33 @@ class QueueConf:
         The job-manager's authoritative view of the resolved parent.
         """
         return (self._entries.get(name) or {}).get("parent", "")
+
+    def policy(self, name=None):
+        """The queue's effective policy dict (empty if none).
+
+        The job-manager has already merged the global policy, RFC 33
+        virtual-queue inheritance, and the queue's own policy, so this is a
+        direct lookup. ``name`` None or an unconfigured queue (the
+        anonymous-queue case) -> the global policy.
+        """
+        entry = self._entries.get(name)
+        if entry is None:
+            return self._global_policy
+        return entry.get("policy") or {}
+
+    def defaults(self, name=None):
+        """The queue's effective job defaults
+        (``policy.jobspec.defaults.system``), an empty dict if none.
+        """
+        try:
+            return self.policy(name)["jobspec"]["defaults"]["system"]
+        except KeyError:
+            return {}
+
+    @property
+    def default_queue(self):
+        """The configured default queue name, or "" if none."""
+        return self._default_queue
 
 
 class QueueConfRPC(RPC):

--- a/src/bindings/python/flux/queue.py
+++ b/src/bindings/python/flux/queue.py
@@ -7,6 +7,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
+import copy
 import math
 
 try:
@@ -16,7 +17,7 @@ except ModuleNotFoundError:
 
 from flux.resource import resource_list
 from flux.rpc import RPC
-from flux.util import parse_fsd
+from flux.util import dict_merge, parse_fsd
 
 """Simple access to information about Flux queues from Python.
 
@@ -185,9 +186,14 @@ def queue_conf_from_config(config):
     the job-manager is from an older version of Flux that does not provide
     the queue config directly.
 
-    Returns ``{"queues": [{"name": str, "requires"?: list, "parent"?: str},
-    ...]}``. A virtual queue (RFC 33) has no "requires" of its own, so its
-    effective "requires" is resolved from its parent.
+    Returns ``{"queues": [{"name": str, "requires"?: list, "parent"?: str,
+    "policy"?: dict}, ...], "policy"?: dict, "default_queue"?: str}``. A
+    virtual queue (RFC 33) has no "requires" of its own, so its effective
+    "requires" is resolved from its parent. Each queue's "policy" is its
+    fully effective policy (the global [policy], the parent's policy for a
+    virtual queue, and its own, merged per key). The top-level "policy" is
+    the global [policy] (the effective policy for the anonymous queue or a
+    job with no queue) and "default_queue" is the default queue name.
 
     Args:
         config (dict): a broker config, e.g. from the ``config.get`` RPC.
@@ -196,26 +202,53 @@ def queue_conf_from_config(config):
         ValueError: a virtual queue names a parent that is not configured.
     """
     queues = config.get("queues", {})
+    global_policy = config.get("policy") or {}
     entries = []
     for name, entry in queues.items():
         conf = {"name": name}
         parent = entry.get("parent")
+        # A virtual queue (RFC 33) inherits its parent's requires and layers
+        # its own policy over the parent's, so resolve both against the
+        # parent entry. An unresolvable parent is fatal (fail closed):
+        # falling through would report the vqueue as unconstrained.
         if parent is not None:
-            # Virtual queue: inherit the parent's requires. An unresolvable
-            # parent is fatal (fail closed) - falling through would report
-            # the vqueue as covering the full instance resource set.
             if parent not in queues:
                 raise ValueError(
                     f"queue '{name}': parent queue '{parent}' is not configured"
                 )
             conf["parent"] = parent
             requires = queues[parent].get("requires")
+            base_policy = queues[parent].get("policy")
         else:
             requires = entry.get("requires")
+            base_policy = None
         if requires is not None:
             conf["requires"] = requires
+        # Effective per-queue policy: the global [policy], then the parent's
+        # policy (for a virtual queue), then the queue's own, merged per key
+        # from the bottom up (mirrors the job-manager's queue_policy()). Each
+        # layer is deep-copied before merging: dict_merge() shares nested
+        # dicts from its second argument, so a later merge could otherwise
+        # mutate the parent's or global's stored config. An empty result is
+        # omitted (empty == absent).
+        policy = copy.deepcopy(global_policy)
+        if base_policy:
+            dict_merge(policy, copy.deepcopy(base_policy))
+        dict_merge(policy, copy.deepcopy(entry.get("policy") or {}))
+        if policy:
+            conf["policy"] = policy
         entries.append(conf)
-    return {"queues": entries}
+    result = {"queues": entries}
+    if global_policy:
+        result["policy"] = global_policy
+    try:
+        result["default_queue"] = global_policy["jobspec"]["defaults"]["system"][
+            "queue"
+        ]
+    except KeyError:
+        # No default queue, return result as is
+        pass
+    return result
 
 
 class QueueConf:

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -121,20 +121,27 @@ static int queue_configure (const flux_conf_t *conf,
 {
     struct queue_ctx *qctx = arg;
     json_t *config = NULL;
+    json_t *policy = NULL;
 
-    /* N.B. both keys are optional, so unpack fails only on an internal
+    /* N.B. all keys are optional, so unpack fails only on an internal
      * error such as out of memory.
      */
     if (flux_conf_unpack (conf,
                           error,
-                          "{s?{s?b} s?o}",
+                          "{s?{s?b} s?o s?o}",
                           "job-manager",
                             "stop-queues-on-restart",
                               &qctx->stop_on_restart,
-                          "queues", &config) < 0)
+                          "queues", &config,
+                          "policy", &policy) < 0)
         return -1;
     if (queues_configure (qctx->queues, config, error) < 0)
         return -1;
+    /* Set after queues_configure() so a config that fails validation does
+     * not update the global policy. Borrowed from 'conf'; the queues object
+     * increfs it.
+     */
+    queues_set_global_policy (qctx->queues, policy);
     return 1;
 }
 

--- a/src/modules/job-manager/queues.c
+++ b/src/modules/job-manager/queues.c
@@ -48,6 +48,12 @@ struct queue {
                                  * virtual queue's is always NULL - see
                                  * queue_root() for the effective value)
                                  */
+    json_t *policy;             /* this queue's own [queues.NAME.policy]
+                                 * table (own only; NULL if unset). See
+                                 * queue_policy() for the vqueue-resolved
+                                 * value. The global [policy] is not merged
+                                 * in here.
+                                 */
     struct queue *parent;       /* resolved parent queue (RFC 33 virtual
                                  * queues), or NULL if not virtual. Not
                                  * owned; borrowed from the same queues
@@ -61,6 +67,11 @@ struct queue {
 struct queues {
     struct queue *anon;         /* live when named == NULL */
     zhashx_t *named;            /* non-NULL selects named mode */
+    json_t *global_policy;      /* the global [policy] table (own ref) or
+                                 * NULL. The per-key base merged beneath
+                                 * each queue's own policy to form its
+                                 * effective policy (see queue_policy()).
+                                 */
     json_t *list_cache;         /* cached queue-list response, built
                                  * lazily by queues_list_response() and
                                  * invalidated by notify() on any
@@ -102,6 +113,7 @@ static void queue_free (struct queue *q)
     if (q) {
         int saved_errno = errno;
         json_decref (q->requires);
+        json_decref (q->policy);
         free (q->name);
         free (q->disable_reason);
         free (q->stop_reason);
@@ -254,13 +266,19 @@ static int lookup_parent (struct queues *queues,
 static int queue_parse_config (struct queue *q, json_t *config)
 {
     json_t *requires = NULL;
+    json_t *policy = NULL;
 
-    if (config && json_unpack (config, "{s?O}", "requires", &requires) < 0) {
+    if (config && json_unpack (config,
+                               "{s?O s?O}",
+                               "requires", &requires,
+                               "policy", &policy) < 0) {
         errno = EINVAL;
         return -1;
     }
     json_decref (q->requires);
     q->requires = requires;   /* may be NULL */
+    json_decref (q->policy);
+    q->policy = policy;        /* may be NULL */
     return 0;
 }
 
@@ -315,6 +333,7 @@ void queues_destroy (struct queues *queues)
             zhashx_destroy (&queues->named);
         else
             queue_free (queues->anon);
+        json_decref (queues->global_policy);
         json_decref (queues->list_cache);
         free (queues);
         errno = saved_errno;
@@ -749,6 +768,15 @@ static int queues_config_validate (json_t *config, flux_error_t *error)
         }
     }
     return 0;
+}
+
+void queues_set_global_policy (struct queues *queues, json_t *policy)
+{
+    if (queues->global_policy != policy) {
+        json_decref (queues->global_policy);
+        queues->global_policy = json_incref (policy);
+        cache_invalidate (queues);
+    }
 }
 
 int queues_configure (struct queues *queues,

--- a/src/modules/job-manager/queues.c
+++ b/src/modules/job-manager/queues.c
@@ -33,6 +33,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
+#include "src/common/libmissing/json_object_update_recursive.h"
 #include "ccan/str/str.h"
 
 #include "queues.h"
@@ -984,15 +985,18 @@ error:
 }
 
 /* Encode one queue's effective configuration for the conf object:
- * {"name":s, "requires"?:[...], "parent"?:s}. 'requires' is the
- * effective required-properties array (a virtual queue inherits its
+ * {"name":s, "requires"?:[...], "parent"?:s, "policy"?:{...}}. 'requires'
+ * is the effective required-properties array (a virtual queue inherits its
  * parent's - see queue_requires()), omitted when the queue has none.
- * 'parent' is present only for a virtual queue (RFC 33).
+ * 'parent' is present only for a virtual queue (RFC 33). 'policy' is the
+ * queue's effective policy (global + virtual-queue inheritance + own,
+ * fully merged - see queue_policy()), omitted when empty.
  */
 static json_t *queue_conf_encode (struct queue *q)
 {
     json_t *o;
     json_t *requires;
+    json_t *policy;
 
     if (!(o = json_pack ("{s:s}", "name", q->name)))
         goto nomem;
@@ -1004,6 +1008,14 @@ static json_t *queue_conf_encode (struct queue *q)
         if (set_string (o, "parent", queue_name (queue_parent (q))) < 0)
             goto error;
     }
+    /* queue_policy() sets 'policy' to a new reference with the global
+     * policy merged in, or NULL when the effective policy is empty
+     * (empty == absent, matching the Python queue_conf_from_config()).
+     */
+    if (queue_policy (q, &policy) < 0)
+        goto error;
+    if (policy && json_object_set_new (o, "policy", policy) < 0)
+        goto nomem;
     return o;
 nomem:
     errno = ENOMEM;
@@ -1013,15 +1025,21 @@ error:
 }
 
 /* Encode the effective queue configuration object returned by the
- * queue-list RPC: {"queues":[{name,requires?,parent?}, ...]}. The
- * anonymous queue is omitted (empty array in anon mode). Future global
- * fields (default queue, merged policy) attach here as siblings of
- * "queues".
+ * queue-list RPC:
+ *   {"queues":[{name,requires?,parent?,policy?}, ...],
+ *    "policy"?:{...}, "default_queue"?:s}
+ * Each queue entry's "policy" is its fully effective policy. The
+ * anonymous queue is omitted from "queues" (empty array in anon mode); the
+ * top-level "policy" is the global policy (the effective policy for the
+ * anonymous queue / a job with no queue) and "default_queue" is the
+ * configured default queue name. Both top-level fields are omitted when
+ * unset.
  */
 static json_t *queues_conf_encode (struct queues *queues)
 {
-    json_t *conf;
+    json_t *conf = NULL;
     json_t *a;
+    const char *default_queue = NULL;
 
     if (!(a = json_array ()))
         goto nomem;
@@ -1039,10 +1057,31 @@ static json_t *queues_conf_encode (struct queues *queues)
     }
     if (!(conf = json_pack ("{s:O}", "queues", a)))
         goto nomem;
+    /* Top-level "policy" is the global [policy] table, which is the
+     * effective policy for the anonymous queue / a job with no queue (a
+     * named queue's effective policy is merged into its own entry). Omitted
+     * when unset. "default_queue" is the configured default queue name,
+     * from the global policy only (never a per-queue entry).
+     */
+    if (queues->global_policy) {
+        if (json_object_set (conf, "policy", queues->global_policy) < 0)
+            goto nomem;
+        (void)json_unpack (queues->global_policy,
+                           "{s:{s:{s:{s:s}}}}",
+                           "jobspec",
+                             "defaults",
+                               "system",
+                                 "queue", &default_queue);
+    }
+    if (default_queue) {
+        if (set_string (conf, "default_queue", default_queue) < 0)
+            goto nomem;
+    }
     json_decref (a);
     return conf;
 nomem:
     errno = ENOMEM;
+    ERRNO_SAFE_WRAP (json_decref, conf);
     ERRNO_SAFE_WRAP (json_decref, a);
     return NULL;
 }
@@ -1054,19 +1093,16 @@ static json_t *list_response_build (struct queues *queues)
 {
     json_t *names = NULL;
     json_t *conf = NULL;
-    json_t *resp;
-
+    json_t *resp = NULL;
     if (!(names = queues_list_encode (queues))
-        || !(conf = queues_conf_encode (queues)))
+        || !(conf = queues_conf_encode (queues))
+        || !(resp = json_pack ("{s:O s:O}", "queues", names, "conf", conf)))
         goto error;
-    if (!(resp = json_pack ("{s:O s:O}", "queues", names, "conf", conf)))
-        goto nomem;
     json_decref (names);
     json_decref (conf);
     return resp;
-nomem:
-    errno = ENOMEM;
 error:
+    errno = ENOMEM;
     ERRNO_SAFE_WRAP (json_decref, names);
     ERRNO_SAFE_WRAP (json_decref, conf);
     return NULL;
@@ -1251,6 +1287,60 @@ json_t *queue_requires (struct queue *q)
      * non-virtual queue, so this is the queue's own requires there.
      */
     return queue_root (q)->requires;
+}
+
+/* Merge policy 'layer' into 'policy' (a no-op if 'layer' is NULL).
+ * json_object_update_recursive() shares sub-objects that the target does
+ * not already have, so deep-copy 'layer' first: merging a stored policy
+ * table in directly could alias it, and a later merge could then mutate
+ * the queue's stored config. Returns -1 with errno set on failure.
+ */
+static int merge_policy_layer (json_t *policy, json_t *layer)
+{
+    json_t *copy;
+    int rc;
+
+    if (!layer)
+        return 0;
+    if (!(copy = json_deep_copy (layer)))
+        return -1;
+    rc = json_object_update_recursive (policy, copy);
+    json_decref (copy);
+    return rc;
+}
+
+int queue_policy (struct queue *q, json_t **policyp)
+{
+    json_t *parent_policy = queue_is_virtual (q) ? queue_parent (q)->policy
+                                                 : NULL;
+    json_t *policy;
+
+    /* Effective policy, merged per key from the bottom up: the global
+     * [policy], then (for a virtual queue) the parent's own policy, then
+     * this queue's own policy. The parent (if any) is an already-resolved
+     * live pointer, so there is no unresolvable-parent case here (unlike
+     * the raw-config parsers).
+     *
+     * An empty result (no policy at any layer, or only empty policy tables)
+     * is reported as *policyp == NULL - empty == absent - so callers need
+     * not special-case it.
+     */
+    if (!(policy = json_object ()))
+        goto nomem;
+    if (merge_policy_layer (policy, q->queues->global_policy) < 0
+        || merge_policy_layer (policy, parent_policy) < 0
+        || merge_policy_layer (policy, q->policy) < 0)
+        goto nomem;
+    if (json_object_size (policy) == 0) {
+        json_decref (policy);
+        policy = NULL;
+    }
+    *policyp = policy;
+    return 0;
+nomem:
+    errno = ENOMEM;
+    ERRNO_SAFE_WRAP (json_decref, policy);
+    return -1;
 }
 
 bool queue_is_enabled (struct queue *q)

--- a/src/modules/job-manager/queues.h
+++ b/src/modules/job-manager/queues.h
@@ -39,6 +39,13 @@ int queues_configure (struct queues *queues,
                       json_t *config,
                       flux_error_t *error);
 
+/* Set the global [policy] table (may be NULL). Stored by reference (the
+ * queues object increfs it) and used as the per-key base beneath each
+ * queue's own policy when computing effective policy. Invalidates the
+ * list cache.
+ */
+void queues_set_global_policy (struct queues *queues, json_t *policy);
+
 /* First-class add/remove/update (used by configure)
  *
  * queues_remove() refuses to remove a queue that other queues name as

--- a/src/modules/job-manager/queues.h
+++ b/src/modules/job-manager/queues.h
@@ -133,10 +133,16 @@ json_t *queues_list_encode (struct queues *queues);
 
 /* Assemble the full job-manager.queue-list RPC response:
  *   {"queues":[names...],
- *    "conf":{"queues":[{"name":s,"requires"?:[...],"parent"?:s}, ...]}}
+ *    "conf":{"queues":[{"name":s,"requires"?:[...],"parent"?:s,
+ *                       "policy"?:{...}}, ...],
+ *            "policy"?:{...}, "default_queue"?:s}}
  * The "queues" name array is retained for backwards compatibility; "conf"
  * carries the effective per-queue configuration (a virtual queue's
- * 'requires' is inherited from its parent). Queue order is unspecified.
+ * 'requires' is inherited from its parent, and its 'policy' is fully
+ * effective - global, parent, and own merged - see queue_policy()). The
+ * conf's top-level "policy" is the global policy (the effective policy for
+ * the anonymous queue / a job with no queue) and "default_queue" is the
+ * configured default queue name. Queue order is unspecified.
  *
  * The response is cached and rebuilt lazily; any queue mutation
  * invalidates the cache. Returns a BORROWED reference owned by the queues
@@ -154,6 +160,16 @@ const char *queue_name (struct queue *q);
  * it is the queue's own requires.
  */
 json_t *queue_requires (struct queue *q);
+/* This queue's effective policy: the global [policy], the parent's own
+ * policy (for an RFC 33 virtual queue), and this queue's own policy, all
+ * merged per key from the bottom up.
+ *
+ * On success returns 0 and sets '*policyp' to a NEW reference (caller
+ * decrefs), or to NULL when the effective policy is empty (no policy at any
+ * layer, or only empty policy tables - empty == absent). Returns -1 with
+ * errno set on error.
+ */
+int queue_policy (struct queue *q, json_t **policyp);
 bool queue_is_enabled (struct queue *q);
 const char *queue_disable_reason (struct queue *q);
 /* Own started bit; see queue_is_started_effective() below for a

--- a/src/modules/job-manager/test/queues.c
+++ b/src/modules/job-manager/test/queues.c
@@ -2210,6 +2210,476 @@ static void test_vqueue_root_and_requires (void)
     queues_destroy (qs);
 }
 
+/* queue_policy() returns the effective policy: the global [policy], the
+ * parent's policy (for a virtual queue), and the queue's own policy,
+ * merged per key from the bottom up.
+ */
+static void test_queue_policy (void)
+{
+    struct queues *qs;
+    struct queue *batch;
+    struct queue *expedite;
+    struct queue *inherit;
+    struct queue *plain;
+    struct queue *empty;
+    flux_error_t error;
+    json_t *config;
+    json_t *global;
+    json_t *policy;
+    json_t *policy2;
+    const char *duration = NULL;
+    int nnodes = -1;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* batch: own duration + job-size limits.
+     * expedite: virtual (parent batch), overrides only duration.
+     * inherit: virtual (parent batch), no own policy.
+     * plain: no policy at all.
+     * empty: an explicitly empty policy table.
+     */
+    config = json_pack ("{s:{s:{s:{s:s s:{s:{s:i}}}}} s:{s:s s:{s:{s:s}}}"
+                        " s:{s:s} s:{} s:{s:{}}}",
+                        "batch",
+                          "policy",
+                            "limits",
+                              "duration", "1h",
+                              "job-size",
+                                "max",
+                                  "nnodes", 16,
+                        "expedite",
+                          "parent", "batch",
+                          "policy",
+                            "limits",
+                              "duration", "30m",
+                        "inherit",
+                          "parent", "batch",
+                        "plain",
+                        "empty",
+                          "policy");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed: %s", error.text);
+    json_decref (config);
+
+    /* Global policy: a default duration limit and a global default that
+     * merges beneath every queue's effective policy.
+     */
+    global = json_pack ("{s:{s:s s:{s:{s:i}}}}",
+                        "limits",
+                          "duration", "24h",
+                          "job-size",
+                            "min",
+                              "nnodes", 1);
+    if (!global)
+        BAIL_OUT ("json_pack failed");
+    queues_set_global_policy (qs, global);
+    json_decref (global);
+
+    batch = queues_lookup (qs, "batch", &error);
+    expedite = queues_lookup (qs, "expedite", &error);
+    inherit = queues_lookup (qs, "inherit", &error);
+    plain = queues_lookup (qs, "plain", &error);
+    empty = queues_lookup (qs, "empty", &error);
+    ok (batch && expedite && inherit && plain && empty,
+        "all five queues found");
+
+    /* non-virtual queue: own policy overriding the global, plus the
+     * global's job-size.min inherited. New reference each call.
+     */
+    ok (queue_policy (batch, &policy) == 0
+        && policy != NULL
+        && json_unpack (policy,
+                        "{s:{s:s s:{s:{s:i}}}}",
+                        "limits",
+                          "duration", &duration,
+                          "job-size",
+                            "max",
+                              "nnodes", &nnodes) == 0
+        && streq (duration, "1h")
+        && nnodes == 16,
+        "queue_policy of non-virtual queue overrides the global duration");
+    ok (policy
+        && json_unpack (policy,
+                        "{s:{s:{s:{s:i}}}}",
+                        "limits",
+                          "job-size",
+                            "min",
+                              "nnodes", &nnodes) == 0
+        && nnodes == 1,
+        "queue_policy merges the global job-size.min beneath the queue");
+    /* a second call returns a distinct object (new reference each call) */
+    ok (queue_policy (batch, &policy2) == 0 && policy2 != NULL
+        && policy2 != policy,
+        "queue_policy returns a new reference on each call");
+    json_decref (policy2);
+    json_decref (policy);
+
+    /* virtual queue: own policy over parent's over global - duration
+     * overridden to 30m, parent's job-size.max and global's job-size.min
+     * both inherited.
+     */
+    duration = NULL;
+    nnodes = -1;
+    ok (queue_policy (expedite, &policy) == 0
+        && policy != NULL
+        && json_unpack (policy,
+                        "{s:{s:s s:{s:{s:i}}}}",
+                        "limits",
+                          "duration", &duration,
+                          "job-size",
+                            "max",
+                              "nnodes", &nnodes) == 0
+        && streq (duration, "30m")
+        && nnodes == 16,
+        "queue_policy of vqueue overrides duration and inherits job-size");
+    json_decref (policy);
+
+    /* virtual queue with no own policy: parent's over global */
+    duration = NULL;
+    ok (queue_policy (inherit, &policy) == 0
+        && policy != NULL
+        && json_unpack (policy,
+                        "{s:{s:s}}",
+                        "limits",
+                          "duration", &duration) == 0
+        && streq (duration, "1h"),
+        "queue_policy of vqueue with no own policy inherits the parent's");
+    json_decref (policy);
+
+    /* queue with no own policy: effective policy is the global alone */
+    duration = NULL;
+    ok (queue_policy (plain, &policy) == 0
+        && policy != NULL
+        && json_unpack (policy,
+                        "{s:{s:s}}",
+                        "limits",
+                          "duration", &duration) == 0
+        && streq (duration, "24h"),
+        "queue_policy of a policy-less queue is the global policy");
+    json_decref (policy);
+
+    /* queue with an explicitly empty policy table: still just the global */
+    duration = NULL;
+    ok (queue_policy (empty, &policy) == 0
+        && policy != NULL
+        && json_unpack (policy, "{s:{s:s}}", "limits", "duration", &duration)
+               == 0
+        && streq (duration, "24h"),
+        "queue_policy of an empty policy table is the global policy");
+    json_decref (policy);
+
+    queues_destroy (qs);
+}
+
+/* queue_policy() with no global policy set yields the per-queue layer
+ * alone, and NULL when a queue has no policy at any layer.
+ */
+static void test_queue_policy_no_global (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+    json_t *policy;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{s:{s:{s:s}}} s:{}}",
+                        "batch",
+                          "policy",
+                            "limits",
+                              "duration", "8h",
+                        "plain");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed: %s", error.text);
+    json_decref (config);
+
+    ok (queue_policy (queues_lookup (qs, "batch", NULL), &policy) == 0
+        && policy != NULL,
+        "queue_policy with no global returns the queue's own policy");
+    json_decref (policy);
+
+    /* no policy at any layer and no global: NULL (empty == absent) */
+    ok (queue_policy (queues_lookup (qs, "plain", NULL), &policy) == 0
+        && policy == NULL,
+        "queue_policy of a policy-less queue with no global yields NULL");
+
+    queues_destroy (qs);
+}
+
+/* The encoded conf carries each queue's effective "policy" and, at the top
+ * level, the global policy and default queue name.
+ */
+static void test_conf_policy_encode (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+    json_t *global;
+    json_t *resp;
+    json_t *cq = NULL;
+    json_t *gpol = NULL;
+    const char *dur_batch = NULL;
+    const char *dur_expedite = NULL;
+    const char *dur_global = NULL;
+    const char *defq = NULL;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    config = json_pack ("{s:{s:{s:{s:s}}} s:{s:s s:{s:{s:s}}}}",
+                        "batch",
+                          "policy",
+                            "limits",
+                              "duration", "8h",
+                        "expedite",
+                          "parent", "batch",
+                          "policy",
+                            "limits",
+                              "duration", "1h");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed: %s", error.text);
+    json_decref (config);
+
+    /* Global policy: a default duration limit and a default queue. */
+    global = json_pack ("{s:{s:s} s:{s:{s:{s:s}}}}",
+                        "limits",
+                          "duration", "24h",
+                        "jobspec",
+                          "defaults",
+                            "system",
+                              "queue", "batch");
+    if (!global)
+        BAIL_OUT ("json_pack failed");
+    queues_set_global_policy (qs, global);
+    json_decref (global);
+
+    resp = queues_list_response (qs);
+    ok (resp != NULL
+        && json_unpack (resp,
+                        "{s:{s:o s:o}}",
+                        "conf",
+                          "queues", &cq,
+                          "policy", &gpol) == 0,
+        "conf has queues array and top-level policy");
+
+    /* Per-queue effective policy: batch's own 8h overrides the global 24h;
+     * expedite resolves to its own 1h.
+     */
+    ok (cq && json_array_size (cq) == 2
+        && json_unpack (conf_entry (cq, "batch"),
+                        "{s:{s:{s:s}}}",
+                        "policy",
+                          "limits",
+                            "duration", &dur_batch) == 0
+        && streq (dur_batch, "8h"),
+        "conf per-queue effective policy for batch overrides the global");
+    ok (json_unpack (conf_entry (cq, "expedite"),
+                     "{s:{s:{s:s}}}",
+                     "policy",
+                       "limits",
+                         "duration", &dur_expedite) == 0
+        && streq (dur_expedite, "1h"),
+        "conf per-queue effective policy for expedite is vqueue-resolved");
+
+    /* Top-level policy is the global table; default_queue is at top level. */
+    ok (gpol
+        && json_unpack (gpol, "{s:{s:s}}", "limits", "duration", &dur_global)
+               == 0
+        && streq (dur_global, "24h"),
+        "conf top-level policy is the global policy");
+    ok (json_unpack (resp,
+                     "{s:{s:s}}",
+                     "conf",
+                       "default_queue", &defq) == 0
+        && streq (defq, "batch"),
+        "conf top-level default_queue is the configured default");
+
+    /* resp is a borrowed reference owned by the queues cache; not decref'd. */
+    queues_destroy (qs);
+}
+
+/* queue_policy() must never alias or mutate the queues' stored policy
+ * tables (the per-queue q->policy or the global policy). It merges by
+ * deep-copying each layer; a regression to a shallow merge would let one
+ * queue's resolution corrupt a sibling, its parent, or the global policy.
+ * Exercise every layer and every corruption path.
+ */
+static void test_queue_policy_no_aliasing (void)
+{
+    struct queues *qs;
+    flux_error_t error;
+    json_t *config;
+    json_t *global;
+    json_t *p_batch = NULL;
+    json_t *p_expedite = NULL;
+    json_t *p_urgent = NULL;
+    json_t *p_plain = NULL;
+    const char *s;
+    int n;
+
+    qs = queues_create ();
+    if (!qs)
+        BAIL_OUT ("queues_create failed");
+
+    /* batch: own duration 8h + job-size.max.nnodes 16.
+     * expedite (vqueue of batch): overrides duration to 1h.
+     * urgent   (vqueue of batch): overrides job-size.max.nnodes to 4.
+     * plain: no own policy.
+     * Two siblings overriding different keys of the same parent is the
+     * case most likely to expose aliasing.
+     */
+    config = json_pack ("{s:{s:{s:{s:s s:{s:{s:i}}}}}"
+                        " s:{s:s s:{s:{s:s}}}"
+                        " s:{s:s s:{s:{s:{s:{s:i}}}}}"
+                        " s:{}}",
+                        "batch",
+                          "policy", "limits",
+                            "duration", "8h",
+                            "job-size", "max", "nnodes", 16,
+                        "expedite",
+                          "parent", "batch",
+                          "policy", "limits", "duration", "1h",
+                        "urgent",
+                          "parent", "batch",
+                          "policy", "limits", "job-size", "max", "nnodes", 4,
+                        "plain");
+    if (!config)
+        BAIL_OUT ("json_pack failed");
+    if (queues_configure (qs, config, &error) < 0)
+        BAIL_OUT ("queues_configure failed: %s", error.text);
+    json_decref (config);
+
+    global = json_pack ("{s:{s:s s:{s:{s:i}}}}",
+                        "limits",
+                          "duration", "24h",
+                          "job-size",
+                            "min",
+                              "nnodes", 1);
+    if (!global)
+        BAIL_OUT ("json_pack failed");
+    queues_set_global_policy (qs, global);
+
+    /* Resolve every queue's effective policy up front, holding all the
+     * results live at once - a shallow merge would have them share (and
+     * then clobber) each other's sub-objects.
+     */
+    if (queue_policy (queues_lookup (qs, "batch", NULL), &p_batch) < 0
+        || queue_policy (queues_lookup (qs, "expedite", NULL), &p_expedite) < 0
+        || queue_policy (queues_lookup (qs, "urgent", NULL), &p_urgent) < 0
+        || queue_policy (queues_lookup (qs, "plain", NULL), &p_plain) < 0)
+        BAIL_OUT ("queue_policy failed");
+
+    /* batch: own 8h + own job-size.max 16 + global job-size.min 1 */
+    ok (json_unpack (p_batch,
+                     "{s:{s:s s:{s:{s:i} s:{s:i}}}}",
+                     "limits",
+                       "duration", &s,
+                       "job-size",
+                         "max",
+                           "nnodes", &n,
+                         "min",
+                           "nnodes", &n) == 0,
+        "batch effective policy unpacks");
+    ok (json_unpack (p_batch, "{s:{s:s}}", "limits", "duration", &s) == 0
+        && streq (s, "8h"),
+        "batch duration is its own 8h");
+    n = -1;
+    (void)json_unpack (p_batch,
+                       "{s:{s:{s:{s:i}}}}",
+                       "limits",
+                         "job-size",
+                           "max",
+                             "nnodes", &n);
+    ok (n == 16, "batch keeps its own job-size.max 16 (not aliased away)");
+
+    /* expedite: own 1h, parent's job-size.max 16, global job-size.min 1 */
+    n = -1;
+    ok (json_unpack (p_expedite, "{s:{s:s}}", "limits", "duration", &s) == 0
+        && streq (s, "1h"),
+        "expedite duration is its own 1h");
+    (void)json_unpack (p_expedite,
+                       "{s:{s:{s:{s:i}}}}",
+                       "limits",
+                         "job-size",
+                           "max",
+                             "nnodes", &n);
+    ok (n == 16, "expedite inherits parent's job-size.max 16");
+
+    /* urgent: own job-size.max 4, parent's duration 8h, global min 1 */
+    n = -1;
+    ok (json_unpack (p_urgent, "{s:{s:s}}", "limits", "duration", &s) == 0
+        && streq (s, "8h"),
+        "urgent inherits parent's duration 8h");
+    (void)json_unpack (p_urgent,
+                       "{s:{s:{s:{s:i}}}}",
+                       "limits",
+                         "job-size",
+                           "max",
+                             "nnodes", &n);
+    ok (n == 4, "urgent keeps its own job-size.max 4 (sibling did not leak)");
+    n = -1;
+    (void)json_unpack (p_urgent,
+                       "{s:{s:{s:{s:i}}}}",
+                       "limits",
+                         "job-size",
+                           "min",
+                             "nnodes", &n);
+    ok (n == 1, "urgent inherits global job-size.min 1");
+
+    /* plain: just the global */
+    ok (json_unpack (p_plain, "{s:{s:s}}", "limits", "duration", &s) == 0
+        && streq (s, "24h"),
+        "plain effective policy is the global 24h");
+
+    json_decref (p_batch);
+    json_decref (p_expedite);
+    json_decref (p_urgent);
+    json_decref (p_plain);
+
+    /* The stored per-queue and global policy tables must be untouched by
+     * all that resolution: re-resolve batch and re-check the global.
+     */
+    if (queue_policy (queues_lookup (qs, "batch", NULL), &p_batch) < 0)
+        BAIL_OUT ("queue_policy failed");
+    ok (json_unpack (p_batch, "{s:{s:s}}", "limits", "duration", &s) == 0
+        && streq (s, "8h"),
+        "re-resolved batch is still 8h (stored policy not corrupted)");
+    json_decref (p_batch);
+
+    ok (json_unpack (global, "{s:{s:s}}", "limits", "duration", &s) == 0
+        && streq (s, "24h"),
+        "stored global policy is unchanged after resolution");
+    n = -1;
+    (void)json_unpack (global,
+                       "{s:{s:{s:{s:i}}}}",
+                       "limits",
+                         "job-size",
+                           "min",
+                             "nnodes", &n);
+    ok (n == 1
+        && json_object_get (json_object_get (global, "limits"),
+                            "job-size")
+        && !json_object_get (json_object_get (json_object_get (global,
+                                                               "limits"),
+                                              "job-size"),
+                             "max"),
+        "global policy did not gain a queue's job-size.max (no reverse alias)");
+
+    json_decref (global);
+    queues_destroy (qs);
+}
+
 /* Effective-started 4-state matrix: parent x vqueue, started x stopped. */
 static void test_vqueue_effective_started (void)
 {
@@ -2533,6 +3003,10 @@ int main (int argc, char *argv[])
     test_vqueue_remove_parent_busy ();
     test_vqueue_remove_parent_truncated ();
     test_vqueue_root_and_requires ();
+    test_queue_policy ();
+    test_queue_policy_no_global ();
+    test_queue_policy_no_aliasing ();
+    test_conf_policy_encode ();
     test_vqueue_effective_started ();
     test_vqueue_status_encode ();
     test_vqueue_notify ();

--- a/t/python/t0034-queuelist.py
+++ b/t/python/t0034-queuelist.py
@@ -26,6 +26,7 @@ from flux.queue import (
     queue_config_fetch,
 )
 from flux.resource import resource_list
+from flux.util import parse_fsd
 from subflux import rerun_under_flux
 
 
@@ -220,43 +221,53 @@ class TestQueueList(unittest.TestCase):
         self.assertEqual(sorted(conf2), sorted(conf))
         self.assertEqual(conf2.entries, conf.entries)
 
-    def test_004_vqueue_stale_parent(self):
-        # A QueueInfo parent (sourced from the queue-status RPC) missing
-        # from the config (a separate RPC, so a config reload can race
-        # the two) must raise, not fall back to the full instance
-        # resource set or drop the parent's limits layer.
+    def test_004_queueinfo_from_conf(self):
+        # QueueInfo builds from a QueueConf, which supplies each queue's
+        # effective requires, resolved parent, and effective policy (RFC 33
+        # inheritance and the global policy already merged by the
+        # job-manager). Building from one snapshot means status and config
+        # cannot disagree, so there is no stale-parent race.
         resources = resource_list(self.fh).get()
-        config = {
-            "queues": {
-                "batch": {"requires": ["batch"]},
+        # Conf entries are effective, as the job-manager emits them: batch's
+        # own 8h duration merged over the global 24h; expedite (vqueue)
+        # inherits batch's effective policy and requires.
+        conf = QueueConf(
+            {
+                "policy": {"limits": {"duration": "24h"}},
+                "queues": [
+                    {
+                        "name": "batch",
+                        "requires": ["batch"],
+                        "policy": {"limits": {"duration": "8h"}},
+                    },
+                    {
+                        "name": "expedite",
+                        "parent": "batch",
+                        "requires": ["batch"],
+                        "policy": {"limits": {"duration": "1h"}},
+                    },
+                ],
             }
-        }
-        with self.assertRaises(ValueError) as ctx:
-            QueueInfo(
-                "expedite",
-                config,
-                resources,
-                enabled=True,
-                started=True,
-                default=False,
-                parent="gone",
-            )
-        self.assertIn("parent queue 'gone' is not configured", str(ctx.exception))
-
-        # The limits/defaults lookup path fails the same way even when
-        # constructed with a then-valid parent that a raced config lost:
-        qinfo = QueueInfo(
-            "expedite",
-            config,
-            resources,
-            enabled=True,
-            started=True,
-            default=False,
-            parent="batch",
         )
-        qinfo.config = {"queues": {}}
-        with self.assertRaises(ValueError):
-            list(qinfo._config_entries())
+        expedite = QueueInfo(
+            "expedite", conf, resources, enabled=True, started=True, default=False
+        )
+        self.assertEqual(expedite.parent, "batch")
+        # effective per-queue policy: own duration override
+        self.assertEqual(expedite.limits.duration, parse_fsd("1h"))
+        # no job-size configured anywhere -> unlimited
+        self.assertEqual(expedite.limits.max.nnodes, math.inf)
+
+        batch = QueueInfo(
+            "batch", conf, resources, enabled=True, started=True, default=False
+        )
+        self.assertEqual(batch.limits.duration, parse_fsd("8h"))
+
+        # The anonymous queue (name None) uses the global effective policy.
+        anon = QueueInfo(
+            None, conf, resources, enabled=True, started=True, default=True
+        )
+        self.assertEqual(anon.limits.duration, parse_fsd("24h"))
 
 
 if __name__ == "__main__":

--- a/t/python/t0034-queuelist.py
+++ b/t/python/t0034-queuelist.py
@@ -158,27 +158,44 @@ class TestQueueList(unittest.TestCase):
     def test_0035_conf_matches_helper(self):
         # The queue_conf_from_config() helper (used as the fallback for
         # older brokers and by the hidden --config-file/--from-stdin
-        # options) must reproduce the live job-manager 'conf' object
-        # exactly, so the two implementations do not drift. Queue order is
-        # not guaranteed, so compare with the queues list sorted by name.
+        # options) must reproduce the live job-manager 'conf' object, so the
+        # two implementations do not drift. Include a global [policy] and
+        # per-queue policy (including a virtual queue that overrides one key
+        # and inherits another) so the conf's effective-policy and
+        # default_queue fields are exercised, not just requires/parent.
+        # Queue order is not guaranteed, so compare with queues sorted by
+        # name.
         testconf = """
+        [policy.limits]
+        duration = "24h"
+
+        [policy.jobspec.defaults.system]
+        queue = "batch"
+
         [queues.debug]
         requires = ["debug"]
 
         [queues.batch]
         requires = ["batch"]
+        policy.limits.duration = "8h"
+        policy.limits.job-size.max.nnodes = 16
 
         [queues.expedite]
         parent = "batch"
+        policy.limits.duration = "1h"
         """
         config = tomllib.loads(testconf)
         self.fh.rpc("config.load", config).get()
 
-        def by_name(conf):
-            return sorted(conf["queues"], key=lambda q: q["name"])
+        def normalize(conf):
+            conf = dict(conf)
+            conf["queues"] = sorted(conf["queues"], key=lambda q: q["name"])
+            return conf
 
         resp = self.fh.rpc("job-manager.queue-list").get()
-        self.assertEqual(by_name(resp["conf"]), by_name(queue_conf_from_config(config)))
+        self.assertEqual(
+            normalize(resp["conf"]), normalize(queue_conf_from_config(config))
+        )
 
     def test_0036_queue_config_fetch(self):
         # queue_config_fetch() sends the request and its get() returns a

--- a/t/python/t0048-frobnicator-vqueue.py
+++ b/t/python/t0048-frobnicator-vqueue.py
@@ -84,16 +84,20 @@ class TestConstraintsVQueue(unittest.TestCase):
 
 
 class TestDefaultsVQueue(unittest.TestCase):
-    """RFC 33 virtual queue defaults inheritance in the frobnicator."""
+    """The defaults frobnicator reads effective defaults from QueueConf.
+
+    RFC 33 virtual-queue inheritance is resolved by the job-manager, so the
+    conf entries already carry a vqueue's effective defaults.
+    """
 
     def test_vqueue_inherits_parent_defaults(self):
         dc = DefaultsConfig(
-            {
-                "queues": {
+            queue_conf(
+                {
                     "batch": defaults_config({"duration": "1h"}),
                     "expedite": {"parent": "batch"},
                 }
-            }
+            )
         )
         self.assertEqual(dc.queue_defaults("expedite"), {"duration": "1h"})
 
@@ -101,24 +105,18 @@ class TestDefaultsVQueue(unittest.TestCase):
         expedite = defaults_config({"duration": "5m"})
         expedite["parent"] = "batch"
         dc = DefaultsConfig(
-            {
-                "queues": {
+            queue_conf(
+                {
                     "batch": defaults_config({"duration": "1h", "queue": "batch"}),
                     "expedite": expedite,
                 }
-            }
+            )
         )
         # Own duration overrides the parent's; the parent's other keys
         # are still inherited beneath.
         eff = dc.queue_defaults("expedite")
         self.assertEqual(eff["duration"], "5m")
         self.assertEqual(eff["queue"], "batch")
-
-    def test_vqueue_missing_parent_fails_closed(self):
-        # DefaultsConfig validates every queue at construction, so a
-        # vqueue with an unconfigured parent must raise there.
-        with self.assertRaises(ValueError):
-            DefaultsConfig({"queues": {"expedite": {"parent": "nosuchqueue"}}})
 
 
 if __name__ == "__main__":

--- a/t/python/t0049-queue-conf.py
+++ b/t/python/t0049-queue-conf.py
@@ -10,6 +10,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import copy
 import unittest
 
 import subflux  # noqa: F401 - To set up PYTHONPATH
@@ -79,6 +80,85 @@ class TestQueueConfFromConfig(unittest.TestCase):
             "parent queue 'nosuchqueue' is not configured", str(ctx.exception)
         )
 
+    def test_global_policy_at_top_level(self):
+        # The global [policy] is carried at the top level (the effective
+        # policy for the anonymous queue / a job with no queue).
+        config = {"policy": {"limits": {"duration": "24h"}}}
+        conf = queue_conf_from_config(config)
+        self.assertEqual(conf["policy"], {"limits": {"duration": "24h"}})
+
+    def test_default_queue_at_top_level(self):
+        config = {"policy": {"jobspec": {"defaults": {"system": {"queue": "batch"}}}}}
+        self.assertEqual(queue_conf_from_config(config)["default_queue"], "batch")
+
+    def test_no_default_queue_omits_key(self):
+        conf = queue_conf_from_config({"policy": {"limits": {"duration": "1h"}}})
+        self.assertNotIn("default_queue", conf)
+
+    def test_queue_policy_is_effective(self):
+        # A queue's policy is fully effective: its own overrides the global
+        # per key, and unset keys are inherited from the global.
+        config = {
+            "policy": {
+                "limits": {"duration": "24h", "job-size": {"max": {"nnodes": 4}}}
+            },
+            "queues": {"batch": {"policy": {"limits": {"duration": "8h"}}}},
+        }
+        entry = queue_conf_from_config(config)["queues"][0]
+        self.assertEqual(entry["policy"]["limits"]["duration"], "8h")
+        self.assertEqual(entry["policy"]["limits"]["job-size"]["max"]["nnodes"], 4)
+
+    def test_queue_without_own_policy_gets_global(self):
+        # With a global policy, even a queue with no own policy has an
+        # effective policy (the global).
+        config = {
+            "policy": {"limits": {"duration": "24h"}},
+            "queues": {"batch": {"requires": ["batch"]}},
+        }
+        entry = queue_conf_from_config(config)["queues"][0]
+        self.assertEqual(entry["policy"], {"limits": {"duration": "24h"}})
+
+    def test_queue_policy_omitted_when_empty(self):
+        # No policy at any layer (and no global) -> the key is omitted.
+        conf = queue_conf_from_config({"queues": {"batch": {"requires": ["batch"]}}})
+        self.assertNotIn("policy", conf["queues"][0])
+
+    def test_empty_policy_table_omitted(self):
+        # An explicitly empty policy table with no global is omitted.
+        conf = queue_conf_from_config({"queues": {"batch": {"policy": {}}}})
+        self.assertEqual(conf["queues"], [{"name": "batch"}])
+
+    def test_vqueue_policy_merges_global_parent_own(self):
+        # A vqueue's effective policy merges the global, then the parent's,
+        # then its own, per key.
+        config = {
+            "policy": {"limits": {"job-size": {"min": {"nnodes": 1}}}},
+            "queues": {
+                "batch": {
+                    "policy": {
+                        "limits": {
+                            "duration": "8h",
+                            "job-size": {"max": {"nnodes": 16}},
+                        }
+                    }
+                },
+                "expedite": {
+                    "parent": "batch",
+                    "policy": {"limits": {"duration": "1h"}},
+                },
+            },
+        }
+        by_name = {q["name"]: q for q in queue_conf_from_config(config)["queues"]}
+        self.assertEqual(
+            by_name["expedite"]["policy"],
+            {
+                "limits": {
+                    "duration": "1h",  # own
+                    "job-size": {"max": {"nnodes": 16}, "min": {"nnodes": 1}},
+                }  # max from parent, min from global
+            },
+        )
+
 
 class TestQueueConf(unittest.TestCase):
     """QueueConf exposes effective per-queue configuration."""
@@ -141,6 +221,125 @@ class TestQueueConf(unittest.TestCase):
         self.assertEqual(
             self.qc.entries["batch"], {"name": "batch", "requires": ["batch"]}
         )
+
+
+class TestPolicyAliasing(unittest.TestCase):
+    """queue_conf_from_config() must not alias or mutate its input.
+
+    The per-queue effective-policy merge layers the global policy, the
+    parent's policy, and the queue's own. A naive merge shares nested dicts
+    by reference, so encoding one queue could corrupt another queue's
+    entry, the global policy, or the caller's original config. These tests
+    pin down that every layer is deep-copied.
+    """
+
+    # A config exercising deep nesting and every inheritance layer: a
+    # global limit + default queue, a parent (batch) with its own nested
+    # job-size limit, two sibling virtual queues of batch overriding
+    # different keys, and a plain queue with no own policy.
+    def _config(self):
+        return {
+            "policy": {
+                "limits": {
+                    "duration": "24h",
+                    "job-size": {"min": {"nnodes": 1}},
+                },
+                "jobspec": {"defaults": {"system": {"queue": "batch"}}},
+            },
+            "queues": {
+                "batch": {
+                    "policy": {
+                        "limits": {
+                            "duration": "8h",
+                            "job-size": {"max": {"nnodes": 16}},
+                        }
+                    }
+                },
+                "expedite": {
+                    "parent": "batch",
+                    "policy": {"limits": {"duration": "1h"}},
+                },
+                "urgent": {
+                    "parent": "batch",
+                    "policy": {"limits": {"job-size": {"max": {"nnodes": 4}}}},
+                },
+                "plain": {},
+            },
+        }
+
+    def _by_name(self, config):
+        return {q["name"]: q for q in queue_conf_from_config(config)["queues"]}
+
+    def test_input_config_not_mutated(self):
+        # The caller's config dict must be byte-for-byte unchanged.
+        config = self._config()
+        before = copy.deepcopy(config)
+        queue_conf_from_config(config)
+        self.assertEqual(config, before)
+
+    def test_parent_entry_not_corrupted_by_vqueue(self):
+        # Encoding expedite/urgent (which override batch's keys) must not
+        # change batch's effective policy.
+        by = self._by_name(self._config())
+        self.assertEqual(by["batch"]["policy"]["limits"]["duration"], "8h")
+        self.assertEqual(
+            by["batch"]["policy"]["limits"]["job-size"]["max"]["nnodes"], 16
+        )
+
+    def test_sibling_vqueues_independent(self):
+        # Two vqueues of the same parent overriding different keys must not
+        # leak into each other.
+        by = self._by_name(self._config())
+        # expedite overrides duration, inherits batch's job-size.max=16
+        self.assertEqual(by["expedite"]["policy"]["limits"]["duration"], "1h")
+        self.assertEqual(
+            by["expedite"]["policy"]["limits"]["job-size"]["max"]["nnodes"], 16
+        )
+        # urgent overrides job-size.max=4, inherits batch's duration=8h
+        self.assertEqual(by["urgent"]["policy"]["limits"]["duration"], "8h")
+        self.assertEqual(
+            by["urgent"]["policy"]["limits"]["job-size"]["max"]["nnodes"], 4
+        )
+
+    def test_global_inherited_everywhere(self):
+        # The global job-size.min=1 must appear in every queue's effective
+        # policy, and the global's own copy must be intact at the top level.
+        conf = queue_conf_from_config(self._config())
+        by = {q["name"]: q for q in conf["queues"]}
+        for name in ("batch", "expedite", "urgent", "plain"):
+            self.assertEqual(
+                by[name]["policy"]["limits"]["job-size"]["min"]["nnodes"],
+                1,
+                f"{name} lost the global job-size.min",
+            )
+        self.assertEqual(conf["policy"]["limits"]["duration"], "24h")
+        self.assertEqual(conf["policy"]["limits"]["job-size"]["min"]["nnodes"], 1)
+
+    def test_mutating_result_does_not_affect_siblings_or_global(self):
+        # Mutating one queue's returned policy must not touch any other
+        # queue's entry, the top-level global, or the input config.
+        config = self._config()
+        conf = queue_conf_from_config(config)
+        by = {q["name"]: q for q in conf["queues"]}
+        by["expedite"]["policy"]["limits"]["duration"] = "MUTATED"
+        by["expedite"]["policy"]["limits"]["job-size"]["max"]["nnodes"] = -999
+        self.assertEqual(by["batch"]["policy"]["limits"]["duration"], "8h")
+        self.assertEqual(
+            by["urgent"]["policy"]["limits"]["job-size"]["max"]["nnodes"], 4
+        )
+        self.assertEqual(conf["policy"]["limits"]["duration"], "24h")
+        self.assertEqual(
+            config["queues"]["batch"]["policy"]["limits"]["job-size"]["max"]["nnodes"],
+            16,
+        )
+
+    def test_repeated_calls_identical(self):
+        # Repeated encoding of the same config must yield identical output
+        # (no cumulative corruption from a shared/aliased layer).
+        config = self._config()
+        first = queue_conf_from_config(config)
+        second = queue_conf_from_config(config)
+        self.assertEqual(first, second)
 
 
 if __name__ == "__main__":

--- a/t/python/t0049-queue-conf.py
+++ b/t/python/t0049-queue-conf.py
@@ -163,13 +163,18 @@ class TestQueueConfFromConfig(unittest.TestCase):
 class TestQueueConf(unittest.TestCase):
     """QueueConf exposes effective per-queue configuration."""
 
-    # A representative config: a real queue with its own requires, a virtual
-    # queue inheriting its parent, and a queue with no requires.
+    # A representative config: a global policy with a default queue and a
+    # duration limit, a real queue overriding the limit, a virtual queue
+    # inheriting its parent, and a queue with no own policy.
     # QueueConf.from_config runs it through queue_conf_from_config, so the
-    # per-queue requires entries are already vqueue-resolved.
+    # entries are already effective (vqueue-resolved, global merged in).
     CONFIG = {
+        "policy": {
+            "limits": {"duration": "24h"},
+            "jobspec": {"defaults": {"system": {"queue": "batch", "duration": "1h"}}},
+        },
         "queues": {
-            "batch": {"requires": ["batch"]},
+            "batch": {"requires": ["batch"], "policy": {"limits": {"duration": "8h"}}},
             "expedite": {"parent": "batch"},
             "plain": {},
         },
@@ -218,9 +223,48 @@ class TestQueueConf(unittest.TestCase):
     def test_entries(self):
         # The raw name -> entry escape hatch.
         self.assertEqual(sorted(self.qc.entries), ["batch", "expedite", "plain"])
+        self.assertEqual(self.qc.entries["batch"]["requires"], ["batch"])
+
+    def test_default_queue(self):
+        self.assertEqual(self.qc.default_queue, "batch")
+
+    def test_default_queue_absent(self):
         self.assertEqual(
-            self.qc.entries["batch"], {"name": "batch", "requires": ["batch"]}
+            QueueConf.from_config({"queues": {"batch": {}}}).default_queue, ""
         )
+
+    def test_policy_named_queue(self):
+        # batch's own 8h overrides the global 24h; effective policy is a
+        # direct lookup (already merged by the encoder).
+        self.assertEqual(self.qc.policy("batch")["limits"]["duration"], "8h")
+
+    def test_policy_inherits(self):
+        # expedite (vqueue, no own policy) inherits its parent batch's
+        # effective policy (8h); plain (no policy) gets the global (24h).
+        self.assertEqual(self.qc.policy("expedite")["limits"]["duration"], "8h")
+        self.assertEqual(self.qc.policy("plain")["limits"]["duration"], "24h")
+
+    def test_policy_anonymous(self):
+        # name None or an unconfigured queue -> the global policy.
+        self.assertEqual(self.qc.policy()["limits"]["duration"], "24h")
+        self.assertEqual(self.qc.policy("nosuchqueue")["limits"]["duration"], "24h")
+
+    def test_policy_empty_when_no_global(self):
+        qc = QueueConf.from_config({"queues": {"batch": {}}})
+        self.assertEqual(qc.policy("batch"), {})
+        self.assertEqual(qc.policy(), {})
+
+    def test_defaults(self):
+        # batch inherits the global jobspec defaults (it overrides only the
+        # duration limit, not the defaults).
+        self.assertEqual(
+            self.qc.defaults("batch"), {"queue": "batch", "duration": "1h"}
+        )
+        self.assertEqual(self.qc.defaults(), {"queue": "batch", "duration": "1h"})
+
+    def test_defaults_empty(self):
+        qc = QueueConf.from_config({"queues": {"batch": {}}})
+        self.assertEqual(qc.defaults("batch"), {})
 
 
 class TestPolicyAliasing(unittest.TestCase):

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -205,5 +205,26 @@ test_expect_success 'defaults plugin requires queue if configured' '
 	    > nodefaultnojob.out &&
 	jq -e ".errstr == \"no queue specified\"" <nodefaultnojob.out
 '
+test_expect_success 'configure a virtual queue' '
+	cat <<-EOF >conf.d/conf.toml &&
+	[queues.batch]
+	requires = [ "batch" ]
+	policy.jobspec.defaults.system.duration = "8h"
+	[queues.expedite]
+	parent = "batch"
+	policy.jobspec.defaults.system.duration = "1h"
+	EOF
+	flux config reload
+'
+test_expect_success 'frobnicator resolves virtual queue defaults and constraints' '
+	flux run --env=-* --dry-run --queue=expedite hostname \
+	   | flux job-frobnicator --jobspec-only \
+	> vqueue.out &&
+	# effective duration is the vqueue own override:
+	jq -e ".data.attributes.system.duration == 3600" <vqueue.out &&
+	# effective constraint is the parent requires (RFC 33 inheritance):
+	jq -e ".data.attributes.system.constraints.properties == [ \"batch\" ]" \
+	    <vqueue.out
+'
 
 test_done

--- a/t/t2246-queue-virtual.t
+++ b/t/t2246-queue-virtual.t
@@ -301,6 +301,13 @@ test_expect_success 'vqueue inherits parent job-size limit' '
 	  expedite-jobsize.err
 '
 
+test_expect_success 'flux queue list shows effective vqueue limits' '
+	test "$(flux queue list -q expedite -no {limits.timelimit!F})" = "30m" &&
+	test "$(flux queue list -q expedite -no {limits.max.nnodes})" = "2" &&
+	test "$(flux queue list -q batch -no {limits.timelimit!F})" = "1h" &&
+	test "$(flux queue list -q batch -no {limits.max.nnodes})" = "2"
+'
+
 test_expect_success 'vqueue job within both inherited and own limits passes' '
 	flux submit -q expedite -N 2 -t 20m hostname
 '


### PR DESCRIPTION
This PR enhances the `job-manager.queue-list` RPC response to include the effective policy for each queue, as well as the global policy in a new `policy` top-level key (this includes the default queue as well as the effective policy for the anonymous queue case). The job

The Python `QueueConf` and `QueueList` classes are then updated to read policy from this response, which allows more consumers to drop custom local processing of the `[queues]` and `[policy]` tables (e.g. `flux queue list` and the `defaults` frobnicator plugin).
