### PR TITLE
job-exec: reject `exec.sdexec-constrain-resources,sdexec-properties` when `exec.service` is not `sdexec`

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -182,6 +182,7 @@ exec.sdexec-constrain-resources
 
    **Requirements:**
 
+   - ``exec.service = "sdexec"``
    - cgroups v2 (unified hierarchy)
    - cpuset cgroup controller delegated to user systemd instance
    - flux-security >= 0.14.0
@@ -199,7 +200,8 @@ exec.sdexec-constrain-resources
 
 exec.sdexec-properties
    (optional) A table of systemd properties to set for all jobs. All values
-   must be strings. See :ref:`sdexec_properties` below.
+   must be strings. See :ref:`sdexec_properties` below. It is an error to
+   specify systemd properties if ``exec.service`` is not set to ``sdexec``.
 
 exec.sdexec-stop-timer-sec
    (optional) Configure the length of time in seconds after a unit enters

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -381,6 +381,30 @@ int config_setup (flux_t *h,
         }
     }
 
+    /*  sdexec-properties requires exec.service = "sdexec"
+     */
+    if (tmpconf.sdexec_properties
+        && !streq (tmpconf.exec_service, "sdexec")) {
+        errprintf (errp,
+                   "exec.sdexec-properties requires "
+                   "exec.service=\"sdexec\", got exec.service=\"%s\"",
+                   tmpconf.exec_service);
+        errno = EINVAL;
+        return -1;
+    }
+
+    /*  sdexec-constrain-resources requires exec.service = "sdexec"
+     */
+    if (tmpconf.sdexec_constrain_resources
+        && !streq (tmpconf.exec_service, "sdexec")) {
+        errprintf (errp,
+                   "exec.sdexec-constrain-resources requires "
+                   "exec.service=\"sdexec\", got exec.service=\"%s\"",
+                   tmpconf.exec_service);
+        errno = EINVAL;
+        return -1;
+    }
+
     exec_conf = tmpconf;
     return 0;
 }

--- a/t/t2403-job-exec-conf.t
+++ b/t/t2403-job-exec-conf.t
@@ -296,6 +296,27 @@ test_expect_success 'job-exec: cmdline exec service takes priority' '
 	grep "cmdline-exec-service" reload6B.out &&
 	rm -f ${FLUX_CONF_DIR}/exec.toml
 '
+test_expect_success 'job-exec: sdexec-constrain-resources requires exec.service=sdexec' '
+	name=sdexec-constrain-no-sdexec &&
+	cat <<-EOF > ${name}.toml &&
+	[exec]
+	sdexec-constrain-resources = true
+	EOF
+	test_must_fail flux start --config-path=${name}.toml -s1 \
+		flux dmesg > ${name}.log 2>&1 &&
+	grep "exec.sdexec-constrain-resources requires exec.service" ${name}.log
+'
+test_expect_success 'job-exec: sdexec properties require exec.service=sdexec' '
+	name=sdexec-properties-no-sdexec &&
+	cat <<-EOF > ${name}.toml &&
+	[exec.sdexec-properties]
+	MemoryHigh = "200M"
+	MemoryMax = "100M"
+	EOF
+	test_must_fail flux start --config-path=${name}.toml -s1 \
+		flux dmesg > ${name}.log 2>&1 &&
+	grep "exec.sdexec-properties requires exec.service" ${name}.log
+'
 test_expect_success 'job-exec: sdexex properties can be set in exec conf' '
 	name=sdexec-properties &&
 	cat <<-EOF > ${name}.toml &&


### PR DESCRIPTION
Problem: The job execution system silently ignores `exec.sdexec-constrain-resources` and `exec.sdexec-properties` when they are set and `exec.service` != `"sdexec"`. This could cause admins to think resource containment is active when it is not.

Validate that `exec.service` = `"sdexec"` when either of these config keys are set. Generate a fatal error if not.

Add a short note to the docs for each that it is an error if the exec service is not `"sdexec"` when these keys are used.