### PR TITLE
libpmi: conform to recent RFC 13 version handshake changes

### DIFF
--- a/src/common/libpmi/simple_client.c
+++ b/src/common/libpmi/simple_client.c
@@ -28,6 +28,10 @@
 #include "keyval.h"
 #include "pmi.h"
 
+/* Client sends exact required pmi_version and minimum required pmi_subversion.
+ * Server sends client's pmi_version and maximum supported pmi_subversion.
+ * See RFC 13 Version Handshake section for more detail.
+ */
 int pmi_simple_client_init (struct pmi_simple_client *pmi)
 {
     int result = PMI_FAIL;
@@ -50,7 +54,7 @@ int pmi_simple_client_init (struct pmi_simple_client *pmi)
     if (keyval_parse_uint (buf, "pmi_version", &vers) < 0
         || keyval_parse_uint (buf, "pmi_subversion", &subvers) < 0)
         goto done;
-    if (vers != 1 || subvers != 1)
+    if (vers != 1 || subvers < 1)
         goto done;
 
     if (fprintf (pmi->f, "cmd=get_maxes\n") < 0)

--- a/src/common/libpmi/simple_server.c
+++ b/src/common/libpmi/simple_server.c
@@ -253,10 +253,8 @@ int pmi_simple_server_request (struct pmi_simple_server *pmi,
             goto proto;
         if (keyval_parse_uint (buf, "pmi_subversion", &pmi_subversion) < 0)
             goto proto;
-        if (pmi_version < 1 || (pmi_version == 1 && pmi_subversion < 1))
-            snprintf (resp, sizeof (resp), "cmd=response_to_init rc=-1\n");
-        else if (pmi_version == 2) {
-            if (cli->rank == 0) {
+        if (pmi_version != 1 || pmi_subversion > 1) {
+            if (pmi_version == 2 && cli->rank == 0) {
                 warn (pmi,
                       cli,
                       "is application unintentionally using slurm libpmi2.so?");

--- a/src/common/libpmi/test/simple.c
+++ b/src/common/libpmi/test/simple.c
@@ -142,10 +142,14 @@ int main (int argc, char *argv[])
      * of this to beat on its version negotiation without any
      * setup/teardown of the server.
      */
-    ok (fake_init (cfp, 1, 0) == -1,
-        "fake init for protocol 1.0 fails");
+    ok (fake_init (cfp, 1, 3) == -1,
+        "fake init for protocol 1.3 fails");
     ok (fake_init (cfp, 2, 0) == -1,
         "fake init for protocol 2.0 fails");
+    ok (fake_init (cfp, 3, 0) == -1,
+        "fake init for protocol 3.0 fails");
+    ok (fake_init (cfp, 1, 0) == 0,
+        "fake init for protocol 1.0 succeeds");
     ok (fake_init (cfp, 1, 1) == 0,
         "fake init for protocol 1.1 succeeds");
 


### PR DESCRIPTION
I was confused about how the PMI 1 wire protocol version negotiation is intended to work, and had documented it wrong in RFC 13.  As a result, when MPICH 5 came out, its hydra which supports PMI 1.2 could not bootstrap our PMI 1.1 client.

That's fixed here and our server is tightened up too.

Follow on work will be to add support for PMI 1.2 which should enable MPI sessions support in MPICH.