### PR TITLE
doc: enhance header docs for flux_hostlist_nth() and flux_get_hostbyrank()

### DIFF
--- a/src/common/libflux/hosts.h
+++ b/src/common/libflux/hosts.h
@@ -17,6 +17,8 @@ extern "C" {
 
 /* Look up hostname of broker rank, by consulting "hostlist" attribute.
  * This function always returns a printable string, though it may be "(null)".
+ *
+ * The returned value is only valid until the next call.
  */
 const char *flux_get_hostbyrank (flux_t *h, uint32_t rank);
 

--- a/src/common/libhostlist/hostlist.h
+++ b/src/common/libhostlist/hostlist.h
@@ -54,6 +54,10 @@ int hostlist_append_list (struct hostlist *hl1, struct hostlist *hl2);
 /*  Return the nth host in hostlist 'hl' or NULL on failure.
  *
  *  Moves the hostlist cursor to the returned host on success.
+ *
+ *  The returned value is only valid until the next call that modifies
+ *   the cursor, i.e. hostlist_next(), hostlist_first(), hostlist_last(),
+ *    hostlist_find(), and hostlist_nth().
  */
 const char * hostlist_nth (struct hostlist * hl, int n);
 


### PR DESCRIPTION
Problem: the header docs for neither `flux_hostlist_nth()` nor `flux_get_hostbyrank()` metion the fact that their result is invalidated by the next call.

Update headers.