### PR TITLE
[WIP] shell: select task command from scheduler-matched slot label

### DIFF
--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -119,6 +119,60 @@ static void R_update_cb (flux_future_t *f, void *arg)
     (void) flux_shell_plugstack_call (shell, "shell.resource-update", NULL);
 }
 
+/*  Determine the slot label the scheduler matched for resources on `rank`.
+ *
+ *  Fluxion's flexible traverser tags each vertex it allocates to a matched
+ *  slot with that slot's label, emitted in R as
+ *  scheduling.graph.nodes[].metadata.ephemeral.slot_label (present only with
+ *  match-format=rv1; rv1_nosched omits the scheduling key). The label lets the
+ *  shell pick the task command bound to the matched slot (RFC 14 tasks[].slot).
+ *
+ *  On success *labelp is set to a newly allocated label string, or to NULL when
+ *  no label applies to this rank (no scheduling key, no ephemeral label, or a
+ *  jobspec that did not use labeled alternatives) -- in which case the caller
+ *  keeps the tasks[0] default. Returns 0 on success, -1 (errno set) on error,
+ *  including finding more than one distinct label for this rank (which the
+ *  single-label task-selection model cannot represent).
+ */
+static int lookup_slot_label (json_t *R, int rank, char **labelp)
+{
+    json_t *nodes;
+    size_t index;
+    json_t *node;
+    const char *found = NULL;
+    char *label = NULL;
+
+    *labelp = NULL;
+    if (json_unpack (R, "{s:{s:{s:o}}}", "scheduling", "graph", "nodes", &nodes)
+            < 0)
+        return 0;
+    json_array_foreach (nodes, index, node) {
+        int node_rank = -1;
+        const char *slot_label = NULL;
+        if (json_unpack (node,
+                         "{s:{s:i s?{s?s}}}",
+                         "metadata",
+                         "rank", &node_rank,
+                         "ephemeral", "slot_label", &slot_label) < 0)
+            continue;
+        if (node_rank != rank || !slot_label)
+            continue;
+        if (found && !streq (found, slot_label)) {
+            shell_log_error ("rank %d has conflicting slot labels '%s' and '%s'",
+                             rank, found, slot_label);
+            errno = EINVAL;
+            return -1;
+        }
+        found = slot_label;
+    }
+    if (found && !(label = strdup (found))) {
+        errno = ENOMEM;
+        return -1;
+    }
+    *labelp = label;
+    return 0;
+}
+
 /*  Fetch jobinfo (jobspec, R) from job-info service if not provided on
  *   command line, and parse.
  */
@@ -310,6 +364,19 @@ struct shell_info *shell_info_create (flux_shell_t *shell)
     info->shell_rank = info->rankinfo.nodeid;
     info->total_ntasks = rcalc_total_ntasks (info->rcalc);
 
+    /*  If the scheduler matched a labeled slot (xor_slot/or_slot) for this
+     *  rank's resources, select the task command bound to that label. With no
+     *  label (single-task jobspec, or match-format without a scheduling key)
+     *  the tasks[0] default is kept.
+     */
+    if (lookup_slot_label (info->R, broker_rank, &info->matched_slot_label) < 0)
+        goto error;
+    if (jobspec_resolve_task_command (jobspec, info->matched_slot_label) < 0) {
+        shell_log_error ("no task found for matched slot label '%s'",
+                         info->matched_slot_label);
+        goto error;
+    }
+
     if (!(map = create_taskmap (info))
         || shell_info_set_taskmap (info, map) < 0) {
         taskmap_destroy (map);
@@ -334,6 +401,7 @@ void shell_info_destroy (struct shell_info *info)
         idset_destroy (info->taskids);
         hostlist_destroy (info->hostlist);
         free (info->hwloc_xml);
+        free (info->matched_slot_label);
         free (info);
         errno = saved_errno;
     }

--- a/src/shell/info.h
+++ b/src/shell/info.h
@@ -36,6 +36,7 @@ struct shell_info {
     struct idset *taskids;
     struct hostlist *hostlist;
     char *hwloc_xml;
+    char *matched_slot_label;   // slot label matched for this rank, or NULL
     flux_future_t *R_watch_future;
 };
 

--- a/src/shell/jobspec.c
+++ b/src/shell/jobspec.c
@@ -175,6 +175,7 @@ struct jobspec *jobspec_parse (const char *jobspec,
     struct jobspec *job;
     json_t *resources;
     json_t *count;
+    json_t *task;
     bool is_node_specified;
     const char *type;
 
@@ -198,17 +199,32 @@ struct jobspec *jobspec_parse (const char *jobspec,
     if (json_unpack_ex (job->jobspec,
                         error,
                         0,
-                        "{s:i s:o s:[{s:o s:o}] s:{s?{s?s s?O s?{s?O}}}}",
+                        "{s:i s:o s:o s:{s?{s?s s?O s?{s?O}}}}",
                         "version", &job->version,
                         "resources", &resources,
-                        "tasks",
-                            "command", &job->command,
-                            "count", &count,
+                        "tasks", &job->tasks,
                         "attributes",
                             "system",
                                 "cwd", &job->cwd,
                                 "environment", &job->environment,
                                 "shell", "options", &job->options) < 0) {
+        goto error;
+    }
+    /* Parse the first task's command and count. A jobspec may carry multiple
+     * tasks, each bound to a slot label; jobspec_resolve_task_command() may
+     * later repoint job->command to the task matching the scheduler's chosen
+     * slot. Until then (and for single-task jobspecs) tasks[0] is the default.
+     */
+    if (!(task = json_array_get (job->tasks, 0))) {
+        set_error (error, "tasks array is empty");
+        goto error;
+    }
+    if (json_unpack_ex (task,
+                        error,
+                        0,
+                        "{s:o s:o}",
+                        "command", &job->command,
+                        "count", &count) < 0) {
         goto error;
     }
     if (job->environment && !json_is_object (job->environment)) {
@@ -300,6 +316,35 @@ struct jobspec *jobspec_parse (const char *jobspec,
 error:
     jobspec_destroy (job);
     return NULL;
+}
+
+int jobspec_resolve_task_command (struct jobspec *job, const char *label)
+{
+    size_t index;
+    json_t *task;
+
+    /* No matched label: leave job->command at the tasks[0] default. This is
+     * the path for single-task jobspecs and for schedulers/formats that do
+     * not report a matched slot label (e.g. match-format=rv1_nosched).
+     */
+    if (!label || *label == '\0')
+        return 0;
+
+    json_array_foreach (job->tasks, index, task) {
+        const char *slot = NULL;
+        json_t *command = NULL;
+        if (json_unpack (task, "{s:s s:o}", "slot", &slot, "command", &command)
+                == 0
+            && streq (slot, label)) {
+            /* command is borrowed from job->jobspec, same as job->command;
+             * no reference count change is needed to repoint.
+             */
+            job->command = command;
+            return 0;
+        }
+    }
+    errno = ENOENT;
+    return -1;
 }
 
 /*

--- a/src/shell/jobspec.h
+++ b/src/shell/jobspec.h
@@ -26,7 +26,8 @@ struct jobspec {
     int slots_per_node;         // number of slots per node (-1=unspecified)
     int node_count;             // number of nodes (-1=unspecified)
     bool node_exclusive;        // exclusive=true on node resource
-    json_t *command;
+    json_t *tasks;              // full tasks array (borrowed from jobspec)
+    json_t *command;           // command to run (borrowed; tasks[N].command)
     const char *cwd;
     json_t *environment;
     json_t *options;            // attributes.system.shell.options, if any
@@ -36,6 +37,16 @@ struct jobspec {
 
 struct jobspec *jobspec_parse (const char *jobspec, rcalc_t *r, json_error_t *error);
 void jobspec_destroy (struct jobspec *job);
+
+/*  Select the task command bound to a matched slot `label` and point
+ *  job->command at it. If `label` is NULL or empty, job->command is left as
+ *  tasks[0].command (unchanged default behavior). If `label` is set but no
+ *  task has a matching `slot`, return -1 with errno set to ENOENT.
+ *
+ *  Both job->command and each task's command are borrowed references into
+ *  job->jobspec, so repointing requires no reference count changes.
+ */
+int jobspec_resolve_task_command (struct jobspec *job, const char *label);
 
 #endif /* !_SHELL_JOBSPEC_H */
 

--- a/src/shell/test/jobspec.c
+++ b/src/shell/test/jobspec.c
@@ -227,6 +227,92 @@ struct input bad_input[] = {
     { NULL, NULL, NULL },
 };
 
+/*  Return the first element of a parsed jobspec's command array as a C string,
+ *  or NULL. Used to check which task command jobspec_resolve_task_command ()
+ *  selected.
+ */
+static const char *command0 (struct jobspec *js)
+{
+    return json_string_value (json_array_get (js->command, 0));
+}
+
+/*  A jobspec with two tasks, each bound to a different slot label, mirroring
+ *  the per-xor-slot task selection use case.
+ */
+static const char *multitask_jobspec =
+    "{\"version\": 1,"
+    " \"resources\": [{\"type\": \"slot\", \"count\": 1, \"label\": \"task\","
+    "   \"with\": [{\"type\": \"core\", \"count\": 1}]}],"
+    " \"tasks\": ["
+    "   {\"command\": [\"app_a\"], \"slot\": \"alpha\", \"count\": {\"per_slot\": 1}},"
+    "   {\"command\": [\"app_b\"], \"slot\": \"beta\", \"count\": {\"per_slot\": 1}}],"
+    " \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/tmp\","
+    "   \"environment\": {}}}}";
+
+static const char *multitask_R =
+    "{\"version\": 1, \"execution\": {\"R_lite\":"
+    " [{\"rank\": \"0\", \"children\": {\"core\": \"0\"}}]}}";
+
+static void test_task_resolution (void)
+{
+    struct jobspec *js;
+    rcalc_t *rs;
+    json_error_t error;
+
+    /*  Multi-task jobspec parses, and command defaults to tasks[0].
+     */
+    rs = rcalc_create (multitask_R);
+    js = jobspec_parse (multitask_jobspec, rs, &error);
+    ok (js != NULL, "multi-task jobspec parses");
+    if (js) {
+        ok (json_array_size (js->tasks) == 2,
+            "multi-task jobspec captured both tasks");
+        is (command0 (js), "app_a",
+            "command defaults to tasks[0] before resolution");
+
+        /*  NULL and empty labels keep the tasks[0] default.
+         */
+        ok (jobspec_resolve_task_command (js, NULL) == 0,
+            "resolve with NULL label succeeds");
+        is (command0 (js), "app_a", "NULL label keeps tasks[0]");
+        ok (jobspec_resolve_task_command (js, "") == 0,
+            "resolve with empty label succeeds");
+        is (command0 (js), "app_a", "empty label keeps tasks[0]");
+
+        /*  A matching label selects that task's command.
+         */
+        ok (jobspec_resolve_task_command (js, "beta") == 0,
+            "resolve with label 'beta' succeeds");
+        is (command0 (js), "app_b", "label 'beta' selects app_b");
+        ok (jobspec_resolve_task_command (js, "alpha") == 0,
+            "resolve with label 'alpha' succeeds");
+        is (command0 (js), "app_a", "label 'alpha' selects app_a");
+
+        /*  A label with no matching task fails.
+         */
+        ok (jobspec_resolve_task_command (js, "gamma") < 0,
+            "resolve with unknown label fails");
+
+        jobspec_destroy (js);
+    }
+    rcalc_destroy (rs);
+
+    /*  A single-task jobspec (the common case) is unaffected: resolving any
+     *  label either keeps tasks[0] (no label) or fails cleanly.
+     */
+    rs = rcalc_create (good_input[0].r);
+    js = jobspec_parse (good_input[0].j, rs, &error);
+    ok (js != NULL, "single-task jobspec parses");
+    if (js) {
+        is (command0 (js), "hostname", "single-task command is tasks[0]");
+        ok (jobspec_resolve_task_command (js, NULL) == 0,
+            "single-task resolve with NULL label succeeds");
+        is (command0 (js), "hostname", "single-task command unchanged");
+        jobspec_destroy (js);
+    }
+    rcalc_destroy (rs);
+}
+
 int main (int argc, char **argv)
 {
     plan (NO_PLAN);
@@ -303,6 +389,8 @@ int main (int argc, char **argv)
             jobspec_destroy (js);
         rcalc_destroy (rs);
     }
+
+    test_task_resolution ();
 
     done_testing ();
     return 0;


### PR DESCRIPTION
  ## Summary

  This PR adds the flux-core shell support needed to select a task command based on the slot alternative
  matched by the scheduler.

  It complements [flux-sched#1550](https://github.com/flux-framework/flux-sched/pull/1550), which records the
  matched flexible-slot label in the scheduler’s R metadata. Together, the changes allow a jobspec with
  multiple `tasks[]` entries—each associated with a `tasks[].slot` label—to run the command corresponding to
  the resource alternative selected at scheduling time.

  ## Implementation

  - Preserve the complete jobspec `tasks` array during shell parsing, instead of retaining only `tasks[0]`.
  - Continue to use `tasks[0]` as the default command for ordinary single-task jobspecs.
  - Read the current broker rank’s matched slot label from:
    `scheduling.graph.nodes[].metadata.ephemeral.slot_label`
    in R.
  - Resolve `job->command` to the task whose `slot` matches that label before tasks are created. This means
  existing consumers of `job->command`, including task argv construction and the default job name,
  automatically use the selected command.
  - Fail clearly if R identifies a slot label for which the jobspec has no task.
  - Reject conflicting labels for resources allocated to the same rank, since the shell currently selects one
  command per rank.

  ## Compatibility

  Jobs without labeled task alternatives are unchanged:

  - Single-task jobspecs continue to run `tasks[0]`.
  - Jobs scheduled with an R match format that does not include scheduling metadata, such as `rv1_nosched`,
  also retain the `tasks[0]` default.

  ## Testing

  Adds unit coverage for multi-task jobspec parsing and command resolution, including:

  - default selection of `tasks[0]`;
  - NULL and empty labels;
  - matching labels selecting the corresponding command; and
  - unknown labels returning an error.

[Flux-sched companion PR here](https://github.com/flux-framework/flux-sched/pull/1550)