### PR TITLE
fix GPU id assignment in jobs run under resource containment

### DIFF
--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -45,8 +45,24 @@ with the following layout:
    "ntasks";i,
    "service";s,
    "options": { "verbose":b, "standalone":b },
+   "constrained_resources":b,
    "jobspec":o,
    "R":o
+
+where :var:`constrained_resources` indicates that the job's access to
+resources has been constrained to its allocation, as configured by
+``exec.sdexec-constrain-resources`` in :man5:`flux-config-exec`. The value
+is always present.
+
+Resource ids in :var:`R` and in the rank info object are not affected by
+this setting: they are always the ids assigned by the enclosing instance.
+When resources are constrained, however, tools and libraries that enumerate
+devices see only the subset available to the job and index them from zero,
+so those ids are not valid indices within the library. A plugin that
+translates resource ids from :var:`R` into identifiers for use outside
+Flux must account for this. For example, the builtin ``gpu-affinity``
+plugin sets :envvar:`CUDA_VISIBLE_DEVICES` to the position of each allocated
+GPU within the rank's allocation rather than to its id from :var:`R`.
 
 :func:`flux_shell_get_rank_info` returns shell rank information as a json
 string with the following layout:

--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -13,11 +13,11 @@ SYNOPSIS
    #include <errno.h>
 
    int flux_shell_get_info (flux_shell_t *shell,
-                           char **json_str);
+                            char **json_str);
 
    int flux_shell_info_unpack (flux_shell_t *shell,
-                              const char *fmt,
-                              ...);
+                               const char *fmt,
+                               ...);
 
    int flux_shell_get_rank_info (flux_shell_t *shell,
                                  int shell_rank,
@@ -42,8 +42,8 @@ with the following layout:
    "instance_owner":i,
    "rank":i,
    "size":i,
-   "ntasks";i,
-   "service";s,
+   "ntasks":i,
+   "service":s,
    "options": { "verbose":b, "standalone":b },
    "constrained_resources":b,
    "jobspec":o,
@@ -72,8 +72,8 @@ string with the following layout:
    "id":i,
    "name":s,
    "broker_rank":i,
-   "ntasks":i
-   "taskids":s
+   "ntasks":i,
+   "taskids":s,
    "resources": { "ncores":i, "cores":s, ... }
 
 where :var:`id` is the shell rank, :var:`name` is the hostname of that shell
@@ -84,7 +84,7 @@ tasks (an RFC 22 idset string), and :var:`resources` is a dictionary of
 resource name to resource ids assigned to the shell rank.
 
 :func:`flux_shell_info_unpack` and :func:`flux_shell_rank_info_unpack`
-accomplished the same thing with Jansson-style formatting arguments.
+accomplish the same thing with Jansson-style formatting arguments.
 
 If :var:`shell_rank` is set to -1, the current shell rank is used.
 

--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -198,6 +198,12 @@ exec.sdexec-constrain-resources
       service = "sdexec"
       sdexec-constrain-resources = true
 
+   If this setting is enabled in an instance which is itself running under
+   resource containment, that instance must be started with
+   ``resource.rediscover=true``. Otherwise GPU ids in **R** are relative to
+   the enclosing allocation while the instance topology describes the entire
+   node, and jobs will be constrained to devices they cannot access.
+
 exec.sdexec-properties
    (optional) A table of systemd properties to set for all jobs. All values
    must be strings. See :ref:`sdexec_properties` below. It is an error to

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -105,6 +105,17 @@ parent-kvs-namespace :ref:`[readonly] <attr_readonly>`
    This is the KVS namespace assigned to this Flux instance by its enclosing
    instance, if it was launched by Flux as a job.
 
+constrained-resources :ref:`[readonly] <attr_readonly>`
+   Set to ``1`` if this broker's access to resources is constrained to the
+   allocation of the job that launched it, or ``0`` otherwise. The value is
+   obtained from the ``flux.constrained-resources`` PMI key published by the
+   enclosing instance's job shell.
+
+   Note that this describes a constraint imposed *on* this instance, not one
+   that this instance imposes on its own jobs. For example, if resources are
+   constrained, resource ids in **R** may refer only to the devices and CPUs
+   available to this instance rather than to all of those present on the node.
+
 hostlist
    An RFC 29 hostlist in broker rank order.  This value may be used to
    translate between broker ranks and hostnames.

--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -610,6 +610,24 @@ MISCELLANEOUS
    helper program when this variable is set to its path.  It is set by the
    job-exec system in the IMP environment at job launch.
 
+.. envvar:: FLUX_EXEC_CONSTRAINED_RESOURCES
+
+   Set to ``1`` by the job execution system in the job shell environment
+   when the job's resources are constrained to its allocation, as configured
+   by ``exec.sdexec-constrain-resources``. See :man5:`flux-config-exec`.
+
+   This variable is internal to the job shell, which uses it to set the
+   :var:`constrained_resources` member of the shell info object. Shell
+   plugins should use :man3:`flux_shell_info_unpack` rather than reading
+   this variable directly. The shell's PMI server additionally publishes
+   ``flux.constrained-resources`` so that a Flux instance launched as a job
+   sets the ``constrained-resources`` broker attribute, which broker modules
+   can query. See :man7:`flux-broker-attributes`.
+
+   This variable is not passed to the job environment, and the broker clears
+   it at startup so that a value inherited from the enclosing environment
+   cannot affect jobs run by the instance. Setting it manually has no effect.
+
 .. _sub_command_environment:
 
 SUB-COMMAND ENVIRONMENT

--- a/doc/man7/flux-shell-options.rst
+++ b/doc/man7/flux-shell-options.rst
@@ -349,6 +349,14 @@ GPU AFFINITY
 
     Task 0 sees GPU 0, task 1 sees GPU 1.
 
+  When the job's resources are constrained to its allocation (see
+  ``exec.sdexec-constrain-resources`` in :man5:`flux-config-exec`), the GPU
+  runtime enumerates only the devices available to the job. In that case
+  ``CUDA_VISIBLE_DEVICES`` contains the position of each allocated GPU
+  within the job's allocation rather than its id from **R** -- a job
+  allocated GPU id 7 of 8 gets ``CUDA_VISIBLE_DEVICES=0``. Ids given in
+  ``map:LIST`` are used as-is and are never translated.
+
 INPUT/OUTPUT
 ============
 

--- a/doc/man7/flux-shell-options.rst
+++ b/doc/man7/flux-shell-options.rst
@@ -309,13 +309,14 @@ GPU AFFINITY
 
 .. option:: gpu-affinity=OPT
 
-  Control GPU device visibility via ``CUDA_VISIBLE_DEVICES``. If unspecified,
-  defaults to ``on`` (each task sees all GPUs allocated to the job).
+  Control GPU device visibility via :envvar:`CUDA_VISIBLE_DEVICES`. If
+  unspecified, defaults to ``on`` (each task sees all GPUs allocated to
+  the job).
 
   *OPT* may be:
 
   **on**
-    Set ``CUDA_VISIBLE_DEVICES`` to include all GPUs allocated to the job.
+    Set :envvar:`CUDA_VISIBLE_DEVICES` to include all GPUs allocated to the job.
     All tasks see the same GPU set.
 
     .. code-block:: console
@@ -323,7 +324,7 @@ GPU AFFINITY
       $ flux run -o gpu-affinity=on myapp
 
   **off**
-    Disable the gpu-affinity plugin. ``CUDA_VISIBLE_DEVICES`` will not be
+    Disable the gpu-affinity plugin. :envvar:`CUDA_VISIBLE_DEVICES` will not be
     set by the shell.
 
     .. code-block:: console
@@ -332,7 +333,7 @@ GPU AFFINITY
 
   **per-task**
     Divide allocated GPUs evenly among local tasks. Each task's
-    ``CUDA_VISIBLE_DEVICES`` includes only its assigned GPUs. If there are
+    :envvar:`CUDA_VISIBLE_DEVICES` includes only its assigned GPUs. If there are
     more tasks than GPUs, tasks share GPUs as evenly as possible.
 
     .. code-block:: console
@@ -352,9 +353,9 @@ GPU AFFINITY
   When the job's resources are constrained to its allocation (see
   ``exec.sdexec-constrain-resources`` in :man5:`flux-config-exec`), the GPU
   runtime enumerates only the devices available to the job. In that case
-  ``CUDA_VISIBLE_DEVICES`` contains the position of each allocated GPU
+  :envvar:`CUDA_VISIBLE_DEVICES` contains the position of each allocated GPU
   within the job's allocation rather than its id from **R** -- a job
-  allocated GPU id 7 of 8 gets ``CUDA_VISIBLE_DEVICES=0``. Ids given in
+  allocated GPU id 7 of 8 gets :envvar:`CUDA_VISIBLE_DEVICES=0`. Ids given in
   ``map:LIST`` are used as-is and are never translated.
 
 INPUT/OUTPUT
@@ -657,7 +658,7 @@ HWLOC CONFIGURATION
 
   This allows tasks to query the hardware topology without scanning the
   system directly. Also unsets :envvar:`HWLOC_COMPONENTS` which may
-  interfere with ``HWLOC_XMLFILE``.
+  interfere with :envvar:`HWLOC_XMLFILE`.
 
   .. code-block:: console
 

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -95,6 +95,7 @@ static struct registered_attr attrtab[] = {
     { "local-uri", ATTR_IMMUTABLE },
     { "parent-uri", ATTR_READONLY | ATTR_IMMUTABLE },
     { "instance-level", ATTR_READONLY | ATTR_IMMUTABLE },
+    { "constrained-resources", ATTR_READONLY | ATTR_IMMUTABLE },
     { "jobid", ATTR_READONLY | ATTR_IMMUTABLE },
     { "jobid-path", ATTR_READONLY | ATTR_IMMUTABLE },
     { "parent-kvs-namespace", ATTR_READONLY | ATTR_IMMUTABLE },

--- a/src/broker/bootstrap.c
+++ b/src/broker/bootstrap.c
@@ -119,6 +119,26 @@ error:
     return -1;
 }
 
+/* Check for flux.constrained-resources, which indicates this instance
+ * is booting under Flux with resource containment. If not found, set to
+ * "0" to simplify use of the attribute.
+ */
+static int setattr_constrained_resources (struct bootstrap *boot,
+                                          flux_error_t *errp)
+{
+    char *val;
+    int rc;
+
+    val = lookup (boot->upmi, "flux.constrained-resources");
+    rc = setattr (boot->ctx->attrs,
+                  "constrained-resources",
+                  val ? val : "0",
+                  errp);
+    free (val);
+
+    return rc;
+}
+
 /* Initialize some broker attributes using information obtained during
  * bootstrap, such as pre-put values from the PMI KVS.
  */
@@ -183,6 +203,9 @@ static int bootstrap_setattrs_early (struct bootstrap *boot,
                 return -1;
         }
     }
+
+    if (setattr_constrained_resources (boot, errp) < 0)
+        return -1;
 
     if (setattr_broker_mapping (boot, errp) < 0)
         return -1;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -795,6 +795,13 @@ static int init_attrs_post_boot (attr_t *attrs, flux_error_t *errp)
      */
     unsetenv ("FLUX_PROXY_REMOTE");
 
+    /* FLUX_EXEC_CONSTRAINED_RESOURCES should never be set in the broker
+     * environment, but clear it now in case that somehow happens. This
+     * prevents the variable from leaking to the job shell via the job-exec
+     * module, or to the initial program/rc environment.
+     */
+    unsetenv ("FLUX_EXEC_CONSTRAINED_RESOURCES");
+
     if (instance_is_job) {
         val = getenv ("FLUX_KVS_NAMESPACE");
         if (attr_set (attrs, "parent-kvs-namespace", val) < 0) {

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -382,6 +382,19 @@ int rlist_remove_ranks (struct rlist *rl, const struct idset *ranks)
     return count;
 }
 
+int rlist_set_remap (struct rlist *rl, const char *name, bool remap)
+{
+    if (!rl || !name) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (remap)
+        zhashx_delete (rl->noremap, name);
+    else if (zhashx_insert (rl->noremap, name, (void *) name) < 0)
+        return 0;   /* already present */
+    return 0;
+}
+
 int rlist_remap (struct rlist *rl)
 {
     uint32_t rank = 0;

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -91,6 +91,11 @@ int rlist_remove_ranks (struct rlist *rl, const struct idset *ranks);
  */
 int rlist_remap (struct rlist *rl);
 
+/*  Enable or disable remap of resources named 'name' during rlist_remap().
+ *   By default, type "gpu" is the only resource type not remapped.
+ */
+int rlist_set_remap (struct rlist *rl, const char *name, bool remap);
+
 /*  Re-assign hostnames to rlist 'rl'. The number of hosts in the "hosts"
  *   hostlist expression must match the size of rlist 'rl'.
  */

--- a/src/common/librlist/test/rlist.c
+++ b/src/common/librlist/test/rlist.c
@@ -324,25 +324,36 @@ struct remap_test {
     const char *cores;
     const char *gpus;
     const char *hosts;
+    int remap_gpus;
 
     const char *result;
 };
 
 struct remap_test remap_tests[] = {
     {
-        "1,7,9,53", "0-3", NULL, "foo[1,7,9,53]",
+        "1,7,9,53", "0-3", NULL, "foo[1,7,9,53]", 0,
         "rank[0-3]/core[0-3]",
     },
     {
-        "1,7,9,53", "1,5,7,9", "1,3", "foo[1,7,9,53]",
+        "1,7,9,53", "1,5,7,9", "1,3", "foo[1,7,9,53]", 0,
         "rank[0-3]/core[0-3],gpu[1,3]",
+    },
+    {
+        "1,7,9,53", "1,5,7,9", "1,3", "foo[1,7,9,53]", 1,
+        "rank[0-3]/core[0-3],gpu[0-1]",
     },
     { 0 },
 };
 
 void test_remap ()
 {
+    struct rlist *rl, *cpy;
+    char *s;
+    char *R;
     struct remap_test *t = remap_tests;
+
+    ok (rlist_set_remap (NULL, NULL, false) < 0 && errno == EINVAL,
+        "rlist_set_remap(NULL, NULL, false) fails with EINVAL)");
 
     while (t && t->ranks) {
         char *before;
@@ -355,6 +366,12 @@ void test_remap ()
             BAIL_OUT ("rlist_from_R failed");
 
         before = rlist_dumps (rl);
+        if (t->remap_gpus) {
+            ok (rlist_set_remap (rl, NULL, false) < 0 && errno == EINVAL,
+                "rlist_set_remap(rl, NULL, false) fails with EINVAL)");
+            ok (rlist_set_remap (rl, "gpu", true) == 0,
+                "rlist_set_remap (gpu, true)");
+        }
         ok (rlist_remap (rl) == 0,
                 "rlist_remap (%s)", before);
         after = rlist_dumps (rl);
@@ -368,15 +385,51 @@ void test_remap ()
 
         t++;
     }
+
+    /*  Ensure remap settings survive rlist_copy_empty()
+     */
+    R = R_create ("0-3", "4-7", "1,3", "host[0-3]", NULL);
+    if (!R)
+        BAIL_OUT ("R_create failed");
+
+    if (!(rl = rlist_from_R (R)))
+        BAIL_OUT ("rlist_from_R failed");
+    ok (rlist_set_remap (rl, "gpu", true) == 0,
+        "rlist_set_remap (gpu, true)");
+    if (!(cpy = rlist_copy_empty (rl)))
+        BAIL_OUT ("rlist_copy_empty failed");
+    ok (rlist_remap (cpy) == 0,
+        "rlist_remap of copy works");
+    s = rlist_dumps (cpy);
+    is (s, "rank[0-3]/core[0-3],gpu[0-1]",
+        "gpu remap setting survived rlist_copy_empty()");
+    free (s);
+    rlist_destroy (rl);
+    rlist_destroy (cpy);
+
+    /*  "core" is remapped by default. Check that it can be disabled
+     */
+    if (!(rl = rlist_from_R (R)))
+        BAIL_OUT ("rlist_from_R failed");
+    ok (rlist_set_remap (rl, "core", false) == 0,
+        "rlist_set_remap (core, false)");
+    ok (rlist_remap (rl) == 0,
+        "rlist_remap works");
+    s = rlist_dumps (rl);
+    is (s, "rank[0-3]/core[4-7],gpu[1,3]",
+        "core ids were not remapped");
+    rlist_destroy (rl);
+    free (s);
+    free (R);
 }
 
 struct remap_test assign_hosts_tests[] = {
     {
-        "1,7,9,53", "0-3", NULL, "foo[1,7,9,53]",
+        "1,7,9,53", "0-3", NULL, "foo[1,7,9,53]", 0,
         "rank[0-3]/core[0-3]",
     },
     {
-        "1,7,9,53", "1,5,7,9", "1,3", "foo[1,7,9,53]",
+        "1,7,9,53", "1,5,7,9", "1,3", "foo[1,7,9,53]", 0,
         "rank[0-3]/core[0-3],gpu[1,3]",
     },
     { 0 },

--- a/src/modules/job-exec/bulkexec.c
+++ b/src/modules/job-exec/bulkexec.c
@@ -24,6 +24,9 @@
  *                               "init", or "starting"
  *    "barrier-timeout":F      - Specify timeout for start barrier in floating
  *                               point seconds.
+ *    "sdexec-test-expected-cpus":s
+ *                             - Set the sdexec expected-cpus option for
+ *                               post-start check testing purposes.
  * }
  *
  */

--- a/src/modules/job-exec/bulkexec.c
+++ b/src/modules/job-exec/bulkexec.c
@@ -27,6 +27,9 @@
  *    "sdexec-test-expected-cpus":s
  *                             - Set the sdexec expected-cpus option for
  *                               post-start check testing purposes.
+ *    "test-constrained-resources":i
+ *                             - Force FLUX_EXEC_CONSTRAINED_RESOURCES=1
+ *                               for testing purposes
  * }
  *
  */
@@ -55,6 +58,11 @@ struct exec_ctx {
 
     const char * mock_exception;   /* fake exception */
     const char *sdexec_test_expected_cpus; /* override for post-start check */
+
+    /*  If non-zero force setting of FLUX_EXEC_CONSTRAINED_RESOURCES in
+     *  the job shell environment for testing purposes.
+     */
+    int test_constrained_resources;
 
     /*  Shells enter a sequence of barriers during startup.  Only the first
      *  is timed; on completion the current barrier is destroyed and a fresh
@@ -104,7 +112,7 @@ static struct exec_ctx *exec_ctx_create (struct jobinfo *job,
     if (json_unpack_ex (job->jobspec,
                         &error,
                         0,
-                        "{s?{s?{s?{s?{s?s s?s s?s s?F !}}}}}",
+                        "{s?{s?{s?{s?{s?s s?s s?s s?i s?F !}}}}}",
                         "attributes",
                           "system",
                             "exec",
@@ -113,6 +121,8 @@ static struct exec_ctx *exec_ctx_create (struct jobinfo *job,
                                 "mock_exception", &ctx->mock_exception,
                                 "sdexec-test-expected-cpus",
                                     &ctx->sdexec_test_expected_cpus,
+                                "test-constrained-resources",
+                                    &ctx->test_constrained_resources,
                                 "barrier-timeout", &ctx->barrier_timeout) < 0) {
         errprintf (errp,
                    "failed to unpack system.exec.bulkexec for %s: %s",
@@ -501,6 +511,19 @@ static int exec_init (struct jobinfo *job)
     }
     if (!(cmd = job_shell_cmd_create (job, service)))
         goto err;
+    /* If testing with FLUX_EXEC_CONSTRAINED_RESOURCES, set it here before
+     * commands are pushed into bulk-exec:
+     */
+    if (ctx->test_constrained_resources
+        && flux_cmd_setenvf (cmd,
+                             1,
+                             "FLUX_EXEC_CONSTRAINED_RESOURCES",
+                             "1") < 0) {
+        flux_log_error (job->h,
+                        "Failed to set FLUX_EXEC_CONSTRAINED_RESOURCES=1");
+        goto err;
+    }
+
     /* When per-rank sdexec options are needed, push one cmd per rank so
      * each transient unit can be configured for its own allocation.
      * Otherwise push a single command covering all ranks (the common case).

--- a/src/modules/job-exec/exec_cmd.c
+++ b/src/modules/job-exec/exec_cmd.c
@@ -58,6 +58,14 @@ flux_cmd_t *job_shell_cmd_create (struct jobinfo *job, const char *service)
         flux_log_error (job->h, "exec_init: flux_cmd_setenvf");
         goto err;
     }
+    if (config_get_sdexec_constrain_resources ()
+        && flux_cmd_setenvf (cmd,
+                             1,
+                             "FLUX_EXEC_CONSTRAINED_RESOURCES",
+                             "1") < 0) {
+        flux_log_error (job->h, "setenv(FLUX_EXEC_CONSTRAINED_RESOURCES=1)");
+        goto err;
+    }
     if (job->multiuser) {
         if (flux_cmd_setenvf (cmd,
                               1,

--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -95,6 +95,7 @@
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/jpath.h"
+#include "ccan/str/str.h"
 
 #include "rutil.h"
 #include "resource.h"
@@ -349,7 +350,11 @@ static bool no_duplicates (const char *hosts)
  * thus *Rp should be set to NULL before calling this function.
  * On failure return -1 (errno is not set).
  */
-static int convert_R (flux_t *h, json_t *R, int size, json_t **Rp)
+static int convert_R (flux_t *h,
+                      json_t *R,
+                      int size,
+                      bool remap_gpus,
+                      json_t **Rp)
 {
     struct rlist *rl;
     struct idset *ranks;
@@ -391,6 +396,8 @@ static int convert_R (flux_t *h, json_t *R, int size, json_t **Rp)
     }
     /*  Also always remap ids to zero origin
      */
+    if (remap_gpus && rlist_set_remap (rl, "gpu", true) < 0)
+        goto error;
     if (rlist_remap (rl) < 0)
         goto error;
     if (!(*Rp = rlist_to_R (rl)))
@@ -527,7 +534,7 @@ static int lookup_R_fallback (struct inventory *inv, flux_jobid_t id)
         flux_log_error (h, "lookup R from enclosing instance (fallback)");
         goto done;
     }
-    if (convert_R (h, job_R, inv->ctx->size, &R) < 0) {
+    if (convert_R (h, job_R, inv->ctx->size, false, &R) < 0) {
         flux_log (h, LOG_ERR, "fatal error while normalizing R");
         errno = EINVAL;
         goto done;
@@ -550,6 +557,16 @@ done:
     return rc;
 }
 
+static bool check_constrained_resources (flux_t *h)
+{
+    const char *val = flux_attr_get (h, "constrained-resources");
+    if (!val)
+        flux_log_error (h, "failed to get constrained-resources attribute");
+    if (val && streq (val, "1"))
+        return true;
+    return false;
+}
+
 static int start_resource_watch (struct inventory *inv,
                                  struct resource_config *config)
 {
@@ -559,6 +576,7 @@ static int start_resource_watch (struct inventory *inv,
     flux_jobid_t id;
     flux_future_t *f = NULL;
     json_t *R = NULL;
+    bool remap_gpus = false;
     int rc = -1;
     const char *service = "job-info.update-watch";
 
@@ -619,7 +637,12 @@ static int start_resource_watch (struct inventory *inv,
             goto done;
         }
     }
-    if (convert_R (h, job_R, inv->ctx->size, &R) < 0) {
+    /* Check value of constrained_resources broker attribute. If "1", then
+     * remap GPUs since ids should be an index into available GPUs, not
+     * all GPUs on the node.
+     */
+    remap_gpus = check_constrained_resources (h);
+    if (convert_R (h, job_R, inv->ctx->size, remap_gpus, &R) < 0) {
         flux_log (h, LOG_ERR, "fatal error while normalizing R");
         errno = EINVAL;
         goto done;

--- a/src/shell/gpubind.c
+++ b/src/shell/gpubind.c
@@ -50,6 +50,7 @@ static struct gpu_affinity *gpu_affinity_create (flux_shell_t *shell)
 {
     const char *gpu_list = NULL;
     struct gpu_affinity *ctx = calloc (1, sizeof (*ctx));
+
     if (!ctx)
         return NULL;
     if (flux_shell_rank_info_unpack (shell,
@@ -66,6 +67,43 @@ static struct gpu_affinity *gpu_affinity_create (flux_shell_t *shell)
         goto error;
     }
     ctx->ngpus = idset_count (ctx->gpus);
+
+    /*  Under device containment the cgroup denies access to the device
+     *  nodes of unallocated GPUs, and the GPU runtimes enumerate only
+     *  the devices they can open, indexing them from zero. Verified with
+     *  ROCm and CUDA on AMD MI300X and NVIDIA H100 systems.
+     *  (see flux-framework/flux-core#7790).
+     */
+    if (ctx->ngpus > 0) {
+        int constrained = 0;
+
+        if (flux_shell_info_unpack (shell,
+                                   "{s:b}",
+                                   "constrained_resources",
+                                   &constrained) < 0) {
+            shell_log_errno ("flux_shell_info_unpack");
+            goto error;
+        }
+        if (constrained) {
+            struct idset *rel;
+
+            if (!(rel = idset_create (0, IDSET_FLAG_AUTOGROW))) {
+                shell_log_errno ("idset_create");
+                goto error;
+            }
+            if (idset_range_set (rel, 0, ctx->ngpus - 1) < 0) {
+                shell_log_errno ("idset_range_set");
+                idset_destroy (rel);
+                goto error;
+            }
+            shell_debug ("device containment active: remap gpus: %s to %d-%d",
+                         gpu_list,
+                         0,
+                         ctx->ngpus - 1);
+            idset_destroy (ctx->gpus);
+            ctx->gpus = rel;
+        }
+    }
     return ctx;
 error:
     gpu_affinity_destroy (ctx);

--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -279,6 +279,10 @@ struct shell_info *shell_info_create (flux_shell_t *shell)
         return NULL;
     }
     info->jobid = shell->jobid;
+    if (getenv ("FLUX_EXEC_CONSTRAINED_RESOURCES")) {
+        info->constrained_resources = true;
+        unsetenv ("FLUX_EXEC_CONSTRAINED_RESOURCES");
+    }
 
     if (shell_init_jobinfo (shell, info) < 0)
         goto error;

--- a/src/shell/info.h
+++ b/src/shell/info.h
@@ -28,6 +28,7 @@ struct shell_info {
     int shell_rank;
     int shell_size;
     int total_ntasks;
+    bool constrained_resources;
     json_t *R;
     struct jobspec *jobspec;
     rcalc_t *rcalc;

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -311,6 +311,13 @@ static int set_flux_tbon_interface_hint (struct shell_pmi *pmi)
     return 0;
 }
 
+static int set_flux_constrained_resources (struct shell_pmi *pmi)
+{
+    if (pmi->shell->info->constrained_resources)
+        put_dict (pmi->locals, "flux.constrained-resources", "1");
+    return 0;
+}
+
 static int set_flux_instance_level (struct shell_pmi *pmi)
 {
     char *p;
@@ -457,6 +464,7 @@ static struct shell_pmi *pmi_create (flux_shell_t *shell, json_t *config)
         goto error;
     if (set_flux_instance_level (pmi) < 0
         || set_flux_tbon_interface_hint (pmi) < 0
+        || set_flux_constrained_resources (pmi) < 0
         || (!nomap && set_flux_taskmap (pmi) < 0))
         goto error;
     return pmi;

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -542,8 +542,10 @@ static json_t *flux_shell_get_info_object (flux_shell_t *shell)
         return o;
 
     if (!(o = json_pack_ex (&err, 0,
-                            "{ s:I s:i s:i s:i s:i s:s s:O s:O s:{ s:i }}",
+                            "{ s:I s:b s:i s:i s:i s:i s:s s:O s:O s:{ s:i }}",
                             "jobid", shell->info->jobid,
+                            "constrained_resources",
+                                shell->info->constrained_resources,
                             "rank",  shell->info->shell_rank,
                             "instance_owner", (int) shell->broker_owner,
                             "size",  shell->info->shell_size,

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -119,6 +119,7 @@ const struct hostlist *flux_shell_get_hostlist (flux_shell_t *shell);
  *   "ntasks";i,
  *   "service":s,
  *   "options": { "verbose":b },
+ *   "constrained_resources":b,
  *   "jobspec":o,
  *   "R":o
  *  }

--- a/t/shell/initrc/tests/0001-shell-info.lua
+++ b/t/shell/initrc/tests/0001-shell-info.lua
@@ -44,6 +44,9 @@ R = shell.info.R
 type_ok (R, "table",
     "shell.info.R is a table")
 
+type_ok (shell.info.constrained_resources, "boolean",
+    "shell.info.constrained_resources is a boolean")
+
 rankinfo = shell.rankinfo
 type_ok (rankinfo, "table",
     "shell.rankinfo is a table")

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -630,6 +630,14 @@ test_expect_success 'broker fails gracefully when local-uri in unwritable dir' '
 test_expect_success 'broker broker.pid attribute is immutable' '
 	test_must_fail flux start ${ARGS} --setattr=broker.pid=1234 flux getattr broker.pid
 '
+test_expect_success 'constrained-resources attr defaults to 0' '
+	flux start ${ARGS} flux getattr constrained-resources >cr.out &&
+	test "$(cat cr.out)" = "0"
+'
+test_expect_success 'constrained-resources attr is immutable' '
+	test_must_fail flux start ${ARGS} --setattr=constrained-resources=1 \
+		flux getattr constrained-resources
+'
 test_expect_success 'broker --verbose option works' '
 	flux start ${ARGS} -o,-v true
 '

--- a/t/t2416-sdexec-constrain-resources.t
+++ b/t/t2416-sdexec-constrain-resources.t
@@ -85,7 +85,17 @@ test_expect_success 'exec.sdexec-constrain-resources is set' '
 test_expect_success 'sdexec-mapper module is running' '
 	flux ping -c 1 sdexec-mapper
 '
-
+test_expect_success 'shell info reports constrained_resources' '
+	cat >info.lua <<-EOT &&
+	print(shell.info.constrained_resources)
+	EOT
+	flux run -n1 -c1 -o initrc=$(pwd)/info.lua true >info.out 2>&1 &&
+	grep true info.out
+'
+test_expect_success 'nested instance sets constrained-resources attribute' '
+	flux alloc -n1 -c1 flux getattr constrained-resources >nested.out &&
+	test "$(cat nested.out)" = "1"
+'
 #
 # basic: cpuset.cpus.effective is set and non-empty for a constrained job
 #
@@ -504,7 +514,17 @@ test_expect_success MULTICORE \
 	./getcpus.sh >unconstrained.expected &&
 	test_cmp unconstrained.expected cpus1unconstrained.out
 '
-
+test_expect_success 'shell info reports constrained_resources=false' '
+	cat >info.lua <<-EOT &&
+	print(shell.info.constrained_resources)
+	EOT
+	flux run -n1 -c1 -o initrc=$(pwd)/info.lua true >info2.out 2>&1 &&
+	grep false info2.out
+'
+test_expect_success 'nested instance shows constrained-resources=0' '
+	flux alloc -n1 -c1 flux getattr constrained-resources >nested2.out &&
+	test "$(cat nested2.out)" = "0"
+'
 #
 # Diagnostic CLI: flux python -m flux.sdexec.map
 #

--- a/t/t2604-job-shell-affinity.t
+++ b/t/t2604-job-shell-affinity.t
@@ -300,6 +300,108 @@ test_expect_success 'flux-shell: gpu-affinity bad arg is ignored' '
 	test_debug "cat ${name}.err" >&2 &&
 	grep "Failed to get gpu-affinity shell option" ${name}.err
 '
+test_expect_success 'flux-shell: create multi-gpu R with non-zero origin ids' '
+	flux R encode --cores=0-1 --gpus=4-7 >R.gpu4-7
+'
+test_expect_success 'flux-shell: gpu-affinity uses absolute ids when unconstrained' '
+	name=gpu-unconstrained &&
+	flux run -N1 -n2 \
+		--label-io \
+		--setattr=alloc-bypass.R="$(cat R.gpu4-7)" \
+		printenv CUDA_VISIBLE_DEVICES >${name}.output 2>${name}.err &&
+	cat >${name}.expected <<-EOF  &&
+	0: 4,5,6,7
+	1: 4,5,6,7
+	EOF
+	test_debug "cat ${name}.output ${name}.err" &&
+	sort -k1,1n ${name}.output > ${name}.out &&
+	test_cmp ${name}.expected ${name}.out
+'
+test_expect_success 'flux-shell: gpu-affinity reindexes from 0 when constrained' '
+	name=gpu-constrained &&
+	flux run -N1 -n2 \
+		--label-io \
+		--setattr=alloc-bypass.R="$(cat R.gpu4-7)" \
+		--setattr=exec.bulkexec.test-constrained-resources=1 \
+		printenv CUDA_VISIBLE_DEVICES >${name}.output 2>${name}.err &&
+	cat >${name}.expected <<-EOF  &&
+	0: 0,1,2,3
+	1: 0,1,2,3
+	EOF
+	test_debug "cat ${name}.output ${name}.err" &&
+	sort -k1,1n ${name}.output > ${name}.out &&
+	test_cmp ${name}.expected ${name}.out
+'
+test_expect_success 'flux-shell: constrained gpu-affinity is a no-op for zero-origin ids' '
+	name=gpu-constrained-noop &&
+	flux run -N1 -n2 \
+		--label-io \
+		--setattr=alloc-bypass.R="$(cat R.gpu)" \
+		--setattr=exec.bulkexec.test-constrained-resources=1 \
+		printenv CUDA_VISIBLE_DEVICES >${name}.output 2>${name}.err &&
+	cat >${name}.expected <<-EOF  &&
+	0: 0,1,2,3
+	1: 0,1,2,3
+	EOF
+	test_debug "cat ${name}.output ${name}.err" &&
+	sort -k1,1n ${name}.output > ${name}.out &&
+	test_cmp ${name}.expected ${name}.out
+'
+test_expect_success 'flux-shell: constrained gpu-affinity=per-task' '
+	name=gpu-constrained-per-task &&
+	flux run -N1 -n2 \
+		--label-io \
+		--setattr=alloc-bypass.R="$(cat R.gpu4-7)" \
+		--setattr=exec.bulkexec.test-constrained-resources=1 \
+		-o gpu-affinity=per-task \
+		printenv CUDA_VISIBLE_DEVICES >${name}.output 2>${name}.err &&
+	cat >${name}.expected <<-EOF  &&
+	0: 0,1
+	1: 2,3
+	EOF
+	test_debug "cat ${name}.output ${name}.err" &&
+	sort -k1,1n ${name}.output > ${name}.out &&
+	test_cmp ${name}.expected ${name}.out
+'
+test_expect_success 'flux-shell: constrained gpu-affinity=map: is not reindexed' '
+	name=gpu-constrained-map &&
+	flux run -N1 -n2 \
+		--label-io \
+		--setattr=alloc-bypass.R="$(cat R.gpu4-7)" \
+		--setattr=exec.bulkexec.test-constrained-resources=1 \
+		-o gpu-affinity="map:7;4-6" \
+		printenv CUDA_VISIBLE_DEVICES >${name}.output 2>${name}.err &&
+	cat >${name}.expected <<-EOF  &&
+	0: 7
+	1: 4,5,6
+	EOF
+	test_debug "cat ${name}.output ${name}.err" &&
+	sort -k1,1n ${name}.output > ${name}.out &&
+	test_cmp ${name}.expected ${name}.out
+'
+test_expect_success 'flux-shell: constrained gpu-affinity=off sets nothing' '
+	name=gpu-constrained-off &&
+	test_expect_code 1 flux run -N1 -n2 \
+		--label-io \
+		--setattr=alloc-bypass.R="$(cat R.gpu4-7)" \
+		--setattr=exec.bulkexec.test-constrained-resources=1 \
+		-o gpu-affinity=off \
+		--env=-CUDA_VISIBLE_DEVICES \
+		printenv CUDA_VISIBLE_DEVICES >${name}.output 2>${name}.err &&
+	cat >${name}.expected <<-EOF  &&
+	EOF
+	test_debug "cat ${name}.output ${name}.err" &&
+	sort -k1,1n ${name}.output > ${name}.out &&
+	test_cmp ${name}.expected ${name}.out
+'
+test_expect_success 'flux-shell: constrained job with no GPUs still gets -1' '
+	name=gpu-constrained-none &&
+	flux run \
+		--setattr=exec.bulkexec.test-constrained-resources=1 \
+		printenv CUDA_VISIBLE_DEVICES >${name}.out 2>&1 &&
+	test_debug "cat ${name}.out" &&
+	grep "^-1" ${name}.out
+'
 test_expect_success 'flux-shell: create multi-node multi-gpu R' '
 	cat >R2.gpu <<-EOF
 	{

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -173,4 +173,29 @@ test_expect_success 'constrained-resources attr is passed from shell to broker' 
 	test_debug "cat constrained-resources.out" &&
 	test "$(cat constrained-resources.out)" = "1"
 '
+test_expect_success 'broker does not remap GPUs when constrained-resources=0' '
+	flux jobtap load alloc-bypass.so &&
+	flux R encode --cores=4-7 --gpus=4-7 > R.gpu4-7 &&
+	flux alloc -N1 --setattr=alloc-bypass.R="$(cat R.gpu4-7)" \
+		-o cpu-affinity=off \
+		-o gpu-affinity=off \
+		--conf=resource.noverify=true \
+		flux resource R > R-norerank.json &&
+	test_debug "cat R-norerank.json" &&
+	GPUS="$(jq -rS .execution.R_lite[0].children.gpu <R-norerank.json)" &&
+	test_debug "echo got GPUs=$GPUS" &&
+	test "$GPUS" = "4-7"
+'
+test_expect_success 'broker remaps GPUs when constrained-resources=1' '
+	flux alloc -N1 --setattr=alloc-bypass.R="$(cat R.gpu4-7)" \
+		--setattr=exec.bulkexec.test-constrained-resources=1 \
+		-o cpu-affinity=off \
+		-o gpu-affinity=off \
+		--conf=resource.noverify=true \
+		flux resource R > R-rerank.json &&
+	test_debug "cat R-rerank.json" &&
+	GPUS="$(jq -rS .execution.R_lite[0].children.gpu <R-rerank.json)" &&
+	test_debug "echo got GPUs=$GPUS" &&
+	test "$GPUS" = "0-3"
+'
 test_done

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -161,4 +161,16 @@ test_expect_success 'flux_open(3) accepts path-like URIs: "/", "../.." etc' '
 	EOF
 	flux alloc -n1 flux alloc -n1 flux alloc -n1 flux python ./flux_open.py
 '
+test_expect_success 'constrained-resources attr is set to 0 by default' '
+	flux alloc -n1 flux getattr constrained-resources \
+		>constrained-resources-default.out &&
+	test_debug "cat constrained-resources-default.out" &&
+	test "$(cat constrained-resources-default.out)" = "0"
+'
+test_expect_success 'constrained-resources attr is passed from shell to broker' '
+	flux alloc -n1 --setattr=exec.bulkexec.test-constrained-resources=1 \
+		flux getattr constrained-resources >constrained-resources.out &&
+	test_debug "cat constrained-resources.out" &&
+	test "$(cat constrained-resources.out)" = "1"
+'
 test_done


### PR DESCRIPTION
When exec.sdexec-constrain-resources is enabled and a job is allocated a subset of the GPUs on a node, the cgroup hides the unallocated devices, so the GPU runtime enumerates only the allocated ones and indexes them from zero. The gpu-affinity shell plugin, however, sets CUDA_VISIBLE_DEVICES to the absolute ids from R, which are no longer valid indices. A job allocated GPU 7 of 8 gets CUDA_VISIBLE_DEVICES=7 against a single visible device and fails with "no device is detected". Whole-node jobs work only because the ids and the indices happen to coincide.

This PR adds a `FLUX_EXEC_CONSTRAINED_RESOURCES` environment variable, set by job-exec in the job shell environment when containment is active, exposed to plugins as a new `constrained_resources` member of the shell info object. The gpu-affinity plugin uses it to emit each allocated GPU's position within the rank's allocation instead of its id from R.

The same information is published by the shell PMI server as `flux.constrained-resources`, so a Flux instance launched as a job picks it up and assigns it to a new `constrained-resources` broker attribute. The resource module uses that to remap GPU ids in R to zero origin along with cores, so jobs of a subinstance get correct indices too.

Resource ids in R are unchanged. Site shell plugins that set visible-device variables themselves may need to consume `constrained_resources` to apply the same correction.

Fixes #7790
