### PR TITLE
kvs: enable nightly garbage collection on system instance

### DIFF
--- a/doc/guide/admin_daily.rst
+++ b/doc/guide/admin_daily.rst
@@ -38,10 +38,12 @@ This state is held in the ``content.sqlite`` that was configured above.
 See also :man1:`flux-shutdown`.
 
 .. note::
-    ``flux-shutdown --gc`` should be used from time to time to perform offline
-    KVS garbage collection.  This, in conjunction with configuring inactive
-    job purging, keeps the size of the ``content.sqlite`` database in check
-    and improves Flux startup time.
+    Routine garbage collection is handled automatically by the daily
+    ``51-flux-gc`` job described under `KVS maintenance`_ below.
+    ``flux-shutdown --gc`` may still be used to perform offline garbage
+    collection during a planned restart.  Either, in conjunction with
+    configuring inactive job purging, keeps the size of the ``content.sqlite``
+    database in check and improves Flux startup time.
 
 The brokers on other nodes will automatically shut down in response,
 then respawn, awaiting the return of the rank 0 broker.
@@ -53,6 +55,28 @@ To shut down a single node running Flux, simply run
  $ sudo systemctl stop flux
 
 on that node.
+
+KVS maintenance
+===============
+
+Flux installs the following scripts under ``/etc/cron.daily`` that perform
+routine key-value store maintenance on the rank 0 node once per day:
+
+- ``50-flux-dump`` writes a KVS snapshot to the ``dump`` subdirectory of the
+  ``statedir`` using :man1:`flux-dump` for emergency recovery purposes.
+
+- ``51-flux-gc`` performs online garbage collection of the KVS using
+  :man1:`flux-gc`, reclaiming space from unreferenced blobs while
+  the instance keeps running.
+
+Both scripts exit silently on any node that is not rank 0, or when the broker
+is not running, so the package may be installed uniformly across the cluster.
+
+To disable either job, remove its execute bit:
+
+.. code-block:: console
+
+ $ sudo chmod -x /etc/cron.daily/51-flux-gc
 
 Configuration update
 ====================

--- a/doc/man1/flux-logger.rst
+++ b/doc/man1/flux-logger.rst
@@ -20,6 +20,9 @@ For more information, refer to the :ref:`broker_logging` section of
 The wall clock time (UTC) and the broker rank are added to the log
 message when it is created.
 
+Logging is restricted to the Flux instance owner and silently fails
+if the caller does not have sufficient privilege.
+
 
 OPTIONS
 =======

--- a/doc/man1/flux-logger.rst
+++ b/doc/man1/flux-logger.rst
@@ -28,7 +28,7 @@ OPTIONS
 
    Specify the log message severity by name.  Valid severity names are
    *emerg*, *alert*, *crit*, *err*, *warning*, *notice*, *info*, *debug*.
-   The default severity is *info*.
+   The default severity is *notice*.
 
 .. option:: -n, --appname=NAME
 

--- a/doc/man3/flux_log.rst
+++ b/doc/man3/flux_log.rst
@@ -39,6 +39,9 @@ which is initialized to the calling process's PID.
 application name, which is initialized to the value of the :var:`__progname`
 symbol (normally the :var:`argv[0]` program name).
 
+Logging is restricted to the Flux instance owner and silently fails
+if the caller does not have sufficient privilege.
+
 
 RETURN VALUE
 ============

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -13,7 +13,8 @@ fluxrc1dir = $(fluxconfdir)/rc1.d
 tmpfiles_DATA = flux.conf
 
 dist_crondaily_SCRIPTS = \
-	cron.daily/50-flux-dump
+	cron.daily/50-flux-dump \
+	cron.daily/51-flux-gc
 
 nobase_dist_fluxlibexec_DATA = \
 	modprobe/rc1.py \

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -7,13 +7,9 @@ systemdsystemunit_DATA = \
 #endif
 
 tmpfilesdir = $(prefix)/lib/tmpfiles.d
-crondir = $(fluxconfdir)/system/cron.d
 fluxrc1dir = $(fluxconfdir)/rc1.d
 
 tmpfiles_DATA = flux.conf
-
-dist_cron_DATA = \
-	kvs-backup.cron
 
 nobase_dist_fluxlibexec_DATA = \
 	modprobe/rc1.py \

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -7,9 +7,13 @@ systemdsystemunit_DATA = \
 #endif
 
 tmpfilesdir = $(prefix)/lib/tmpfiles.d
+crondailydir = $(sysconfdir)/cron.daily
 fluxrc1dir = $(fluxconfdir)/rc1.d
 
 tmpfiles_DATA = flux.conf
+
+dist_crondaily_SCRIPTS = \
+	cron.daily/50-flux-dump
 
 nobase_dist_fluxlibexec_DATA = \
 	modprobe/rc1.py \

--- a/etc/cron.daily/50-flux-dump
+++ b/etc/cron.daily/50-flux-dump
@@ -1,0 +1,23 @@
+#!/bin/sh
+# 50-flux-dump - Flux KVS content dump
+#
+# Installed to /etc/cron.daily/
+#
+# Note: chmod -x to disable.
+
+# Exit silently if Flux is down, or this is not the leader broker.
+# N.B. this short circuits the flux user transition on non-participating
+# ranks to avoid a PAM session auth-log entry per node from runuser.
+test "$(flux getattr rank 2>/dev/null)" = "0" || exit 0
+
+exec runuser -u flux -- sh -c '
+    runcmd() {
+        name=cron.daily
+        (eval "$@" | flux logger -n $name -s info) 2>&1 \
+            | flux logger -n $name -s err
+    }
+    statedir=$(flux getattr statedir)
+    mkdir -p $(flux getattr statedir)/dump
+    runcmd flux dump --quiet --ignore-failed-read \
+       "$statedir/dump/$(date +%Y%m%d_%H%M%S).tgz"
+'

--- a/etc/cron.daily/51-flux-gc
+++ b/etc/cron.daily/51-flux-gc
@@ -1,0 +1,20 @@
+#!/bin/sh
+# 51-flux-gc - Flux online KVS garbage collection
+#
+# Installed to /etc/cron.daily/
+#
+# Note: chmod -x to disable.
+
+# Exit silently if Flux is down, or this is not the leader broker.
+# N.B. this short circuits the flux user transition on non-participating
+# ranks to avoid a PAM session auth-log entry per node from runuser.
+test "$(flux getattr rank 2>/dev/null)" = "0" || exit 0
+
+exec runuser -u flux -- sh -c '
+    runcmd() {
+        name=cron.daily
+        (eval "$@" | flux logger -n $name -s info) 2>&1 \
+            | flux logger -n $name -s err
+    }
+    runcmd flux gc --maxreqs=16
+'

--- a/etc/kvs-backup.cron
+++ b/etc/kvs-backup.cron
@@ -1,1 +1,0 @@
-0 3 * * * sh -c "flux dump --quiet --ignore-failed-read $(flux getattr statedir)/dump/$(date +%Y%m%d_%H%M%S).tgz"

--- a/src/cmd/builtin/gc.c
+++ b/src/cmd/builtin/gc.c
@@ -153,7 +153,7 @@ static void mark_reap (flux_future_t *f, void *arg)
     else {
         m->marked += marked;
         if (verbose > 1)
-            log_msg ("marked %d blobs", marked);
+            printf ("marked %d blobs\n", marked);
     }
 
     flux_future_destroy (f);
@@ -337,7 +337,7 @@ static int enumerate_checkpoint_roots (flux_t *h, json_t *roots_array)
         /* No checkpoints yet (ENOENT) is OK - just no roots to mark */
         if (errno == ENOENT) {
             if (verbose)
-                log_msg ("no checkpoints found");
+                printf ("no checkpoints found\n");
             rc = 0;
             goto done;
         }
@@ -368,7 +368,7 @@ static int enumerate_checkpoint_roots (flux_t *h, json_t *roots_array)
     }
 
     if (verbose)
-        log_msg ("enumerated %d checkpoint roots", count);
+        printf ("enumerated %d checkpoint roots\n", count);
 
     rc = 0;
 done:
@@ -392,8 +392,10 @@ static int enumerate_private_namespace_roots (flux_t *h, json_t *roots_array)
          * checkpoints alone are correct (mirroring flux-dump --checkpoint).
          */
         if (errno == ENOSYS || errno == ENOENT) {
-            if (verbose)
-                log_msg ("kvs not loaded; skipping live private namespace roots");
+            if (verbose) {
+                printf ("kvs not loaded;"
+                        " skipping live private namespace roots\n");
+            }
             rc = 0;
             goto done;
         }
@@ -469,7 +471,7 @@ static int enumerate_private_namespace_roots (flux_t *h, json_t *roots_array)
     }
 
     if (verbose)
-        log_msg ("enumerated %d private namespace roots", count);
+        printf ("enumerated %d private namespace roots\n", count);
 
     rc = 0;
 done:
@@ -592,7 +594,7 @@ static int mark_all_roots (flux_t *h, json_t *roots_array, int64_t *markedp)
         goto done;
 
     if (verbose)
-        log_msg ("mark phase complete");
+        printf ("mark phase complete\n");
 
     *markedp = m.marked;
     rc = 0;
@@ -607,7 +609,7 @@ static int sweep_blobs (flux_t *h, int64_t *deletedp)
     int64_t cursor = 0;
 
     if (verbose)
-        log_msg ("starting sweep phase");
+        printf ("starting sweep phase\n");
 
     /* Sweep by walking the objects table in rowid order via a cursor, bounded
      * at the frozen high-water rowid.  Each call deletes garbage in a rowid
@@ -641,17 +643,18 @@ static int sweep_blobs (flux_t *h, int64_t *deletedp)
 
         total_deleted += deleted;
 
-        if (verbose > 1)
-            log_msg ("swept %jd blobs, cursor %jd/%jd",
-                     (intmax_t)deleted,
-                     (intmax_t)cursor,
-                     (intmax_t)horizon_high_water);
+        if (verbose > 1) {
+            printf ("swept %jd blobs, cursor %jd/%jd\n",
+                    (intmax_t)deleted,
+                    (intmax_t)cursor,
+                    (intmax_t)horizon_high_water);
+        }
 
         flux_future_destroy (f);
     }
 
     if (verbose)
-        log_msg ("sweep complete: deleted %jd blobs", (intmax_t)total_deleted);
+        printf ("sweep complete: deleted %jd blobs\n", (intmax_t)total_deleted);
 
     *deletedp = total_deleted;
     return 0;
@@ -666,6 +669,8 @@ int cmd_gc (optparse_t *p, int argc, char **argv)
     json_t *roots = NULL;
     int64_t marked = 0;
     int64_t deleted = 0;
+
+    setvbuf(stdout, NULL, _IONBF, 0);
 
     if (optindex != argc) {
         optparse_print_usage (p);
@@ -689,10 +694,11 @@ int cmd_gc (optparse_t *p, int argc, char **argv)
     horizon_epoch = current_epoch;
     horizon_high_water = high_water;
 
-    if (verbose)
-        log_msg ("froze epoch at %jd, high-water rowid %jd",
-                 (intmax_t)horizon_epoch,
-                 (intmax_t)high_water);
+    if (verbose) {
+        printf ("froze epoch at %jd, high-water rowid %jd\n",
+                (intmax_t)horizon_epoch,
+                (intmax_t)high_water);
+    }
 
     /* Enumerate roots */
     if (!(roots = json_array ()))
@@ -713,7 +719,7 @@ int cmd_gc (optparse_t *p, int argc, char **argv)
         log_err_exit ("failed to enumerate live primary root");
 
     if (verbose)
-        log_msg ("enumerated %zu total roots", json_array_size (roots));
+        printf ("enumerated %zu total roots\n", json_array_size (roots));
 
     /* Mark phase */
     if (mark_all_roots (h, roots, &marked) < 0)
@@ -740,10 +746,11 @@ int cmd_gc (optparse_t *p, int argc, char **argv)
      * 'deleted' counts blobs actually reclaimed -- the accurate figures, in
      * contrast to a pre-mark count that would include reachable data.
      */
-    log_msg ("gc complete: marked %jd, reclaimed %jd blobs (horizon epoch %jd)",
-             (intmax_t)marked,
-             (intmax_t)deleted,
-             (intmax_t)horizon_epoch);
+    printf ("gc complete:"
+            " marked %jd, reclaimed %jd blobs (horizon epoch %jd)\n",
+            (intmax_t)marked,
+            (intmax_t)deleted,
+            (intmax_t)horizon_epoch);
     json_decref (roots);
     json_decref (visited);
     flux_close (h);

--- a/src/cmd/flux-logger.c
+++ b/src/cmd/flux-logger.c
@@ -73,6 +73,8 @@ int main (int argc, char *argv[])
     }
     if (optind == argc) {
         len = read_all (STDIN_FILENO, (void **)&message);
+        if (len == 0)
+            goto done;
     } else {
         if ((e = argz_create (argv + optind, &message, &len)) != 0)
             log_errn_exit (e, "argz_create");
@@ -88,6 +90,7 @@ int main (int argc, char *argv[])
 
     flux_close (h);
 
+done:
     free (message);
     log_fini ();
     return 0;


### PR DESCRIPTION
Problem: flux-gc(1) is not run automatically.

This converts nightly KVS dumps from flux-cron(1) to a regular system cron.daily script, then adds a new cron.daily script to perform garbage collection.  The scripts are no-ops on non-leader nodes or when flux is not running.  They should not generate any system log noise.

The scripts send their stdout & stderr to the broker via flux-logger(1), at LOG_INFO and LOG_ERR respectively.  That proved slightly irritating and resulted in the following minor fixups:
- flux-logger: don't log an empty message if stdin is empty
- log flux-gc(1) non-error messages to stdout instead of stderr
- add a note about required credentials to flux-logger(1) and flux_log(3).

I did install this on my debian test system and observed that a log was created and gc fired.  Log output looks like this:
```
[Sep01 06:25] cron.daily.info[0]: gc complete: marked 1367, reclaimed 0 blobs (horizon epoch 2)
```

p.s. AFAICS there is no alternate `cron.daily`  directory for packaged scripts, so these are installed directly to `/etc`