### PR TITLE
gc: protect the empty-directory blob from sweep

### DIFF
--- a/src/cmd/builtin/gc.c
+++ b/src/cmd/builtin/gc.c
@@ -22,6 +22,7 @@
 #include "src/common/libkvs/kvs_treewalk.h"
 #include "src/common/libutil/blobref.h"
 #include "src/common/libcontent/content.h"
+#include "src/common/libutil/errno_safe.h"
 #include "ccan/str/str.h"
 
 #include "builtin.h"
@@ -540,6 +541,62 @@ done:
     return rc;
 }
 
+/* Protect the canonical RFC 11 empty directory object.
+ * See flux-framework/flux-core#7808.
+ *
+ * The KVS stores this blob once at initialization and assumes it persists
+ * until the next offline gc; an online gc that swept it would break the next
+ * namespace create with a dangling reference.
+ */
+static int protect_empty_dir (flux_t *h, int64_t *markedp)
+{
+    const char *hash_name;
+    json_t *dir = NULL;
+    char *data = NULL;
+    char blobref[BLOBREF_MAX_STRING_SIZE];
+    json_t *hashes = NULL;
+    flux_future_t *f = NULL;
+    int marked;
+    int rc = -1;
+
+    if (!(hash_name = flux_attr_get (h, "content.hash")))
+        return -1;
+    if (!(dir = treeobj_create_dir ())
+        || !(data = treeobj_encode (dir)))
+        goto done;
+    if (blobref_hash (hash_name,
+                      data,
+                      strlen (data),
+                      blobref,
+                      sizeof (blobref)) < 0)
+        goto done;
+    if (!(hashes = json_pack ("[s]", blobref))) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if (!(f = flux_rpc_pack (h,
+                             "content-backing.mark",
+                             0,
+                             0,
+                             "{s:I s:O}",
+                             "epoch", horizon_epoch,
+                             "hashes", hashes)))
+        goto done;
+    if (flux_rpc_get_unpack (f, "{s:i}", "marked", &marked) < 0)
+        goto done;
+    /* N.B. marked may come back 0 or 1, depending on whether any action
+     * was taken.
+     */
+    *markedp += marked;
+    rc = 0;
+done:
+    flux_future_destroy (f);
+    ERRNO_SAFE_WRAP (json_decref, hashes);
+    ERRNO_SAFE_WRAP (free, data);
+    ERRNO_SAFE_WRAP (json_decref, dir);
+    return rc;
+}
+
 /* Flush the final partial batch and wait for every outstanding mark RPC to
  * complete.  Called once, after all roots have been walked; the walk itself
  * cannot drain because mark_reap must not stop the reactor mid-walk.
@@ -724,6 +781,14 @@ int cmd_gc (optparse_t *p, int argc, char **argv)
     /* Mark phase */
     if (mark_all_roots (h, roots, &marked) < 0)
         log_err_exit ("mark phase failed");
+
+    /* The empty-dir blob (root of every fresh namespace) is referenced by
+     * none of the enumerated roots once startup empty-dirs age out; protect it
+     * always.  Part of the mark phase, so it runs before the test-mark-only
+     * stop below.
+     */
+    if (protect_empty_dir (h, &marked) < 0)
+        log_err_exit ("failed to protect empty-dir blob");
 
     /* Stop after the mark phase (testing only).  This is the same state a
      * crash between mark and sweep would leave: the mark phase is complete

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -491,7 +491,10 @@ static void content_load_completion (flux_future_t *f, void *arg)
     }
 
     if (content_load_get (f, &data, &size) < 0) {
-        flux_log_error (ctx->h, "%s: content_load_get", __FUNCTION__);
+        flux_log_error (ctx->h,
+                        "%s: content_load_get %s",
+                        __FUNCTION__,
+                        blobref);
         content_load_cache_entry_error (ctx, entry, errno, blobref);
         goto done;
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -112,6 +112,7 @@ TESTSCRIPTS = \
 	t0043-content-sqlite-gc.t \
 	t0044-gc-cmd.t \
 	t0045-check-json-pack.t \
+	t0046-gc-emptydir.t \
 	t0090-content-enospc.t \
 	t0099-admin-system-scripts.t \
 	t0100-modprobe.t \

--- a/t/t0046-gc-emptydir.t
+++ b/t/t0046-gc-emptydir.t
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+test_description='Test that flux-gc preserves the empty-directory blob'
+
+. `dirname $0`/sharness.sh
+
+# See also: flux-framework/flux-core#7808
+
+test_under_flux 1 kvs --conf=content-sqlite.max_checkpoints=2
+
+# Derive the empty-dir blobref for this instance's content hash: it is the root
+# of a freshly created (empty) namespace.  Creating and removing the probe
+# namespace does not store the blob or leave a lasting reference to it.
+test_expect_success 'derive the empty-directory blobref' '
+	flux kvs namespace create emptydir-probe &&
+	flux kvs getroot -N emptydir-probe -b >emptydir.ref &&
+	flux kvs namespace remove emptydir-probe &&
+	test -s emptydir.ref
+'
+
+# Commit only non-empty content (no empty directories), then sync twice so the
+# epoch advances past the empty-dir blob (stored at epoch 0) and the initial
+# empty root ages off the two retained checkpoints.  The empty-dir blob is now
+# unreferenced and below the gc horizon: without the fix it is reclaimable.
+test_expect_success 'commit non-empty content and advance the epoch' '
+	flux kvs put a.b.c=1 &&
+	flux kvs sync &&
+	flux kvs put a.b.d=2 &&
+	flux kvs sync &&
+	flux content flush
+'
+
+# Without the fix gc reclaims the empty-dir blob here and the content load
+# (from # the backing store, past both caches) fails.  With the fix gc
+# marks the empty-dir blob and it survives.
+test_expect_success 'flux gc preserves the unreferenced empty-directory blob' '
+	flux gc -v 2>&1 &&
+	flux content dropcache &&
+	flux content load $(cat emptydir.ref) >/dev/null
+'
+
+# End to end: a fresh namespace must still be creatable and writable after gc.
+test_expect_success 'namespace create+commit works after gc' '
+	flux kvs namespace create emptydir-after &&
+	flux kvs put -N emptydir-after x.y=1 &&
+	test "$(flux kvs get -N emptydir-after x.y)" = "1" &&
+	flux kvs namespace remove emptydir-after
+'
+
+test_done


### PR DESCRIPTION
Problem: KVS namespace creation fails after a flux-gc(1) run in some circumstances.

The KVS treats the canonical RFC 11 empty directory object specially: to avoid storing it repeatedly on the hot path as KVS namespaces are created with empty roots, it is stored ONCE during KVS initialization and is assumed to persist until the next offline garbage collection.

Online garbage collection subverts this assumption and will sweep the empty directory if it has no references.  This may occur when:
1. system is restored from a dump, which omits empty directories
2. kvs initialization stores the empty directory as described above
3. regular job purging doesn't create any new empty keys (refs) in the jobs directory (e.g. purge limits not reached or idle system)
4. flux-gc sweeps it

The next namespace create fails because it is created with a dangling reference.

Explicitly mark the empty directory blobref as a special case.

Fixes #7808

p.s. the quick fix if this happens to get installed anywhere is just to do `flux kvs mkdir issue#7808` to link the empty directory into the primary namespace where it will get marked by `flux-gc(1)`.