### PR TITLE
support `sdexec.allowed-devices` to extend allowed devices for all jobs when `sdexec-constrain-resources` is set

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -286,7 +286,9 @@ The following unit properties are reserved for use by Flux and should not be
 added to ``exec.sdexec-properties``: AllowedCPUs, AllowedMemoryNodes, DeviceAllow,
 DevicePolicy, Description, Environment, ExecStart, KillMode, RemainAfterExit,
 SendSIGKILL, StandardInputFileDescriptor, StandardOutputFileDescriptor,
-StandardErrorFileDescriptor, TimeoutStopUSec, Type, WorkingDirectory.
+StandardErrorFileDescriptor, TimeoutStopUSec, Type, WorkingDirectory. To allow
+additional devices, use ``sdexec.allowed-devices`` (see :ref:`sdexec_mapper`)
+rather than ``DeviceAllow``.
 
 
 .. _sdexec_mapper:
@@ -314,6 +316,33 @@ sdexec.mapper-searchpath
    (optional) Colon-separated list of directories to search for mapper modules.
    This allows loading custom mappers from site-specific locations without
    modifying the Python system path. (Default: empty).
+
+sdexec.allowed-devices
+   (optional) A list of device path globs allowed for every job regardless of
+   its resource allocation. This is the supported way to grant access to a
+   device that all jobs need, such as a network device (e.g. ``/dev/cxi*``
+   on HPE Slingshot), when ``sdexec-constrain-resources`` is enabled.
+   (Default: empty).
+
+   Each entry is a path glob under ``/dev``, optionally followed by whitespace
+   and a systemd permissions field (``r``, ``w``, ``m``); the default is
+   ``rw``. Recursive ``**`` globs are not allowed. Each match must resolve to a
+   char or block device node within ``/dev``. Expansion happens when the mapper
+   initializes and on ``flux config reload``, not per job, so a node that gains
+   a device needs a config reload. A pattern that matches nothing is silently
+   ignored, so one site-wide policy can be shared across nodes with different
+   hardware: each node grants the devices it has.
+
+   Entries are merged with, not substituted for, the ``DeviceAllow`` entries
+   computed by the mapper (for example GPU devices). The expanded list is
+   visible via ``flux module stats sdexec-mapper``.
+
+   Example:
+
+   .. code-block:: toml
+
+      [sdexec]
+      allowed-devices = [ "/dev/cxi*" ]
 
 Default Mapper Behavior
 ------------------------
@@ -367,7 +396,9 @@ Custom Mappers
 --------------
 
 Sites can customize resource mapping by providing a Python class that extends
-``flux.sdexec.map.ResourceMapper`` or ``flux.sdexec.map.HwlocMapper``.
+``flux.sdexec.map.ResourceMapper`` or ``flux.sdexec.map.HwlocMapper``. The
+static ``sdexec.allowed-devices`` allowlist is always applied by the
+sdexec-mapper module to the mapper's output when the output is non-empty.
 
 The mapper provides two extension points:
 
@@ -753,6 +784,15 @@ EXAMPLES
    [sdexec]
    mapper = "site.mappers.AccountingMapper"
    mapper-searchpath = "/etc/flux/mappers"
+
+::
+
+   [exec]
+   service = "sdexec"
+   sdexec-constrain-resources = true
+   [sdexec]
+   # Allow every job access to the Slingshot fabric device
+   allowed-devices = [ "/dev/cxi*" ]
 
 ::
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1260,3 +1260,5 @@ codebase
 unreviewed
 usernetes
 bgexec
+cxi
+allowlist

--- a/src/bindings/python/flux/sdexec/map.py
+++ b/src/bindings/python/flux/sdexec/map.py
@@ -84,6 +84,13 @@ Configuration
 The sdexec broker module loads the mapper class named by the
 ``[sdexec] mapper`` TOML config key.  The value must be a fully-qualified
 Python class name.  When omitted, :class:`HwlocMapper` is used.
+
+The ``[sdexec] allowed-devices`` config key holds a list of device path globs
+under ``/dev`` that are unconditionally merged into ``DeviceAllow`` for every
+job, independent of its resource allocation. The sdexec-mapper module applies
+this allowlist to the mapper's output (see :func:`expand_allowed_devices` and
+:func:`merge_allowed_devices`), so it works with any mapper class regardless of
+its constructor.
 """
 
 import errno
@@ -246,6 +253,35 @@ def expand_allowed_devices(patterns):
     return list(dict.fromkeys(result))
 
 
+def merge_allowed_devices(properties, allowed_devices):
+    """Merge a static device allowlist into a mapper's DeviceAllow property.
+
+    The allowlist is site policy applied by the sdexec-mapper module to the
+    output of any mapper, so it lives here rather than in a mapper class: a
+    custom :class:`ResourceMapper` that never calls ``super().__init__`` still
+    gets the configured devices. Entries are merged with, not substituted for,
+    any ``DeviceAllow`` set by the mapper's ``map_<type>()`` methods.
+
+    An empty *properties* dict is left untouched: a mapper returns ``{}`` to
+    request unconstrained execution, and adding ``DeviceAllow`` would flip that
+    to a constrained unit.
+
+    Args:
+        properties: Dict of systemd unit properties from a mapper's ``map()``.
+        allowed_devices: List of pre-expanded ``"<path> <perms>"`` entries,
+            as returned by :func:`expand_allowed_devices`.
+
+    Returns:
+        The *properties* dict, modified in place.
+    """
+    if properties and allowed_devices:
+        existing = properties.get("DeviceAllow", "")
+        entries = [e.strip() for e in existing.split(",") if e.strip()]
+        entries.extend(allowed_devices)
+        properties["DeviceAllow"] = ",".join(dict.fromkeys(entries))
+    return properties
+
+
 class ResourceMapper:
     """Base class for resource ID to systemd unit property mappers.
 
@@ -305,7 +341,9 @@ class ResourceMapper:
         by allowing access to standard pseudo devices (/dev/null, /dev/zero,
         etc.) while blocking physical devices unless explicitly allowed via
         ``DeviceAllow`` (set by resource mappers like
-        :meth:`~HwlocMapper.map_gpus`).
+        :meth:`~HwlocMapper.map_gpus`). The static ``sdexec.allowed-devices``
+        allowlist is applied separately by the sdexec-mapper module (see
+        :func:`merge_allowed_devices`), not here.
 
         An empty properties dict is left empty, preserving the ability for
         custom mappers to return ``{}`` to indicate unconstrained execution
@@ -657,6 +695,14 @@ def main(args=None):
         default=None,
         help="fully-qualified mapper class (default: flux.sdexec.map.HwlocMapper)",
     )
+    parser.add_argument(
+        "--allowed-devices",
+        metavar="PATTERN",
+        action="append",
+        default=[],
+        help="device path glob to allow for all jobs (repeatable); "
+        "expanded against the local /dev",
+    )
     opts = parser.parse_args(args)
 
     xml = _get_system_xml(opts.xml)
@@ -672,6 +718,10 @@ def main(args=None):
     else:
         cls = HwlocMapper
 
+    try:
+        allowed = expand_allowed_devices(opts.allowed_devices)
+    except ValueError as exc:
+        raise SystemExit(f"--allowed-devices: {exc}")
     mapper = cls(xml)
     R = _build_R(cores=opts.cores or None, gpus=opts.gpus or None)
     try:
@@ -679,6 +729,7 @@ def main(args=None):
     except OSError as exc:
         print(f"mapper failed: {exc}", file=sys.stderr)
         return 1
+    merge_allowed_devices(result, allowed)
 
     print(json.dumps(result, indent=2))
     return 0

--- a/src/bindings/python/flux/sdexec/map.py
+++ b/src/bindings/python/flux/sdexec/map.py
@@ -88,6 +88,7 @@ Python class name.  When omitted, :class:`HwlocMapper` is used.
 
 import errno
 import math
+import re
 from pathlib import Path
 
 from flux.cli.argparse import FluxArgumentParser
@@ -98,6 +99,10 @@ from flux.resource import ResourceSet
 SYSFS_PCI_DEVICES = "/sys/bus/pci/devices"
 DEV_DRI = "/dev/dri"
 DEV_PREFIX = "/dev"
+DEV_ROOT = Path(DEV_PREFIX)
+
+# systemd.resource-control(5) DeviceAllow permissions field
+_PERMS_RE = re.compile(r"^[rwm]{1,3}$")
 
 # Driver names
 NVIDIA_DRIVER = "nvidia"
@@ -176,6 +181,69 @@ def _scale_memory_prop(value_str, alloc, total):
     if is_pct:
         return f"{round(scaled)}%"
     return str(int(scaled))
+
+
+def _is_device_node(path):
+    """True if path is a char or block device resolving within /dev.
+
+    Some /dev entries are symlinks (e.g. /dev/dri/by-path/*), so the target is
+    resolved rather than rejected, but a symlink pointing outside /dev must not
+    widen the allowlist.
+    """
+    if not (path.is_char_device() or path.is_block_device()):
+        return False
+    try:
+        real = path.resolve(strict=True)
+    except OSError:
+        return False
+    return real == DEV_ROOT or DEV_ROOT in real.parents
+
+
+def expand_allowed_devices(patterns):
+    """Expand configured device path globs to DeviceAllow entries.
+
+    Each entry in patterns is a path glob under /dev, optionally followed by
+    whitespace and a systemd permissions field. Permissions default to "rw".
+    Globs are expanded relative to /dev, so a pattern cannot escape upward,
+    recursive "**" globs are rejected, and each result must be a char or block
+    device node.
+
+    A pattern that matches nothing is silently ignored. This lets a site use
+    one global allowed-devices policy across nodes with different hardware: a
+    node simply grants the devices it has and skips the rest.
+
+    Args:
+        patterns: List of configured pattern strings.
+
+    Returns:
+        Deduplicated list of "<path> <perms>" strings.
+
+    Raises:
+        ValueError: A pattern is malformed or not under /dev.
+    """
+    result = []
+    for entry in patterns or []:
+        if not isinstance(entry, str):
+            raise ValueError(f"allowed-devices entry is not a string: {entry!r}")
+        fields = entry.split()
+        if not fields:
+            raise ValueError("allowed-devices entry is empty")
+        if len(fields) > 2:
+            raise ValueError(f"too many fields in allowed-devices entry: {entry!r}")
+        pattern = fields[0]
+        perms = fields[1] if len(fields) > 1 else "rw"
+        if not _PERMS_RE.match(perms):
+            raise ValueError(f"invalid device permissions in {entry!r}")
+        if not pattern.startswith(f"{DEV_PREFIX}/"):
+            raise ValueError(f"device pattern must be under {DEV_PREFIX}: {pattern!r}")
+        rel = pattern[len(DEV_PREFIX) + 1 :]
+        parts = Path(rel).parts
+        if not rel or ".." in parts or "**" in parts:
+            raise ValueError(f"invalid device pattern: {pattern!r}")
+        matches = sorted(DEV_ROOT.glob(rel))
+        devices = [p for p in matches if _is_device_node(p)]
+        result.extend(f"{path} {perms}" for path in devices)
+    return list(dict.fromkeys(result))
 
 
 class ResourceMapper:

--- a/src/modules/sdexec-mapper.py
+++ b/src/modules/sdexec-mapper.py
@@ -25,9 +25,13 @@ substituted via broker configuration::
 
     [sdexec]
     mapper = "mypackage.mymodule.MyMapper"
+    allowed-devices = [ "/dev/cxi*" ]
 
 The custom class must accept the same constructor arguments as
-:class:`~flux.sdexec.map.HwlocMapper` (xml).
+:class:`~flux.sdexec.map.HwlocMapper` (xml). ``sdexec.allowed-devices`` is a
+list of device path globs under ``/dev`` that this module merges into every
+job's ``DeviceAllow`` after the mapper runs, so it applies to any mapper class
+regardless of its constructor.
 
 Load with::
 
@@ -38,7 +42,7 @@ import errno
 import importlib
 
 from flux.brokermod import BrokerModule, request_handler
-from flux.sdexec.map import HwlocMapper
+from flux.sdexec.map import HwlocMapper, expand_allowed_devices, merge_allowed_devices
 
 
 def _load_mapper_class(dotted_name):
@@ -61,6 +65,8 @@ class SdexecMapModule(BrokerModule):
         self._mapper = None
         self._mapper_class = None
         self._mapper_searchpath = None
+        self._allowed_device_patterns = None
+        self._allowed_devices = None
         self._sdexec_props = None
         self._requests = 0
 
@@ -97,6 +103,14 @@ class SdexecMapModule(BrokerModule):
             self._mapper_class = "flux.sdexec.map.HwlocMapper"
 
         self._mapper_searchpath = searchpath
+
+        patterns = self.handle.conf_get("sdexec.allowed-devices", default=[])
+        if not isinstance(patterns, list):
+            raise ValueError("sdexec.allowed-devices is not an array")
+        allowed = expand_allowed_devices(patterns)
+
+        self._allowed_device_patterns = patterns
+        self._allowed_devices = allowed
         self._mapper = cls(self._xml, rank)
         self._sdexec_props = self.handle.conf_get("exec.sdexec-properties", default={})
 
@@ -118,6 +132,7 @@ class SdexecMapModule(BrokerModule):
             result = self._mapper.map(
                 msg.payload["R"], extra_properties=self._sdexec_props
             )
+            merge_allowed_devices(result, self._allowed_devices)
             self._requests += 1
             self.handle.respond(msg, result)
         except OSError as exc:
@@ -139,6 +154,8 @@ class SdexecMapModule(BrokerModule):
             self._mapper = None
             self._mapper_class = None
             self._mapper_searchpath = None
+            self._allowed_device_patterns = None
+            self._allowed_devices = None
             self._sdexec_props = None
             self.handle.respond(msg)
         except Exception as exc:
@@ -159,6 +176,8 @@ class SdexecMapModule(BrokerModule):
                 "config": {
                     "mapper_class": self._mapper_class,
                     "mapper_searchpath": self._mapper_searchpath or "",
+                    "allowed_device_patterns": self._allowed_device_patterns or [],
+                    "allowed_devices": self._allowed_devices or [],
                 },
                 "requests": self._requests,
             }

--- a/t/python/t0043-sdexec-map.py
+++ b/t/python/t0043-sdexec-map.py
@@ -14,15 +14,18 @@ import io
 import json
 import math
 import os
+import re
+import stat as stat_mod
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 from unittest.mock import patch
 
 import flux.sdexec.map as m
 import subflux  # noqa: F401 - for PYTHONPATH
 from flux.idset import IDset
-from flux.sdexec.map import HwlocMapper, ResourceMapper
+from flux.sdexec.map import HwlocMapper, ResourceMapper, merge_allowed_devices
 from pycotap import TAPTestRunner
 
 os.environ["PATH"] = (
@@ -536,6 +539,75 @@ class TestFinalizeProperties(unittest.TestCase):
         self.assertEqual(result["DevicePolicy"], "closed")
 
 
+class TestMergeAllowedDevices(unittest.TestCase):
+    """Test merge_allowed_devices(), which applies the static allowlist to a
+    mapper's output independent of the mapper class."""
+
+    DEVLINK = re.compile(r"^\S+ [rwm]{1,3}$")
+
+    def _assert_valid_entries(self, device_allow):
+        """Every DeviceAllow entry has exactly one space and non-empty perms."""
+        for entry in device_allow.split(","):
+            self.assertRegex(entry, self.DEVLINK)
+
+    def test_no_existing_device_allow(self):
+        """With no mapper DeviceAllow, the entry comes from the allowlist alone."""
+        props = {"AllowedCPUs": "0-1", "DevicePolicy": "closed"}
+        merge_allowed_devices(props, ["/dev/cxi0 rw"])
+        self.assertEqual(props["DeviceAllow"], "/dev/cxi0 rw")
+        self._assert_valid_entries(props["DeviceAllow"])
+
+    def test_appended_to_existing(self):
+        """Allowlist entries are appended to a mapper-set DeviceAllow value."""
+        props = {"DeviceAllow": "/dev/dri/renderD128 rw", "DevicePolicy": "closed"}
+        merge_allowed_devices(props, ["/dev/cxi0 rw"])
+        entries = props["DeviceAllow"].split(",")
+        self.assertIn("/dev/dri/renderD128 rw", entries)
+        self.assertIn("/dev/cxi0 rw", entries)
+        self._assert_valid_entries(props["DeviceAllow"])
+
+    def test_duplicate_appears_once(self):
+        """An allowlist entry duplicating a mapper device is deduplicated."""
+        props = {"DeviceAllow": "/dev/dri/renderD128 rw"}
+        merge_allowed_devices(props, ["/dev/dri/renderD128 rw"])
+        entries = props["DeviceAllow"].split(",")
+        self.assertEqual(entries.count("/dev/dri/renderD128 rw"), 1)
+
+    def test_empty_properties_stays_empty(self):
+        """Empty properties (unconstrained execution) are not turned on."""
+        props = {}
+        merge_allowed_devices(props, ["/dev/cxi0 rw"])
+        self.assertEqual(props, {})
+
+    def test_empty_allowlist_is_noop(self):
+        """An empty or None allowlist leaves properties unchanged."""
+        base = {"AllowedCPUs": "0-1", "DevicePolicy": "closed"}
+        for allowed in (None, []):
+            props = dict(base)
+            merge_allowed_devices(props, allowed)
+            self.assertEqual(props, base)
+            self.assertNotIn("DeviceAllow", props)
+
+    def test_returns_same_dict(self):
+        """merge_allowed_devices modifies and returns the same dict."""
+        props = {"DevicePolicy": "closed"}
+        self.assertIs(merge_allowed_devices(props, ["/dev/cxi0 rw"]), props)
+
+    def test_applies_to_any_mapper_output(self):
+        """The merge applies to a custom mapper that never calls super().__init__."""
+
+        class BespokeMapper(ResourceMapper):
+            def __init__(self):  # deliberately ignores the base constructor
+                self._rank = 0
+
+            def map_cores(self, cores):
+                return {"AllowedCPUs": cores}
+
+        result = BespokeMapper().map(make_R(cores="0"))
+        merge_allowed_devices(result, ["/dev/cxi0 rw"])
+        self.assertEqual(result["DeviceAllow"], "/dev/cxi0 rw")
+
+
 class TestParseSize(unittest.TestCase):
     """Test the _parse_size() helper."""
 
@@ -722,6 +794,163 @@ class TestHwlocMapperMemoryMax(unittest.TestCase):
         self.assertEqual(received["extra"], ep)
 
 
+class _FakeDev:
+    """Describe a fake /dev entry for the expand_allowed_devices tests.
+
+    kind is one of "char", "block", "file", "dir", or "symlink". For a
+    symlink, target is the resolved path (a string).
+    """
+
+    def __init__(self, kind, target=None):
+        self.kind = kind
+        self.target = target
+
+
+class TestExpandAllowedDevices(unittest.TestCase):
+    """Test expand_allowed_devices() against a patched fake /dev.
+
+    No broker and no real /dev dependency: Path.glob, Path.stat, and
+    Path.resolve are patched to describe a synthetic device tree.
+    """
+
+    def setUp(self):
+        # Map of absolute path string -> _FakeDev describing it.
+        self.tree = {}
+
+    def _expand(self, patterns):
+        tree = self.tree
+
+        def fake_glob(path_self, pattern):
+            prefix = str(path_self)
+            matched = []
+            for p in tree:
+                if not p.startswith(prefix + "/"):
+                    continue
+                rel = p[len(prefix) + 1 :]
+                if Path(rel).match(pattern):
+                    matched.append(Path(p))
+            return matched
+
+        def fake_stat(path_self):
+            entry = tree.get(str(path_self))
+            if entry is None:
+                raise OSError(errno.ENOENT, "no such fake device")
+            if entry.kind == "char":
+                mode = stat_mod.S_IFCHR
+            elif entry.kind == "block":
+                mode = stat_mod.S_IFBLK
+            elif entry.kind == "dir":
+                mode = stat_mod.S_IFDIR
+            elif entry.kind == "symlink":
+                # stat() follows the link to its target
+                target = tree.get(entry.target)
+                if target is None:
+                    raise OSError(errno.ENOENT, "dangling symlink")
+                mode = stat_mod.S_IFCHR if target.kind == "char" else stat_mod.S_IFBLK
+            else:
+                mode = stat_mod.S_IFREG
+            st = mock.Mock()
+            st.st_mode = mode
+            return st
+
+        def fake_resolve(path_self, strict=False):
+            entry = tree.get(str(path_self))
+            if entry is not None and entry.kind == "symlink":
+                return Path(entry.target)
+            return path_self
+
+        with patch.object(Path, "glob", fake_glob), patch.object(
+            Path, "stat", fake_stat
+        ), patch.object(Path, "resolve", fake_resolve):
+            return m.expand_allowed_devices(patterns)
+
+    def test_single_literal(self):
+        self.tree = {"/dev/cxi0": _FakeDev("char")}
+        self.assertEqual(self._expand(["/dev/cxi0"]), ["/dev/cxi0 rw"])
+
+    def test_glob_multiple_sorted(self):
+        self.tree = {
+            "/dev/cxi1": _FakeDev("char"),
+            "/dev/cxi0": _FakeDev("char"),
+        }
+        self.assertEqual(self._expand(["/dev/cxi*"]), ["/dev/cxi0 rw", "/dev/cxi1 rw"])
+
+    def test_explicit_perms(self):
+        self.tree = {"/dev/cxi0": _FakeDev("char")}
+        self.assertEqual(self._expand(["/dev/cxi* r"]), ["/dev/cxi0 r"])
+
+    def test_perms_separated_by_any_whitespace(self):
+        # The pattern and perms may be separated by any whitespace run, not
+        # just a single space.
+        self.tree = {"/dev/cxi0": _FakeDev("char")}
+        self.assertEqual(self._expand(["/dev/cxi0\tr"]), ["/dev/cxi0 r"])
+        self.assertEqual(self._expand(["/dev/cxi0   rw"]), ["/dev/cxi0 rw"])
+
+    def test_invalid_perms_raises(self):
+        with self.assertRaises(ValueError):
+            self._expand(["/dev/foo x"])
+        with self.assertRaises(ValueError):
+            self._expand(["/dev/foo rwmx"])
+
+    def test_too_many_fields_raises(self):
+        with self.assertRaises(ValueError):
+            self._expand(["/dev/foo rw extra"])
+
+    def test_empty_entry_raises(self):
+        with self.assertRaises(ValueError):
+            self._expand(["   "])
+
+    def test_pattern_not_under_dev_raises(self):
+        for bad in ["/etc/*", "dev/cxi0", "/dev"]:
+            with self.assertRaises(ValueError):
+                self._expand([bad])
+
+    def test_pattern_with_dotdot_raises(self):
+        with self.assertRaises(ValueError):
+            self._expand(["/dev/../etc/shadow"])
+
+    def test_recursive_glob_rejected(self):
+        # "**" would recurse into subdirectories of /dev; reject it explicitly.
+        for bad in ["/dev/**", "/dev/**/cxi0"]:
+            with self.assertRaises(ValueError):
+                self._expand([bad])
+
+    def test_non_string_entry_raises(self):
+        with self.assertRaises(ValueError):
+            self._expand([42])
+
+    def test_regular_file_skipped(self):
+        self.tree = {"/dev/notadev": _FakeDev("file")}
+        self.assertEqual(self._expand(["/dev/notadev"]), [])
+
+    def test_directory_skipped(self):
+        self.tree = {"/dev/shm": _FakeDev("dir")}
+        self.assertEqual(self._expand(["/dev/shm"]), [])
+
+    def test_symlink_outside_dev_skipped(self):
+        self.tree = {
+            "/dev/evil": _FakeDev("symlink", target="/tmp/evil"),
+            "/tmp/evil": _FakeDev("char"),
+        }
+        self.assertEqual(self._expand(["/dev/evil"]), [])
+
+    def test_symlink_inside_dev_returned(self):
+        self.tree = {
+            "/dev/link": _FakeDev("symlink", target="/dev/cxi0"),
+            "/dev/cxi0": _FakeDev("char"),
+        }
+        self.assertEqual(self._expand(["/dev/link"]), ["/dev/link rw"])
+
+    def test_no_match_silently_ignored(self):
+        # A glob matching nothing yields no entries and raises nothing, so a
+        # global allowed-devices policy works across heterogeneous nodes.
+        self.assertEqual(self._expand(["/dev/nomatch*"]), [])
+
+    def test_duplicate_patterns_deduplicated(self):
+        self.tree = {"/dev/cxi0": _FakeDev("char")}
+        self.assertEqual(self._expand(["/dev/cxi0", "/dev/cxi0"]), ["/dev/cxi0 rw"])
+
+
 class TestMain(unittest.TestCase):
     """Test the main() CLI entry point."""
 
@@ -782,6 +1011,24 @@ class TestMain(unittest.TestCase):
         ):
             ret = m.main(["--cores=0"])
         self.assertEqual(ret, 1)
+
+    def test_allowed_devices_merged(self):
+        """--allowed-devices entries appear in DeviceAllow."""
+        captured = io.StringIO()
+        with patch.object(m, "_get_system_xml", return_value=HWLOC_XML), patch.object(
+            m, "expand_allowed_devices", return_value=["/dev/null rw"]
+        ), patch("sys.stdout", captured):
+            ret = m.main(["--cores=0", "--allowed-devices=/dev/null"])
+        self.assertEqual(ret, 0)
+        result = json.loads(captured.getvalue())
+        self.assertEqual(result["DeviceAllow"], "/dev/null rw")
+        self.assertEqual(result["DevicePolicy"], "closed")
+
+    def test_allowed_devices_bad_pattern_exits(self):
+        """A malformed --allowed-devices pattern raises SystemExit."""
+        with patch.object(m, "_get_system_xml", return_value=HWLOC_XML):
+            with self.assertRaises(SystemExit):
+                m.main(["--cores=0", "--allowed-devices=/etc/passwd"])
 
 
 if __name__ == "__main__":

--- a/t/t2416-sdexec-constrain-resources.t
+++ b/t/t2416-sdexec-constrain-resources.t
@@ -288,6 +288,110 @@ test_expect_success 'MemoryMax absolute: revert to default config' '
 '
 
 #
+# Static device allowlist: sdexec.allowed-devices is merged into DeviceAllow
+# for every job. Use /dev/null, a char device present everywhere, so the
+# test needs no fabric NIC or GPU.
+#
+# Note: /dev/null is always usable by a job regardless of this config, since
+# systemd's DevicePolicy=closed includes it in a built-in whitelist. These
+# tests remain valid because they assert on the systemd DeviceAllow unit
+# property (i.e. that our config->expand->merge->unit plumbing works), not on
+# whether the job can actually access the device.
+#
+test_expect_success 'allowed-devices: configure sdexec.allowed-devices' '
+	cat >config/config.toml <<-EOT &&
+	[systemd]
+	enable = true
+	sdexec-debug = true
+	[exec]
+	service = "sdexec"
+	sdexec-constrain-resources = true
+	[sdexec]
+	allowed-devices = [ "/dev/null" ]
+	EOT
+	flux config reload
+'
+
+test_expect_success 'allowed-devices: stats report patterns and expansion' '
+	flux module stats sdexec-mapper >devstats.json &&
+	jq -e ".config.allowed_device_patterns == [\"/dev/null\"]" <devstats.json &&
+	jq -e ".config.allowed_devices == [\"/dev/null rw\"]" <devstats.json
+'
+
+test_expect_success "allowed-devices: job unit DeviceAllow contains /dev/null" '
+	result=$(flux run -n1 -c1 ./get_unit_prop.sh DeviceAllow) &&
+	test_debug "echo DeviceAllow=$result" &&
+	echo "$result" | grep "/dev/null rw"
+'
+
+# Use the glob /dev/nul* rather than a literal path so this exercises glob
+# expansion end to end: it matches exactly /dev/null on every system, and the
+# configured pattern differs from the expanded result, proving the mapper
+# expanded it rather than passing it through verbatim.
+test_expect_success 'allowed-devices: glob pattern is expanded' '
+	cat >config/config.toml <<-EOT &&
+	[systemd]
+	enable = true
+	sdexec-debug = true
+	[exec]
+	service = "sdexec"
+	sdexec-constrain-resources = true
+	[sdexec]
+	allowed-devices = [ "/dev/nul*" ]
+	EOT
+	flux config reload &&
+	flux module stats sdexec-mapper >devglob.json &&
+	jq -e ".config.allowed_device_patterns == [\"/dev/nul*\"]" <devglob.json &&
+	jq -e ".config.allowed_devices == [\"/dev/null rw\"]" <devglob.json &&
+	result=$(flux run -n1 -c1 ./get_unit_prop.sh DeviceAllow) &&
+	test_debug "echo DeviceAllow=$result" &&
+	echo "$result" | grep "/dev/null rw"
+'
+
+test_expect_success 'allowed-devices: changed config picked up via reload' '
+	cat >config/config.toml <<-EOT &&
+	[systemd]
+	enable = true
+	sdexec-debug = true
+	[exec]
+	service = "sdexec"
+	sdexec-constrain-resources = true
+	[sdexec]
+	allowed-devices = [ "/dev/zero" ]
+	EOT
+	flux config reload &&
+	result=$(flux run -n1 -c1 ./get_unit_prop.sh DeviceAllow) &&
+	test_debug "echo DeviceAllow=$result" &&
+	echo "$result" | grep "/dev/zero rw" &&
+	test_must_fail sh -c "echo \"$result\" | grep /dev/null"
+'
+
+test_expect_success 'allowed-devices: bad pattern makes jobs fail' '
+	cat >config/config.toml <<-EOT &&
+	[systemd]
+	enable = true
+	sdexec-debug = true
+	[exec]
+	service = "sdexec"
+	sdexec-constrain-resources = true
+	[sdexec]
+	allowed-devices = [ "/etc/*" ]
+	EOT
+	flux config reload &&
+	test_must_fail flux run -n1 -c1 hostname
+'
+test_expect_success 'allowed-devices: restore config' '
+	cat >config/config.toml <<-EOT &&
+	[systemd]
+	enable = true
+	sdexec-debug = true
+	[exec]
+	service = "sdexec"
+	sdexec-constrain-resources = true
+	EOT
+	flux config reload
+'
+#
 # Sad path: post-start AllowedCPUs check failure drains rank
 #
 # SDEXEC_TEST_EXPECTED_CPUS injects a wrong expected CPU idset (requires


### PR DESCRIPTION
When `exec.sdexec-constrain-devices=true` there is no simple way to extend the set of devices allowed for jobs outside of those provided by the mapper other than writing a new `ResourceMapper` class, but adding to the set of allowed devices is expected to be common practice, since many interconnects will need their devices allowed for use with MPI.

This PR adds a new `sdexec.allowed-devices` config key which supports a list of glob patterns that extend the allowed devices to every job beyond what is returned by the mapper. This allows sites to easily extend the allowed devices list for simple cases like interconnect device nodes, without writing and maintaining a custom mapper.