### PR TITLE
libsubprocess: skip socketpair unless fork is used

### DIFF
--- a/src/common/libsubprocess/fork.c
+++ b/src/common/libsubprocess/fork.c
@@ -12,6 +12,7 @@
 # include "config.h"
 #endif
 
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <signal.h>
@@ -282,6 +283,17 @@ static int local_exec (flux_subprocess_t *p)
 
 int create_process_fork (flux_subprocess_t *p)
 {
+    /* set CLOEXEC on sync_fds, so on exec(), child sync_fd is closed
+     * and seen by parent */
+#if SOCK_CLOEXEC
+    if (socketpair (PF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, p->sync_fds) < 0)
+        return -1;
+#else
+    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, p->sync_fds) < 0
+        || fd_set_cloexec (p->sync_fds[0]) < 0
+        || fd_set_cloexec (p->sync_fds[1]) < 0)
+        return -1;
+#endif
     if ((p->pid = fork ()) < 0)
         return -1;
 

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -13,7 +13,6 @@
 #endif
 
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <errno.h>
@@ -200,18 +199,6 @@ static flux_subprocess_t *subprocess_create (
      * (i.e. fd == 0)
      */
     init_pair_fds (p->sync_fds);
-
-    /* set CLOEXEC on sync_fds, so on exec(), child sync_fd is closed
-     * and seen by parent */
-#if SOCK_CLOEXEC
-    if (socketpair (PF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, p->sync_fds) < 0)
-        goto error;
-#else
-    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, p->sync_fds) < 0
-        || fd_set_cloexec (p->sync_fds[0]) < 0
-        || fd_set_cloexec (p->sync_fds[1]) < 0)
-        goto error;
-#endif
 
     if (!(p->channels = zhash_new ())
         || !(p->msgchans = zhash_new ()))


### PR DESCRIPTION
Problem: a high-fanout flux-exec fails when it hits the file descriptor ulimit.

All subprocesses, including remote ones, create the socketpair(2) that is only used for synchronization with fork(2).

Make that local to fork.c so it is only created when needed.

Fixes #7803